### PR TITLE
A small fix and some javadoc

### DIFF
--- a/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/LibSVMAnomalyTrainer.java
+++ b/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/LibSVMAnomalyTrainer.java
@@ -67,7 +67,7 @@ public class LibSVMAnomalyTrainer extends LibSVMTrainer<Event> {
 
     /**
      * Creates a one-class LibSVM trainer using the supplied parameters.
-     * @param parameters
+     * @param parameters The training parameters.
      */
     public LibSVMAnomalyTrainer(SVMParameters<Event> parameters) {
         super(parameters);

--- a/Clustering/Core/src/main/java/org/tribuo/clustering/example/ClusteringDataGenerator.java
+++ b/Clustering/Core/src/main/java/org/tribuo/clustering/example/ClusteringDataGenerator.java
@@ -51,6 +51,7 @@ public abstract class ClusteringDataGenerator {
      * Generates a dataset drawn from a mixture of 5 2d gaussians.
      *
      * @param size The number of points to sample for the dataset.
+     * @param seed The RNG seed.
      * @return A pair of datasets.
      */
     public static Dataset<ClusterID> gaussianClusters(long size, long seed) {

--- a/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMModel.java
+++ b/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMModel.java
@@ -72,7 +72,7 @@ public abstract class LibSVMModel<T extends Output<T>> extends Model<T> implemen
 
     /**
      * Gets the underlying list of libsvm models.
-     * @return
+     * @return The underlying model list.
      */
     public List<svm_model> getModel() {
         return models;

--- a/Core/src/main/java/org/tribuo/CategoricalInfo.java
+++ b/Core/src/main/java/org/tribuo/CategoricalInfo.java
@@ -204,6 +204,7 @@ public class CategoricalInfo extends SkeletalVariableInfo {
      * Samples a value from this feature according to the frequency of observation.
      * @param rng The RNG to use.
      * @param totalObservations The observations including the implicit zeros.
+     * @return The sampled value.
      */
     public double frequencyBasedSample(SplittableRandom rng, long totalObservations) {
         if ((totalObservations != this.totalObservations) || (cdf == null)) {
@@ -217,6 +218,7 @@ public class CategoricalInfo extends SkeletalVariableInfo {
      * Samples a value from this feature according to the frequency of observation.
      * @param rng The RNG to use.
      * @param totalObservations The observations including the implicit zeros.
+     * @return The sampled value.
      */
     public double frequencyBasedSample(Random rng, long totalObservations) {
         if ((totalObservations != this.totalObservations) || (cdf == null)) {

--- a/Core/src/main/java/org/tribuo/util/MurmurHash3.java
+++ b/Core/src/main/java/org/tribuo/util/MurmurHash3.java
@@ -49,7 +49,12 @@ public final class MurmurHash3 {
         return k;
     }
 
-    /** Gets a long from a byte buffer in little endian byte order. */
+    /**
+     * Gets a long from a byte buffer in little endian byte order.
+     * @param buf The buffer to operate on.
+     * @param offset The current offset into the buffer.
+     * @return A long.
+     */
     public static final long getLongLittleEndian(byte[] buf, int offset) {
         return     ((long)buf[offset+7]    << 56)   // no mask needed
                 | ((buf[offset+6] & 0xffL) << 48)
@@ -62,7 +67,14 @@ public final class MurmurHash3 {
     }
 
 
-    /** Returns the MurmurHash3_x86_32 hash. */
+    /**
+     * Returns the MurmurHash3_x86_32 hash.
+     * @param data The data to hash.
+     * @param offset The offset into the data.
+     * @param len The length of the data to hash.
+     * @param seed The initial seed of the hash.
+     * @return The murmurhash3_x86_32 hash.
+     */
     public static int murmurhash3_x86_32(byte[] data, int offset, int len, int seed) {
 
         final int c1 = 0xcc9e2d51;
@@ -115,9 +127,15 @@ public final class MurmurHash3 {
     }
 
 
-    /** Returns the MurmurHash3_x86_32 hash of the UTF-8 bytes of the String without actually encoding
+    /**
+     * Returns the MurmurHash3_x86_32 hash of the UTF-8 bytes of the String without actually encoding
      * the string to a temporary buffer.  This is more than 2x faster than hashing the result
      * of String.getBytes().
+     * @param data The data to hash.
+     * @param offset The offset into the data.
+     * @param len The length of the data to hash.
+     * @param seed The initial seed of the hash.
+     * @return The murmurhash3_x86_32 hash.
      */
     public static int murmurhash3_x86_32(CharSequence data, int offset, int len, int seed) {
 
@@ -238,7 +256,14 @@ public final class MurmurHash3 {
     }
 
 
-    /** Returns the MurmurHash3_x64_128 hash, placing the result in "out". */
+    /**
+     * Returns the MurmurHash3_x64_128 hash, placing the result in "out".
+     * @param key The data to hash.
+     * @param offset The offset into the data.
+     * @param len The length of the data to hash.
+     * @param seed The initial state of the hash.
+     * @param out The output value (as it's 128 bits).
+     */
     public static void murmurhash3_x64_128(byte[] key, int offset, int len, int seed, LongPair out) {
         // The original algorithm does have a 32 bit unsigned seed.
         // We have to mask to match the behavior of the unsigned types and prevent sign extension.

--- a/Data/src/main/java/org/tribuo/data/text/TextFeatureExtractor.java
+++ b/Data/src/main/java/org/tribuo/data/text/TextFeatureExtractor.java
@@ -36,6 +36,6 @@ public interface TextFeatureExtractor<T extends Output<T>> extends Configurable,
      * @param data The input text.
      * @return An example
      */
-    public Example<T> extract(T label, String data);
+    public Example<T> extract(T output, String data);
 
 }

--- a/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionTrainer.java
+++ b/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionTrainer.java
@@ -33,6 +33,7 @@ import libsvm.svm_parameter;
 import libsvm.svm_problem;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -102,7 +103,7 @@ public class LibSVMRegressionTrainer extends LibSVMTrainer<Regressor> {
             models.add(svm.svm_train(problem, curParams));
         }
 
-        return models;
+        return Collections.unmodifiableList(models);
     }
 
     @Override

--- a/Util/Tokenization/src/main/java/org/tribuo/util/tokens/Tokenizer.java
+++ b/Util/Tokenization/src/main/java/org/tribuo/util/tokens/Tokenizer.java
@@ -105,11 +105,13 @@ public interface Tokenizer extends Configurable, Cloneable, Provenancable<Config
      * with a fresh CharSequence.
      *
      * @return A tokenizer with the same configuration, but independent state.
+     * @throws CloneNotSupportedException if the tokenizer isn't cloneable.
      */
     public Tokenizer clone() throws CloneNotSupportedException;
 
     /**
      * Generates a Token object from the current state of the tokenizer.
+     * @return The token object from the current state.
      */
     default public Token getToken() {
         return new Token(getText(), getStart(), getEnd(), getType());

--- a/Util/Tokenization/src/main/java/org/tribuo/util/tokens/universal/UniversalTokenizer.java
+++ b/Util/Tokenization/src/main/java/org/tribuo/util/tokens/universal/UniversalTokenizer.java
@@ -176,6 +176,7 @@ public class UniversalTokenizer implements Tokenizer {
      * correct, since it doesn't count the smart quotes as letters.
      *
      * @param c The character to check.
+     * @return True if the input is a letter or digit.
      */
     public static boolean isLetterOrDigit(char c) {
         if ((c <= 122 && c >= 97)
@@ -208,6 +209,7 @@ public class UniversalTokenizer implements Tokenizer {
      * A quick check for whether a character is a digit.
      *
      * @param c The character to check
+     * @return True if the input is a digit.
      */
     public static boolean isDigit(char c) {
         if ((c <= 57 && c >= 48) // most frequent: ASCII numbers 0...9
@@ -224,6 +226,7 @@ public class UniversalTokenizer implements Tokenizer {
      * A quick check for whether a character is whitespace.
      *
      * @param c The character to check
+     * @return True if the input is a whitespace character.
      */
     public static boolean isWhitespace(char c) {
         //test for white space
@@ -247,6 +250,7 @@ public class UniversalTokenizer implements Tokenizer {
      * Version 2.0.
      *
      * @param c The character to check
+     * @return True if the input character is in a region which is not whitespace separated.
      */
     public static boolean isNgram(char c) {
         // Test for characters that may not separate words with white


### PR DESCRIPTION
LibSVMRegressorTrainer now returns an immutable list, mirroring the other implementations, and a bunch of tiny javadoc fixes to remove all the javadoc warnings and errors.