### PR TITLE
Fixes `ColumnarDataSource` expandRegex issue

### DIFF
--- a/Classification/Explanations/src/main/java/org/tribuo/classification/explanations/lime/LIMEColumnar.java
+++ b/Classification/Explanations/src/main/java/org/tribuo/classification/explanations/lime/LIMEColumnar.java
@@ -107,12 +107,12 @@ public class LIMEColumnar extends LIMEBase implements ColumnarExplainer<Regresso
     public LIMEColumnar(SplittableRandom rng, Model<Label> innerModel, SparseTrainer<Regressor> explanationTrainer,
                         int numSamples, RowProcessor<Label> exampleGenerator, Tokenizer tokenizer) {
         super(rng, innerModel, explanationTrainer, numSamples);
-        this.generator = exampleGenerator;
+        this.generator = exampleGenerator.copy();
         this.responseProcessor = generator.getResponseProcessor();
         this.tokenizer = tokenizer;
         this.tokenizerThreadLocal = ThreadLocal.withInitial(() -> {try { return this.tokenizer.clone(); } catch (CloneNotSupportedException e) { throw new IllegalArgumentException("Tokenizer not cloneable",e); }});
-        if (!exampleGenerator.isConfigured()) {
-            exampleGenerator.expandRegexMapping(innerModel);
+        if (!this.generator.isConfigured()) {
+            this.generator.expandRegexMapping(innerModel);
         }
         this.binarisedInfos = new HashMap<>();
         ArrayList<VariableInfo> infos = new ArrayList<>();

--- a/Data/src/main/java/org/tribuo/data/columnar/ColumnarDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/ColumnarDataSource.java
@@ -83,6 +83,7 @@ public abstract class ColumnarDataSource<T extends Output<T>> implements Configu
             this.processor = processor;
             this.iterator = iterator;
             this.outputRequired = outputRequired;
+            processor.expandRegexMapping(iterator.getFields());
         }
 
         @Override

--- a/Data/src/main/java/org/tribuo/data/columnar/ColumnarDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/ColumnarDataSource.java
@@ -80,10 +80,10 @@ public abstract class ColumnarDataSource<T extends Output<T>> implements Configu
         private Example<T> buffer = null;
 
         InnerIterator(RowProcessor<T> processor, ColumnarIterator iterator, boolean outputRequired) {
-            this.processor = processor;
+            this.processor = processor.copy();
+            this.processor.expandRegexMapping(iterator.getFields());
             this.iterator = iterator;
             this.outputRequired = outputRequired;
-            processor.expandRegexMapping(iterator.getFields());
         }
 
         @Override

--- a/Data/src/main/java/org/tribuo/data/columnar/ResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/ResponseProcessor.java
@@ -42,9 +42,12 @@ public interface ResponseProcessor<T extends Output<T>> extends Configurable, Pr
     public String getFieldName();
 
     /**
+     * @deprecated Response processors should be immutable; downstream objects assume that they are
      * Set the field name this ResponseProcessor uses.
      * @param fieldName The field name.
+     *
      */
+    @Deprecated()
     public void setFieldName(String fieldName);
 
     /**

--- a/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
@@ -382,10 +382,10 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
         if (configured) {
             logger.warning("RowProcessor was already configured, yet expandRegexMapping was called with " + fieldNames.toString());
         }
-        Set<String> fieldsMatchingRegex = partialExpandRegexMapping(fieldNames);
+        Set<String> regexesMatchingFieldNames = partialExpandRegexMapping(fieldNames);
 
-        if (fieldsMatchingRegex.size() != regexMappingProcessors.size()) {
-            throw new IllegalArgumentException("Failed to match all the regexes, found " + fieldsMatchingRegex.size() + ", required " + regexMappingProcessors.size());
+        if (regexesMatchingFieldNames.size() != regexMappingProcessors.size()) {
+            throw new IllegalArgumentException("Failed to match all the regexes, found " + regexesMatchingFieldNames.size() + ", required " + regexMappingProcessors.size());
         } else {
             regexMappingProcessors.clear();
             configured = true;
@@ -401,7 +401,7 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
      * @return the set of regexes that were matched by fieldNames.
      */
     protected Set<String> partialExpandRegexMapping(Collection<String> fieldNames) {
-        HashSet<String> fieldsMatchingRegex = new HashSet<>();
+        HashSet<String> regexesMatchingFieldNames = new HashSet<>();
         // Loop over all regexes
         for (Map.Entry<String,FieldProcessor> e : regexMappingProcessors.entrySet()) {
             Pattern p = Pattern.compile(e.getKey());
@@ -416,18 +416,19 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
                         throw new IllegalArgumentException("Regex " + p.toString() + " matched field " + s + " which already had a field processor " + f.toString());
                     }
 
-                    fieldsMatchingRegex.add(e.getKey());
+                    regexesMatchingFieldNames.add(e.getKey());
                 }
             }
         }
