### PR TITLE
CSVLoader errors on double newlines at the end of files

### DIFF
--- a/Data/src/main/java/org/tribuo/data/csv/CSVIterator.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVIterator.java
@@ -42,13 +42,20 @@ import java.util.logging.Logger;
 public class CSVIterator extends ColumnarIterator implements AutoCloseable {
     private static final Logger logger = Logger.getLogger(CSVIterator.class.getName());
 
+    /**
+     * Default separator character.
+     */
     public final static char SEPARATOR = ',';
+
+    /**
+     * Default quote character.
+     */
     public final static char QUOTE = '"';
 
 
     private final CSVReader reader;
-    // We read numRows for idx from the CSVReader, so we need to keep track of whether the CSVReader read a header row
-    private int rowOffset = 1;
+    // We read numRows for idx from the CSVReader
+    private int recordNum = 0;
 
     /**
      * Builds a CSVIterator for the supplied Reader. Defaults to {@link CSVIterator#SEPARATOR} for the separator
@@ -141,7 +148,6 @@ public class CSVIterator extends ColumnarIterator implements AutoCloseable {
                     logger.warning("Given an empty CSV");
                 } else {
                     this.fields = Collections.unmodifiableList(Arrays.asList(inducedHeader));
-                    rowOffset++;
                 }
             } else {
                 this.fields = Collections.unmodifiableList(fields);
@@ -197,7 +203,8 @@ public class CSVIterator extends ColumnarIterator implements AutoCloseable {
                     return Optional.empty();
                 }
 
-                return Optional.of(new Row(reader.getRecordsRead() - rowOffset,
+                // Note this is intentionally recordNum++ as we count records from 0.
+                return Optional.of(new Row(recordNum++,
                         fields,
                         zip(fields, rawRow, reader.getRecordsRead())));
             } else {

--- a/Data/src/main/java/org/tribuo/data/csv/CSVIterator.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVIterator.java
@@ -183,6 +183,15 @@ public class CSVIterator extends ColumnarIterator implements AutoCloseable {
                 if(reader.getRecordsRead() % 50_000 == 0) {
                     logger.info(String.format("Read %d records on %d lines", reader.getRecordsRead(), reader.getLinesRead()));
                 }
+                if (rawRow.length == 1 && rawRow[0].isEmpty()) {
+                    // Found an extraneous newline in the csv file, aborting.
+                    try {
+                        reader.close();
+                    } catch (IOException e) {
+                        logger.log(Level.WARNING, "Error closing reader at end of file", e);
+                    }
+                    return Optional.empty();
+                }
                 return Optional.of(new Row(reader.getRecordsRead() - rowOffset,
                         fields,
                         zip(fields, rawRow, reader.getRecordsRead())));

--- a/Data/src/test/java/org/tribuo/data/csv/CSVIteratorTest.java
+++ b/Data/src/test/java/org/tribuo/data/csv/CSVIteratorTest.java
@@ -38,6 +38,7 @@ public class CSVIteratorTest {
     private URI noHeaderPath;
     private URI quotePath;
     private URI tsvPath;
+    private URI doubleLineBreak;
     private List<ColumnarIterator.Row> pathReference;
     private List<String> headers;
 
@@ -47,6 +48,7 @@ public class CSVIteratorTest {
         noHeaderPath = getClass().getResource("/org/tribuo/data/csv/test-noheader.csv").toURI();
         quotePath = getClass().getResource("/org/tribuo/data/csv/testQuote.csv").toURI();
         tsvPath = getClass().getResource("/org/tribuo/data/csv/testQuote.tsv").toURI();
+        doubleLineBreak = getClass().getResource("/org/tribuo/data/csv/test-double-line-break.csv").toURI();
 
         headers = Arrays.asList("A B C D RESPONSE".split(" "));
         pathReference = new ArrayList<>();
@@ -94,7 +96,6 @@ public class CSVIteratorTest {
         pathReference.add(new ColumnarIterator.Row(5, headers, rVals));
     }
 
-
     @Test
     public void testCsvReadingCorrectly() throws IOException {
         CSVIterator iter = new CSVIterator(path);
@@ -137,6 +138,19 @@ public class CSVIteratorTest {
     @Test
     public void testQuotedTsvReadingCorrectly() throws IOException {
         CSVIterator iter = new CSVIterator(tsvPath, '\t', '|');
+        for(int i=0; i < pathReference.size();i++) {
+            ColumnarIterator.Row iterRow = iter.next();
+            ColumnarIterator.Row refRow = pathReference.get(i);
+            assertEquals(refRow.getIndex(), iterRow.getIndex(), "Failure on row " + i + " of " + path.toString());
+            assertEquals(refRow.getFields(), iterRow.getFields(), "Failure on row " + i + " of " + path.toString());
+            assertEquals(refRow.getRowData(), iterRow.getRowData(), "Failure on row " + i + " of " + path.toString());
+        }
+        assertFalse(iter.hasNext(), "Iterator should be empty after reading");
+    }
+
+    @Test
+    public void testDoubleLineBreakReadingCorrectly() throws IOException {
+        CSVIterator iter = new CSVIterator(doubleLineBreak);
         for(int i=0; i < pathReference.size();i++) {
             ColumnarIterator.Row iterRow = iter.next();
             ColumnarIterator.Row refRow = pathReference.get(i);

--- a/Data/src/test/resources/org/tribuo/data/csv/test-double-line-break.csv
+++ b/Data/src/test/resources/org/tribuo/data/csv/test-double-line-break.csv
@@ -2,6 +2,7 @@ A,B,C,D,RESPONSE
 1,2,3,4,monkey
 2,5,3,4,monkey
 1,2,5,9,baboon
+
 3,5,8,4,monkey
 6,7,8,9,baboon
 0,7,8,9,baboon

--- a/Data/src/test/resources/org/tribuo/data/csv/test-double-line-break.csv
+++ b/Data/src/test/resources/org/tribuo/data/csv/test-double-line-break.csv
@@ -1,0 +1,8 @@
+A,B,C,D,RESPONSE
+1,2,3,4,monkey
+2,5,3,4,monkey
+1,2,5,9,baboon
+3,5,8,4,monkey
+6,7,8,9,baboon
+0,7,8,9,baboon
+


### PR DESCRIPTION
Which would be fine (as it's not really to spec) if it wasn't for the fact that some datasets (like the Irises we use in the tutorial) come with a double new line at the end.

This patch treats a double newline as the end of the file. Previously if it was in the middle of the file it would cause it to error out, and if it was the end of the file it would also error out.