### PR TITLE
Capturing the provenance for RowProcessor's regex mapped fields

### DIFF
--- a/Data/src/main/java/org/tribuo/data/columnar/ColumnarDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/ColumnarDataSource.java
@@ -81,7 +81,9 @@ public abstract class ColumnarDataSource<T extends Output<T>> implements Configu
 
         InnerIterator(RowProcessor<T> processor, ColumnarIterator iterator, boolean outputRequired) {
             this.processor = processor.copy();
-            this.processor.expandRegexMapping(iterator.getFields());
+            if (!this.processor.isConfigured()) {
+                this.processor.expandRegexMapping(iterator.getFields());
+            }
             this.iterator = iterator;
             this.outputRequired = outputRequired;
         }

--- a/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
@@ -381,14 +381,15 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
     public void expandRegexMapping(Collection<String> fieldNames) {
         if (configured) {
             logger.warning("RowProcessor was already configured, yet expandRegexMapping was called with " + fieldNames.toString());
-        }
-        Set<String> regexesMatchingFieldNames = partialExpandRegexMapping(fieldNames);
-
-        if (regexesMatchingFieldNames.size() != regexMappingProcessors.size()) {
-            throw new IllegalArgumentException("Failed to match all the regexes, found " + regexesMatchingFieldNames.size() + ", required " + regexMappingProcessors.size());
         } else {
-            regexMappingProcessors.clear();
-            configured = true;
+            Set<String> regexesMatchingFieldNames = partialExpandRegexMapping(fieldNames);
+
+            if (regexesMatchingFieldNames.size() != regexMappingProcessors.size()) {
+                throw new IllegalArgumentException("Failed to match all the regexes, found " + regexesMatchingFieldNames.size() + ", required " + regexMappingProcessors.size());
+            } else {
+                regexMappingProcessors.clear();
+                configured = true;
+            }
         }
     }
 
@@ -409,8 +410,11 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
             for (String s : fieldNames) {
                 // Check if the pattern matches the field name
                 if (p.matcher(s).matches()) {
-                    // If it matches, add the field to the fieldProcessorMap map
-                    FieldProcessor f = fieldProcessorMap.put(s,e.getValue().copy(s));
+                    // If it matches, add the field to the fieldProcessorMap map and the fieldProcessorList (for the provenance).
+                    FieldProcessor newProcessor = e.getValue().copy(s);
+                    fieldProcessorList.add(newProcessor);
+                    FieldProcessor f = fieldProcessorMap.put(s,newProcessor);
+
 
                     if (f != null) {
                         throw new IllegalArgumentException("Regex " + p.toString() + " matched field " + s + " which already had a field processor " + f.toString());

--- a/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
@@ -261,7 +261,7 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
      */
     public List<ColumnarFeature> generateFeatures(Map<String,String> row) {
         if (!configured) {
-            throw new IllegalStateException("expandRegexMapping not called, yet there are fieldProcessorMap which have not been bound to a field name.");
+            throw new IllegalStateException("expandRegexMapping not called, yet there are entries in regexMappingProcessors which have not been bound to a field name.");
         }
         List<ColumnarFeature> features = new ArrayList<>();
 

--- a/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/RowProcessor.java
@@ -153,7 +153,7 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
      * @return The field processors.
      */
     public Map<String,FieldProcessor> getFieldProcessors() {
-        return fieldProcessorMap;
+        return Collections.unmodifiableMap(fieldProcessorMap);
     }
 
     /**
@@ -161,7 +161,7 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
      * @return The feature processors.
      */
     public Set<FeatureProcessor> getFeatureProcessors() {
-        return featureProcessors;
+        return Collections.unmodifiableSet(featureProcessors);
     }
 
     /**
@@ -285,7 +285,7 @@ public class RowProcessor<T extends Output<T>> implements Configurable, Provenan
      * @return The set of column names it processes.
      */
     public Set<String> getColumnNames() {
-        return fieldProcessorMap.keySet();
+        return Collections.unmodifiableSet(fieldProcessorMap.keySet());
     }
 
     /**

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/response/BinaryResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/response/BinaryResponseProcessor.java
@@ -68,6 +68,7 @@ public class BinaryResponseProcessor<T extends Output<T>> implements ResponsePro
         return fieldName;
     }
 
+    @Deprecated
     @Override
     public void setFieldName(String fieldName) {
         this.fieldName = fieldName;

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/response/FieldResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/response/FieldResponseProcessor.java
@@ -50,6 +50,7 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
         this.outputFactory = outputFactory;
     }
 
+    @Deprecated
     @Override
     public void setFieldName(String fieldName) {
         this.fieldName = fieldName;

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/response/QuartileResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/response/QuartileResponseProcessor.java
@@ -54,6 +54,7 @@ public class QuartileResponseProcessor<T extends Output<T>> implements ResponseP
         this.outputFactory = outputFactory;
     }
 
+    @Deprecated
     @Override
     public void setFieldName(String fieldName) {
         this.fieldName = fieldName;

--- a/Data/src/test/java/org/tribuo/data/columnar/MockResponseProcessor.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/MockResponseProcessor.java
@@ -49,6 +49,7 @@ public class MockResponseProcessor implements ResponseProcessor<MockOutput> {
         return fieldName;
     }
 
+    @Deprecated
     @Override
     public void setFieldName(String fieldName) {
         this.fieldName = fieldName;


### PR DESCRIPTION
### Description
The current provenance code in `RowProcessor` looks at fields marked `@Config`, however the store of reference for field processors is not the `@Config` field `fieldProcessorList`, it's `fieldProcessorMap`. So when the regex field mapping is expanded the new field processors need to be written into both `fieldProcessorList` and `fieldProcessorMap` as the regex mapping is cleared.

It could go either way with this fix, either keep the regexes in the provenance, or only store the matched fields. The latter has better fidelity at replicating the model, because otherwise new fields could be matched by the regex (however that may be what the user wants). To preserve the flexibility the RowProcessor should be reinstantiated from it's original configuration if the user wants to have the regexes take into account new field names.

It also makes the get methods of RowProcessor return unmodifiable views so people can't break it's invariants accidentally.

### Motivation
Fixes the provenance so it contains all relevant field processors.
