### PR TITLE
Bump OpenJDK 14 to 15 in Github Actions

### DIFF
--- a/.github/workflows/maven-macos.yml
+++ b/.github/workflows/maven-macos.yml
@@ -11,13 +11,12 @@ on:
 
 jobs:
   build:
-
     runs-on: macos-latest
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 14 ]
-    name: OpenJDK ${{ matrix.java }}
+        java: [ 8, 11, 15 ]
+    name: macOS OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup OpenJDK

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Tribuo CI (Ubuntu x86_64, OpenJDK 8, 11, 14)
+name: Tribuo CI (Ubuntu x86_64, OpenJDK 8, 11, latest)
 
 on:
   push:

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 14 ]
-    name: OpenJDK ${{ matrix.java }}
+        java: [ 8, 11, 15 ]
+    name: Ubuntu OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup OpenJDK

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -11,13 +11,12 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 14 ]
-    name: OpenJDK ${{ matrix.java }}
+        java: [ 8, 11, 15 ]
+    name: Windows OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup OpenJDK


### PR DESCRIPTION
### Description
Bumps the CI to test on 8, 11 and 15 from 8, 11 and 14.

### Motivation
We test on LTS and latest.
