### PR TITLE
Fixes a bug where ClusteringMetrics didn't calculate metrics

### DIFF
--- a/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/evaluation/AnomalyMetric.java
+++ b/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/evaluation/AnomalyMetric.java
@@ -170,5 +170,4 @@ public class AnomalyMetric implements EvaluationMetric<Event, AnomalyMetric.Cont
         }
     }
 
-
 }

--- a/Clustering/Core/src/main/java/org/tribuo/clustering/evaluation/ClusteringMetric.java
+++ b/Clustering/Core/src/main/java/org/tribuo/clustering/evaluation/ClusteringMetric.java
@@ -63,6 +63,14 @@ public class ClusteringMetric implements EvaluationMetric<ClusterID, ClusteringM
         return buildContext(model, predictions);
     }
 
+    @Override
+    public String toString() {
+        return "ClusteringMetric(" +
+                "target=" + target +
+                ",name='" + name + '\'' +
+                ')';
+    }
+
     static final class Context extends MetricContext<ClusterID> {
 
         private final ArrayList<Integer> predictedIDs = new ArrayList<>();
@@ -70,6 +78,10 @@ public class ClusteringMetric implements EvaluationMetric<ClusterID, ClusteringM
 
         Context(Model<ClusterID> model, List<Prediction<ClusterID>> predictions) {
             super(model, predictions);
+            for (Prediction<ClusterID> pred : predictions) {
+                predictedIDs.add(pred.getOutput().getID());
+                trueIDs.add(pred.getExample().getOutput().getID());
+            }
         }
 
         public ArrayList<Integer> getPredictedIDs() {

--- a/Clustering/KMeans/src/main/java/org/tribuo/clustering/kmeans/KMeansModel.java
+++ b/Clustering/KMeans/src/main/java/org/tribuo/clustering/kmeans/KMeansModel.java
@@ -62,6 +62,20 @@ public class KMeansModel extends Model<ClusterID> {
         this.distanceType = distanceType;
     }
 
+    /**
+     * Returns a copy of the centroids.
+     * @return The centroids.
+     */
+    public DenseVector[] getCentroidVectors() {
+        DenseVector[] copies = new DenseVector[centroidVectors.length];
+
+        for (int i = 0; i < copies.length; i++) {
+            copies[i] = centroidVectors[i].copy();
+        }
+
+        return copies;
+    }
+
     @Override
     public Prediction<ClusterID> predict(Example<ClusterID> example) {
         SparseVector vector = SparseVector.createSparseVector(example,featureIDMap,false);

--- a/Clustering/KMeans/src/main/java/org/tribuo/clustering/kmeans/KMeansTrainer.java
+++ b/Clustering/KMeans/src/main/java/org/tribuo/clustering/kmeans/KMeansTrainer.java
@@ -249,6 +249,11 @@ public class KMeansTrainer implements Trainer<ClusterID> {
     }
 
     @Override
+    public KMeansModel train(Dataset<ClusterID> dataset) {
+        return train(dataset,Collections.emptyMap());
+    }
+
+    @Override
     public int getInvocationCount() {
         return trainInvocationCounter;
     }

--- a/Clustering/KMeans/src/test/java/org/tribuo/clustering/kmeans/TestKMeans.java
+++ b/Clustering/KMeans/src/test/java/org/tribuo/clustering/kmeans/TestKMeans.java
@@ -20,6 +20,7 @@ import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.Dataset;
 import org.tribuo.Model;
 import org.tribuo.clustering.ClusterID;
+import org.tribuo.clustering.evaluation.ClusteringEvaluation;
 import org.tribuo.clustering.evaluation.ClusteringEvaluator;
 import org.tribuo.clustering.example.ClusteringDataGenerator;
 import org.tribuo.clustering.kmeans.KMeansTrainer.Distance;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -42,6 +44,25 @@ public class TestKMeans {
     public static void setup() {
         Logger logger = Logger.getLogger(KMeansTrainer.class.getName());
         logger.setLevel(Level.WARNING);
+    }
+
+    @Test
+    public void testEvaluation() {
+        Dataset<ClusterID> data = ClusteringDataGenerator.gaussianClusters(500, 1L);
+        Dataset<ClusterID> test = ClusteringDataGenerator.gaussianClusters(500, 2L);
+        ClusteringEvaluator eval = new ClusteringEvaluator();
+
+        KMeansTrainer trainer = new KMeansTrainer(5,10,Distance.EUCLIDEAN,1,1);
+
+        KMeansModel model = trainer.train(data);
+
+        ClusteringEvaluation trainEvaluation = eval.evaluate(model,data);
+        assertFalse(Double.isNaN(trainEvaluation.adjustedMI()));
+        assertFalse(Double.isNaN(trainEvaluation.normalizedMI()));
+
+        ClusteringEvaluation testEvaluation = eval.evaluate(model,test);
+        assertFalse(Double.isNaN(testEvaluation.adjustedMI()));
+        assertFalse(Double.isNaN(testEvaluation.normalizedMI()));
     }
 
     public void testKMeans(Pair<Dataset<ClusterID>,Dataset<ClusterID>> p) {


### PR DESCRIPTION
It wasn't copying out the correct values into the context.

I added a test into KMeans (as it's the first place we have a model that can produce predictions), and also a missing accessor for KMeansModel's centroids.