### PR TITLE
bugs in LabelConfusionMatrix.toString

### DIFF
--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
@@ -203,15 +203,15 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
     public String toString() {
         if (labelOrder == null) {
             labelOrder = new ArrayList<>(domain.getDomain());
-        } else {
-            labelOrder.retainAll(occurrences.keySet());
-        }        int maxLen = Integer.MIN_VALUE;
+        }
+        labelOrder.retainAll(occurrences.keySet());
+        
+        int maxLen = Integer.MIN_VALUE;
         for (Label label : labelOrder) {
             maxLen = Math.max(label.getLabel().length(), maxLen);
-            if(occurrences.containsKey(label)) {
-                maxLen = Math.max(String.format(" %,d", (int)(double)occurrences.get(label)).length(), maxLen);
-            }
+            maxLen = Math.max(String.format(" %,d", (int)(double)occurrences.get(label)).length(), maxLen);
         }
+
         StringBuilder sb = new StringBuilder();
         String trueLabelFormat = String.format("%%-%ds", maxLen + 2);
         String predictedLabelFormat = String.format("%%%ds", maxLen + 2);


### PR DESCRIPTION
I made two changes to LabelConfusionMatrix.toString.  The first fixes a NullPointerException I was getting if I was evaluating a small dataset and not all of the labels were seen by adding a conditional using occurrences.containsKey.  The second is to use labelOrder to drive the order of the printing of the labels.  Previously, this was ignored.  I tested these two changes in v3 in my local environment and they seem to work.  I feel pretty certain the code before was wrong and so this needs some attention.  I can't give 100% assurance that I fixed this correctly because I had a bit of difficulty grokking everything that was going on there.  