### PR TITLE
Skipping the XGBoost tests on Windows in Github Actions.

### DIFF
--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -DskipXGBoostTests=true -B package --file pom.xml

--- a/Classification/Explanations/pom.xml
+++ b/Classification/Explanations/pom.xml
@@ -111,6 +111,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                     <skipTests>${skipXGBoostTests}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
             <plugin>

--- a/Classification/XGBoost/pom.xml
+++ b/Classification/XGBoost/pom.xml
@@ -76,6 +76,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                     <skipTests>${skipXGBoostTests}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/Common/XGBoost/pom.xml
+++ b/Common/XGBoost/pom.xml
@@ -97,6 +97,13 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                     <skipTests>${skipXGBoostTests}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/Regression/XGBoost/pom.xml
+++ b/Regression/XGBoost/pom.xml
@@ -76,6 +76,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                     <skipTests>${skipXGBoostTests}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
         <junit.version>5.6.2</junit.version>
         <opencsv.version>5.2</opencsv.version>
         <commonsmath.version>3.6.1</commonsmath.version>
+
+        <!-- Other properties -->
+        <!-- used by CI on Windows as the
+             XGBoost 1.0.0 binary on Maven Central doesn't
+             include Windows support -->
+        <skipXGBoostTests>false</skipXGBoostTests>
     </properties>
 
     <name>Tribuo</name>


### PR DESCRIPTION
### Description
The XGBoost 1.0.0 binary on Maven Central doesn't have a Windows dll in it. This PR skips the XGBoost tests in the Windows CI until we upgrade to an XGBoost version which does have a Windows binary.
