### PR TITLE
Makes IDXDataSource throw FileNotFoundException when the files don't exist

### DIFF
--- a/Core/src/test/resources/org/tribuo/datasource/config.xml
+++ b/Core/src/test/resources/org/tribuo/datasource/config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+    Description:
+        An example configuration file for an IDXDataSource with invalid paths.
+-->
+
+<config>
+    <component name="mock-factory" type="org.tribuo.test.MockOutputFactory"/>
+
+    <component name="train" type="org.tribuo.datasource.IDXDataSource">
+        <property name="featuresPath" value="these-arent-the-files-you-are-looking-for"/>
+        <property name="outputPath" value="nor-are-they-the-droids"/>
+        <property name="outputFactory" value="mock-factory"/>
+    </component>
+</config>


### PR DESCRIPTION
### Description
If the idx files passed into `IDXDataSource` don't exist then it throws a random looking `NullPointerException` out of readData. This obscures what's actually going wrong, and it really should throw `FileNotFoundException`, so now it does.

### Motivation
Fixes the error message in #58 .