### PR TITLE
Corrected most multithread warnings from SpotBugs

### DIFF
--- a/Classification/Core/src/main/java/org/tribuo/classification/ensemble/AdaBoostTrainer.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/ensemble/AdaBoostTrainer.java
@@ -106,7 +106,7 @@ public class AdaBoostTrainer implements Trainer<Label> {
     }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFTrainer.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFTrainer.java
@@ -118,7 +118,7 @@ public class CRFTrainer implements SequenceTrainer<Label>, WeightedExamples {
     private CRFTrainer() { }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/kernel/KernelSVMTrainer.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/kernel/KernelSVMTrainer.java
@@ -114,7 +114,7 @@ public class KernelSVMTrainer implements Trainer<Label>, WeightedExamples {
     private KernelSVMTrainer() { }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/linear/LinearSGDTrainer.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/linear/LinearSGDTrainer.java
@@ -131,7 +131,7 @@ public class LinearSGDTrainer implements Trainer<Label>, WeightedExamples {
     private LinearSGDTrainer() { }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Clustering/KMeans/src/main/java/org/tribuo/clustering/kmeans/KMeansTrainer.java
+++ b/Clustering/KMeans/src/main/java/org/tribuo/clustering/kmeans/KMeansTrainer.java
@@ -131,7 +131,7 @@ public class KMeansTrainer implements Trainer<ClusterID> {
     }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Common/Trees/src/main/java/org/tribuo/common/trees/AbstractCARTTrainer.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/trees/AbstractCARTTrainer.java
@@ -93,7 +93,7 @@ public abstract class AbstractCARTTrainer<T extends Output<T>> implements Decisi
     }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Core/src/main/java/org/tribuo/CategoricalInfo.java
+++ b/Core/src/main/java/org/tribuo/CategoricalInfo.java
@@ -31,11 +31,18 @@ import java.util.SplittableRandom;
  * <p>
  * Contains a mapping from values to observed counts for that value, has
  * an initial optimisation for the binary case to reduce memory consumption.
+ * </p>
  * <p>
  * Can be transformed into a {@link RealInfo} if there are too many unique observed values.
+ * </p>
  * <p>
  * Does not contain an id number, but can be transformed into {@link CategoricalIDInfo} which
  * does contain an id number.
+ * </p>
+ * <p>
+ * Note that the synchronization in this class only protects instantiation where CDF and values
+ * are recomputed. Care should be taken if data is read while {@link #observe(double)} is called.
+ * </p>
  */
 public class CategoricalInfo extends SkeletalVariableInfo {
     private static final long serialVersionUID = 2L;

--- a/Core/src/main/java/org/tribuo/Dataset.java
+++ b/Core/src/main/java/org/tribuo/Dataset.java
@@ -208,7 +208,7 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
     public abstract FeatureMap getFeatureMap();
 
     @Override
-    public Iterator<Example<T>> iterator() {
+    public synchronized Iterator<Example<T>> iterator() {
         if (indices == null) {
             return data.iterator();
         } else {

--- a/Core/src/main/java/org/tribuo/ensemble/BaggingTrainer.java
+++ b/Core/src/main/java/org/tribuo/ensemble/BaggingTrainer.java
@@ -87,7 +87,7 @@ public class BaggingTrainer<T extends Output<T>> implements Trainer<T> {
     }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Interop/ONNX/src/main/java/org/tribuo/interop/onnx/ONNXExternalModel.java
+++ b/Interop/ONNX/src/main/java/org/tribuo/interop/onnx/ONNXExternalModel.java
@@ -199,7 +199,7 @@ public final class ONNXExternalModel<T extends Output<T>> extends ExternalModel<
     }
 
     @Override
-    protected Model<T> copy(String newName, ModelProvenance newProvenance) {
+    protected synchronized Model<T> copy(String newName, ModelProvenance newProvenance) {
         byte[] newModelArray = Arrays.copyOf(modelArray,modelArray.length);
         try {
             return new ONNXExternalModel<>(newName, newProvenance, featureIDMap, outputIDInfo,

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/sequence/TensorflowSequenceTrainer.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/sequence/TensorflowSequenceTrainer.java
@@ -122,7 +122,7 @@ public class TensorflowSequenceTrainer<T extends Output<T>> implements SequenceT
     private TensorflowSequenceTrainer() { }
 
     @Override
-    public void postConfig() throws IOException {
+    public synchronized void postConfig() throws IOException {
         rng = new SplittableRandom(seed);
         graphDef = Files.readAllBytes(graphPath);
     }

--- a/Regression/Core/src/main/java/org/tribuo/regression/impl/SkeletalIndependentRegressionSparseTrainer.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/impl/SkeletalIndependentRegressionSparseTrainer.java
@@ -59,7 +59,7 @@ public abstract class SkeletalIndependentRegressionSparseTrainer<T> implements S
     protected SkeletalIndependentRegressionSparseTrainer() {}
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Regression/Core/src/main/java/org/tribuo/regression/impl/SkeletalIndependentRegressionTrainer.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/impl/SkeletalIndependentRegressionTrainer.java
@@ -60,7 +60,7 @@ public abstract class SkeletalIndependentRegressionTrainer<T> implements Trainer
     protected SkeletalIndependentRegressionTrainer() {}
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Regression/SGD/src/main/java/org/tribuo/regression/sgd/linear/LinearSGDTrainer.java
+++ b/Regression/SGD/src/main/java/org/tribuo/regression/sgd/linear/LinearSGDTrainer.java
@@ -132,7 +132,7 @@ public class LinearSGDTrainer implements Trainer<Regressor>, WeightedExamples {
     private LinearSGDTrainer() { }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         this.rng = new SplittableRandom(seed);
     }
 

--- a/Regression/SLM/src/main/java/org/tribuo/regression/slm/ElasticNetCDTrainer.java
+++ b/Regression/SLM/src/main/java/org/tribuo/regression/slm/ElasticNetCDTrainer.java
@@ -107,7 +107,7 @@ public class ElasticNetCDTrainer implements SparseTrainer<Regressor> {
     }
 
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() {
         if ((l1Ratio < DELTA) || (l1Ratio > 1.0 + DELTA)) {
             throw new PropertyException("l1Ratio","L1 Ratio must be between 0 and 1. Found value " + l1Ratio);
         }


### PR DESCRIPTION
Almost all issues were along the instantiation path in postConfig and hence already single-threaded, but I made the methods synchronized anyway to clear the warnings. A couple actual possible issues were fixed. A few warnings still remain - these should be clean based on our usage.