-        return fieldsMatchingRegex;
+        return regexesMatchingFieldNames;
     }
 
     /**
      * @deprecated In a future release this API will change, in the meantime this is the correct way to get a row
      *   processor with clean state.
      * <p/>
-     * RowProcessor is stateful in a way that can sometimes make it fail the second time it is used. Concretely
+     * When using regexMappingProcessors, RowProcessor is stateful in a way that can sometimes make it fail the second
+     * time it is used. Concretely:
      * <pre>
      *     RowProcessor rp;
      *     Dataset ds1 = new MutableDataset(new CSVDataSource(csvfile1, rp));

--- a/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
@@ -382,10 +382,10 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
         if (configured) {
             logger.warning("RowProcessor was already configured, yet expandRegexMapping was called with " + fieldNames.toString());
         }
-        Set<String> foundFields = partialExpandRegexMapping(fieldNames);
+        Set<String> fieldsMatchingRegex = partialExpandRegexMapping(fieldNames);
 
-        if (foundFields.size() != regexMappingProcessors.size()) {
-            throw new IllegalArgumentException("Failed to match all the regexes, found " + foundFields.size() + ", required " + regexMappingProcessors.size());
+        if (fieldsMatchingRegex.size() != regexMappingProcessors.size()) {
+            throw new IllegalArgumentException("Failed to match all the regexes, found " + fieldsMatchingRegex.size() + ", required " + regexMappingProcessors.size());
         } else {
             regexMappingProcessors.clear();
             configured = true;
@@ -401,7 +401,7 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
      * @return the set of regexes that were matched by fieldNames.
      */
     protected Set<String> partialExpandRegexMapping(Collection<String> fieldNames) {
-        HashSet<String> foundFields = new HashSet<>();
+        HashSet<String> fieldsMatchingRegex = new HashSet<>();
         // Loop over all regexes
         for (Map.Entry<String,FieldProcessor> e : regexMappingProcessors.entrySet()) {
             Pattern p = Pattern.compile(e.getKey());
@@ -416,11 +416,29 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
                         throw new IllegalArgumentException("Regex " + p.toString() + " matched field " + s + " which already had a field processor " + f.toString());
                     }
 
-                    foundFields.add(e.getKey());
+                    fieldsMatchingRegex.add(e.getKey());
                 }
             }
         }
-        return foundFields;
+        return fieldsMatchingRegex;
+    }
+
+    /**
+     * @deprecated In a future release this API will change, in the meantime this is the correct way to get a row
+     *   processor with clean state.
+     * <p/>
+     * RowProcessor is stateful in a way that can sometimes make it fail the second time it is used. Concretely
+     * <pre>
+     *     RowProcessor rp;
+     *     Dataset ds1 = new MutableDataset(new CSVDataSource(csvfile1, rp));
+     *     Dataset ds2 = new MutableDataset(new CSVDataSource(csvfile2, rp)); // this may fail due to state in rp
+     * </pre>
+     * This method returns a RowProcessor with clean state and the same configuration as this row processor.
+     * @return a RowProcessor instance with clean state and the same configuration as this row processor.
+     */
+    @Deprecated
+    public RowProcessor<T> copy() {
+        return new RowProcessor<>(metadataExtractors, weightExtractor, responseProcessor, fieldProcessorMap, regexMappingProcessors, featureProcessors);
     }
 
     @Override

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/RegexFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/RegexFieldProcessor.java
@@ -64,6 +64,7 @@ public class RegexFieldProcessor implements FieldProcessor {
     public RegexFieldProcessor(String fieldName, Pattern regex, EnumSet<Mode> modes) {
         this.regex = regex;
         this.fieldName = fieldName;
+        this.regexString = regex.pattern();
         this.modes = modes;
     }
 

--- a/Data/src/test/java/org/tribuo/data/csv/CSVDataSourceTest.java
+++ b/Data/src/test/java/org/tribuo/data/csv/CSVDataSourceTest.java
@@ -21,6 +21,7 @@ import com.oracle.labs.mlrg.olcut.provenance.ProvenanceUtil;
 import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.tribuo.Dataset;
 import org.tribuo.MutableDataset;
 import org.tribuo.OutputFactory;
 import org.tribuo.data.columnar.FieldProcessor;
@@ -39,8 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  *
@@ -115,4 +115,11 @@ public class CSVDataSourceTest {
 
         assertEquals(13, dataset.getFeatureMap().size());
     }
+
+    @Test
+    public void testRowProcessorReuse() {
+        Dataset<MockOutput> ds1 = new MutableDataset<>(new CSVDataSource<>(regexDataFile, regexRowProcessor, true));
+        Dataset<MockOutput> ds2 = new MutableDataset<>(new CSVDataSource<>(regexDataFile, regexRowProcessor, true));
+    }
+
 }

--- a/Data/src/test/resources/org/tribuo/data/csv/test-regexmapping.csv
+++ b/Data/src/test/resources/org/tribuo/data/csv/test-regexmapping.csv
@@ -1,0 +1,7 @@
+fooA,fooB,fooC,fooD,RESPONSE
+1,2,3,4,monkey
+2,5,3,4,monkey
+1,2,5,9,baboon
+3,5,8,4,monkey
+6,7,8,9,baboon
+0,7,8,9,baboon


### PR DESCRIPTION
Fixes `ColumnarDataSource` and children not correctly calling `RowProcessor.expandRegexMapping` to support dynamic regex field headers.