### PR TITLE
Save Computation in Known Leaf Nodes, Fix minChildWeight bug

### DIFF
--- a/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/CARTClassificationTrainer.java
+++ b/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/CARTClassificationTrainer.java
@@ -110,8 +110,9 @@ public class CARTClassificationTrainer extends AbstractCARTTrainer<Label> {
     }
 
     @Override
-    protected AbstractTrainingNode<Label> mkTrainingNode(Dataset<Label> examples) {
-        return new ClassifierTrainingNode(impurity, examples);
+    protected AbstractTrainingNode<Label> mkTrainingNode(Dataset<Label> examples,
+                                                         AbstractTrainingNode.LeafDeterminer leafDeterminer) {
+        return new ClassifierTrainingNode(impurity, examples, leafDeterminer);
     }
 
     @Override

--- a/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/impl/ClassifierTrainingNode.java
+++ b/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/impl/ClassifierTrainingNode.java
@@ -143,8 +143,8 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
         int bestID = -1;
         double bestSplitValue = 0.0;
         double bestScore = getImpurity();
-        float[] lessThanCountsOfBest = null;
-        float[] greaterThanCountsOfBest = null;
+        float[] lessThanCountsOfBest = new float[weightedLabelCounts.length];
+        float[] greaterThanCountsOfBest = new float[weightedLabelCounts.length];
         float[] lessThanCounts = new float[weightedLabelCounts.length];
         float[] greaterThanCounts = new float[weightedLabelCounts.length];
         for (int i = 0; i < featureIDs.length; i++) {
@@ -166,13 +166,14 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
                     if (score < bestScore) {
                         bestID = i;
                         bestScore = score;
-                        lessThanCountsOfBest = lessThanCounts;
-                        greaterThanCountsOfBest = greaterThanCounts;
+                        System.arraycopy(lessThanCounts,0,lessThanCountsOfBest,0,lessThanCounts.length);
+                        System.arraycopy(lessThanCounts,0,greaterThanCountsOfBest,0,greaterThanCounts.length);
                         bestSplitValue = (f.value + feature.get(j + 1).value) / 2.0;
                     }
                 }
             }
         }
+
         List<AbstractTrainingNode<Label>> output;
         double impurityDecrease = weightSum * (getImpurity() - bestScore);
         // If we found a split better than the current impurity.
@@ -195,8 +196,8 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
         int bestID = -1;
         double bestSplitValue = 0.0;
         double bestScore = getImpurity();
-        float[] lessThanCountsOfBest = null;
-        float[] greaterThanCountsOfBest = null;
+        float[] lessThanCountsOfBest = new float[weightedLabelCounts.length];
+        float[] greaterThanCountsOfBest = new float[weightedLabelCounts.length];
         float[] lessThanCounts = new float[weightedLabelCounts.length];
         float[] greaterThanCounts = new float[weightedLabelCounts.length];
 
@@ -226,8 +227,8 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
                 if (score < bestScore) {
                     bestID = i;
                     bestScore = score;
-                    lessThanCountsOfBest = lessThanCounts;
-                    greaterThanCountsOfBest = greaterThanCounts;
+                    System.arraycopy(lessThanCounts,0,lessThanCountsOfBest,0,lessThanCounts.length);
+                    System.arraycopy(lessThanCounts,0,greaterThanCountsOfBest,0,greaterThanCounts.length);
                     bestSplitValue = (feature.get(splitIdx).value + feature.get(splitIdx + 1).value) / 2.0;
                 }
             }

--- a/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/impl/ClassifierTrainingNode.java
+++ b/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/impl/ClassifierTrainingNode.java
@@ -251,7 +251,8 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
      * @param featureIDs Indices of the features available in this split.
      * @param bestID ID of the feature on which the split should be based.
      * @param bestSplitValue Feature value to use for splitting the data.
-     *                       TODO: update
+     * @param lessThanCounts Weighted label counts for data less than or equal to the split value for the given feature.
+     * @param greaterThanCounts Weighted label counts for data greater than the split value for the given feature.
      * @return A list of training nodes resulting from the split.
      */
     private List<AbstractTrainingNode<Label>> splitAtBest(int[] featureIDs, int bestID, double bestSplitValue,
@@ -328,10 +329,10 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
     }
 
     /**
-     * TODO: fill this in
-     * @param impurityScore
-     * @param weightedCounts
-     * @return
+     * Makes a {@link LeafNode}
+     * @param impurityScore the impurity score for the node.
+     * @param weightedCounts the weighted label counts of the data in the node.
+     * @return a {@link LeafNode}
      */
     private LeafNode<Label> mkLeaf(double impurityScore, float[] weightedCounts) {
         double[] normedCounts = Util.normalizeToDistribution(weightedCounts);

--- a/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/impl/ClassifierTrainingNode.java
+++ b/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/impl/ClassifierTrainingNode.java
@@ -73,7 +73,7 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
      * Constructor which creates the inverted file.
      * @param impurity The impurity function to use.
      * @param examples The training data.
-     * @param leafDeterminer Contains parameters needed to determine whether a node is a leaf.
+     * @param leafDeterminer Contains parameters needed to determine whether a child node will be a leaf.
      */
     public ClassifierTrainingNode(LabelImpurity impurity, Dataset<Label> examples, LeafDeterminer leafDeterminer) {
         this(impurity,invertData(examples), examples.size(), 0, examples.getFeatureIDMap(),
@@ -308,8 +308,7 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
         AbstractTrainingNode<Label> tmpNode;
         if (shouldMakeLessThanLeaf) {
             lessThanOrEqual = mkLeaf(lessThanImpurityScore, lessThanCounts);
-        }
-        else {
+        } else {
             tmpNode = new ClassifierTrainingNode(impurity, lessThanData, lessThanIndices.size, depth + 1,
                     featureIDMap, labelIDMap, leafDeterminer, lessThanCounts, lessThanWeightSum, lessThanImpurityScore);
             lessThanOrEqual = tmpNode;
@@ -318,8 +317,7 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
 
         if (shouldMakeGreaterThanLeaf) {
             greaterThan = mkLeaf(greaterThanImpurityScore, greaterThanCounts);
-        }
-        else {
+        } else {
             tmpNode = new ClassifierTrainingNode(impurity, greaterThanData, numExamples - lessThanIndices.size,
                     depth + 1, featureIDMap, labelIDMap, leafDeterminer, greaterThanCounts, greaterThanWeightSum, greaterThanImpurityScore);
             greaterThan = tmpNode;
@@ -359,8 +357,9 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
     public Node<Label> convertTree() {
         if (split) {
             return mkSplitNode();
+        } else {
+            return mkLeaf(getImpurity(), weightedLabelCounts);
         }
-        return mkLeaf(getImpurity(), weightedLabelCounts);
     }
 
     /**

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractCARTTrainer.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractCARTTrainer.java
@@ -202,7 +202,7 @@ public abstract class AbstractCARTTrainer<T extends Output<T>> implements Decisi
         while (!queue.isEmpty()) {
             AbstractTrainingNode<T> node = queue.poll();
             if ((node.getImpurity() > 0.0) && (node.getDepth() < maxDepth) &&
-                    (node.getWeightSum() > minChildWeight)) {
+                    (node.getWeightSum() >= minChildWeight)) {
                 if (numFeaturesInSplit != featureIDMap.size()) {
                     Util.randpermInPlace(originalIndices, localRNG);
                     System.arraycopy(originalIndices, 0, indices, 0, numFeaturesInSplit);

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractCARTTrainer.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractCARTTrainer.java
@@ -91,6 +91,7 @@ public abstract class AbstractCARTTrainer<T extends Output<T>> implements Decisi
 
     protected int trainInvocationCounter;
 
+
     /**
      * After calls to this superconstructor subclasses must call postConfig().
      * @param maxDepth The maximum depth of the tree.
@@ -191,21 +192,22 @@ public abstract class AbstractCARTTrainer<T extends Output<T>> implements Decisi
             weightSum += e.getWeight();
         }
         float scaledMinImpurityDecrease = getMinImpurityDecrease() * weightSum;
+        AbstractTrainingNode.LeafDeterminer leafDeterminer = new AbstractTrainingNode.LeafDeterminer(maxDepth,
+                minChildWeight, scaledMinImpurityDecrease);
 
-        AbstractTrainingNode<T> root = mkTrainingNode(examples);
+        AbstractTrainingNode<T> root = mkTrainingNode(examples, leafDeterminer);
         Deque<AbstractTrainingNode<T>> queue = new LinkedList<>();
         queue.add(root);
 
         while (!queue.isEmpty()) {
             AbstractTrainingNode<T> node = queue.poll();
             if ((node.getImpurity() > 0.0) && (node.getDepth() < maxDepth) &&
-                    (node.getNumExamples() > minChildWeight)) {
+                    (node.getWeightSum() > minChildWeight)) {
                 if (numFeaturesInSplit != featureIDMap.size()) {
                     Util.randpermInPlace(originalIndices, localRNG);
                     System.arraycopy(originalIndices, 0, indices, 0, numFeaturesInSplit);
                 }
-                List<AbstractTrainingNode<T>> nodes = node.buildTree(indices, localRNG, getUseRandomSplitPoints(),
-                        scaledMinImpurityDecrease);
+                List<AbstractTrainingNode<T>> nodes = node.buildTree(indices, localRNG, getUseRandomSplitPoints());
                 // Use the queue as a stack to improve cache locality.
                 // Building depth first.
                 for (AbstractTrainingNode<T> newNode : nodes) {
@@ -218,7 +220,8 @@ public abstract class AbstractCARTTrainer<T extends Output<T>> implements Decisi
         return new TreeModel<>("cart-tree", provenance, featureIDMap, outputIDInfo, false, root.convertTree());
     }
 
-    protected abstract AbstractTrainingNode<T> mkTrainingNode(Dataset<T> examples);
+    protected abstract AbstractTrainingNode<T> mkTrainingNode(Dataset<T> examples,
+                                                              AbstractTrainingNode.LeafDeterminer leafDeterminer);
 
     protected static abstract class AbstractCARTTrainerProvenance extends SkeletalTrainerProvenance {
         private static final long serialVersionUID = 1L;
@@ -231,5 +234,4 @@ public abstract class AbstractCARTTrainer<T extends Output<T>> implements Decisi
             super(map);
         }
     }
-
 }

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
@@ -33,6 +33,8 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
 
     protected final int numExamples;
 
+    protected final LeafDeterminer leafDeterminer;
+
     protected boolean split;
 
     protected int splitID;
@@ -45,9 +47,10 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
     
     protected AbstractTrainingNode<T> lessThanOrEqual;
 
-    protected AbstractTrainingNode(int depth, int numExamples) {
+    protected AbstractTrainingNode(int depth, int numExamples, LeafDeterminer leafDeterminer) {
         this.depth = depth;
         this.numExamples = numExamples;
+        this.leafDeterminer = leafDeterminer;
     }
 
     /**
@@ -55,17 +58,21 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
      * @param featureIDs Indices of the features available in this split.
      * @param rng Splittable random number generator.
      * @param useRandomSplitPoints Whether to choose split points for features at random.
-     * @param scaledMinImpurityDecrease The product of the weight sum of the original examples and the
-     *                                  minImpurityDecrease.
      * @return A possibly empty list of TrainingNodes.
      */
     public abstract List<AbstractTrainingNode<T>> buildTree(int[] featureIDs, SplittableRandom rng,
-                                                            boolean useRandomSplitPoints, float scaledMinImpurityDecrease);
+                                                            boolean useRandomSplitPoints);
 
     public abstract Node<T> convertTree();
 
+    public abstract float getWeightSum();
+
     public int getDepth() {
         return depth;
+    }
+
+    public int getNumExamples() {
+        return numExamples;
     }
 
     @Override
@@ -82,10 +89,6 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
         }
     }
 
-    public int getNumExamples() {
-        return numExamples;
-    }
-
     @Override
     public boolean isLeaf() {
         return !split;
@@ -95,4 +98,32 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
     public Node<T> copy() {
         throw new UnsupportedOperationException("Copy is not supported on training nodes.");
     }
+
+    /**
+     * Contains parameters needed to determine whether a node is a leaf.
+     */
+    public static class LeafDeterminer {
+        private final int maxDepth;
+        private final float minChildWeight;
+        private final float scaledMinImpurityDecrease;
+
+        public LeafDeterminer(int maxDepth, float minChildWeight, float scaledMinImpurityDecrease) {
+            this.maxDepth = maxDepth;
+            this.minChildWeight = minChildWeight;
+            this.scaledMinImpurityDecrease = scaledMinImpurityDecrease;
+        }
+
+        public int getMaxDepth() {
+            return maxDepth;
+        }
+
+        public float getMinChildWeight() {
+            return minChildWeight;
+        }
+
+        public float getScaledMinImpurityDecrease() {
+            return scaledMinImpurityDecrease;
+        }
+    }
+
 }

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
@@ -43,9 +43,9 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
 
     protected double impurityScore;
     
-    protected AbstractTrainingNode<T> greaterThan;
+    protected Node<T> greaterThan;
     
-    protected AbstractTrainingNode<T> lessThanOrEqual;
+    protected Node<T> lessThanOrEqual;
 
     protected AbstractTrainingNode(int depth, int numExamples, LeafDeterminer leafDeterminer) {
         this.depth = depth;
@@ -73,6 +73,29 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
 
     public int getNumExamples() {
         return numExamples;
+    }
+
+    public boolean shouldMakeLeaf(double impurityScore, float weightSum) {
+        return ((impurityScore == 0.0) ||
+                (depth + 1 >= leafDeterminer.getMaxDepth()) ||
+                (weightSum < leafDeterminer.getMinChildWeight()));
+    }
+
+    public SplitNode<T> mkSplitNode() {
+        Node<T> newGreaterThan = greaterThan;
+        Node<T> newLessThan = lessThanOrEqual;
+
+        // split node
+        if (greaterThan instanceof AbstractTrainingNode) {
+            AbstractTrainingNode<T> abstractGreaterThan = (AbstractTrainingNode<T>) greaterThan;
+            newGreaterThan = abstractGreaterThan.convertTree();
+        }
+
+        if (lessThanOrEqual instanceof AbstractTrainingNode) {
+            AbstractTrainingNode<T> abstractLessThan = (AbstractTrainingNode<T>) lessThanOrEqual;
+            newLessThan = abstractLessThan.convertTree();
+        }
+        return new SplitNode<>(splitValue,splitID,getImpurity(),newGreaterThan,newLessThan);
     }
 
     @Override

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
@@ -65,14 +65,14 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
 
     public abstract Node<T> convertTree();
 
+    /**
+     * The sum of the weights associated with this node's examples.
+     * @return the sum of the weights associated with this node's examples.
+     */
     public abstract float getWeightSum();
 
     public int getDepth() {
         return depth;
-    }
-
-    public int getNumExamples() {
-        return numExamples;
     }
 
     /**
@@ -120,6 +120,10 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
         } else {
             return null;
         }
+    }
+
+    public int getNumExamples() {
+        return numExamples;
     }
 
     @Override

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
@@ -75,12 +75,22 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
         return numExamples;
     }
 
+    /**
+     * Determines whether the node to be created should be a {@link LeafNode}.
+     * @param impurityScore impurity score for the new node.
+     * @param weightSum total example weight for the new node.
+     * @return Whether the new node should be a {@link LeafNode}.
+     */
     public boolean shouldMakeLeaf(double impurityScore, float weightSum) {
         return ((impurityScore == 0.0) ||
                 (depth + 1 >= leafDeterminer.getMaxDepth()) ||
                 (weightSum < leafDeterminer.getMinChildWeight()));
     }
 
+    /**
+     * Transforms an {@link AbstractTrainingNode} into a {@link SplitNode}
+     * @return A {@link SplitNode}
+     */
     public SplitNode<T> mkSplitNode() {
         Node<T> newGreaterThan = greaterThan;
         Node<T> newLessThan = lessThanOrEqual;

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/CARTJointRegressionTrainer.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/CARTJointRegressionTrainer.java
@@ -107,8 +107,9 @@ public class CARTJointRegressionTrainer extends AbstractCARTTrainer<Regressor> {
     }
 
     @Override
-    protected AbstractTrainingNode<Regressor> mkTrainingNode(Dataset<Regressor> examples) {
-        return new JointRegressorTrainingNode(impurity, examples, normalize);
+    protected AbstractTrainingNode<Regressor> mkTrainingNode(Dataset<Regressor> examples,
+                                                             AbstractTrainingNode.LeafDeterminer leafDeterminer) {
+        return new JointRegressorTrainingNode(impurity, examples, normalize, leafDeterminer);
     }
 
     @Override

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/CARTRegressionTrainer.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/CARTRegressionTrainer.java
@@ -166,7 +166,7 @@ public final class CARTRegressionTrainer extends AbstractCARTTrainer<Regressor> 
             while (!queue.isEmpty()) {
                 AbstractTrainingNode<Regressor> node = queue.poll();
                 if ((node.getImpurity() > 0.0) && (node.getDepth() < maxDepth) &&
-                        (node.getWeightSum() > minChildWeight)) {
+                        (node.getWeightSum() >= minChildWeight)) {
                     if (numFeaturesInSplit != featureIDMap.size()) {
                         Util.randpermInPlace(originalIndices, localRNG);
                         System.arraycopy(originalIndices, 0, indices, 0, numFeaturesInSplit);

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/JointRegressorTrainingNode.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/JointRegressorTrainingNode.java
@@ -144,10 +144,10 @@ public class JointRegressorTrainingNode extends AbstractTrainingNode<Regressor> 
      * Calculates the impurity score of the node.
      * @return The impurity score of the node.
      */
-    private double calcImpurity(int[] cur_indices) {
+    private double calcImpurity(int[] curIndices) {
         double tmp = 0.0;
         for (int i = 0; i < targets.length; i++) {
-            tmp += impurity.impurity(cur_indices, targets[i], weights);
+            tmp += impurity.impurity(curIndices, targets[i], weights);
         }
         return tmp / targets.length;
     }

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/RegressorTrainingNode.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/RegressorTrainingNode.java
@@ -319,8 +319,7 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
         AbstractTrainingNode<Regressor> tmpNode;
         if (shouldMakeLeftLeaf) {
             lessThanOrEqual = mkLeaf(leftImpurityScore, leftIndices);
-        }
-        else {
+        } else {
             tmpNode = new RegressorTrainingNode(impurity, lessThanData, leftIndices, targets, weights, dimName,
                     leftIndices.length, depth + 1, featureIDMap, labelIDMap, leafDeterminer, leftWeightSum, leftImpurityScore);
             lessThanOrEqual = tmpNode;
@@ -329,8 +328,7 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
 
         if (shouldMakeRightLeaf) {
             greaterThan = mkLeaf(rightImpurityScore, rightIndices);
-        }
-        else {
+        } else {
             tmpNode = new RegressorTrainingNode(impurity, greaterThanData, rightIndices, targets, weights, dimName,
                     rightIndices.length, depth + 1, featureIDMap, labelIDMap, leafDeterminer, rightWeightSum, rightImpurityScore);
             greaterThan = tmpNode;
@@ -347,31 +345,32 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
     public Node<Regressor> convertTree() {
         if (split) {
             return mkSplitNode();
+        } else {
+            return mkLeaf(getImpurity(), indices);
         }
-        return mkLeaf(getImpurity(), indices);
     }
 
     /**
      * Makes a {@link LeafNode}
      * @param impurityScore the impurity score for the node.
-     * @param indices the indices of the examples to be placed in the node.
+     * @param leafIndices the indices of the examples to be placed in the node.
      * @return A {@link LeafNode}
      */
-    private LeafNode<Regressor> mkLeaf(double impurityScore, int[] indices) {
+    private LeafNode<Regressor> mkLeaf(double impurityScore, int[] leafIndices) {
         double mean = 0.0;
-        double weightSum = 0.0;
+        double leafWeightSum = 0.0;
         double variance = 0.0;
-        for (int i = 0; i < indices.length; i++) {
-            int idx = indices[i];
+        for (int i = 0; i < leafIndices.length; i++) {
+            int idx = leafIndices[i];
             float value = targets[idx];
             float weight = weights[idx];
 
-            weightSum += weight;
+            leafWeightSum += weight;
             double oldMean = mean;
-            mean += (weight / weightSum) * (value - oldMean);
+            mean += (weight / leafWeightSum) * (value - oldMean);
             variance += weight * (value - oldMean) * (value - mean);
         }
-        variance = indices.length > 1 ? variance / (weightSum-1) : 0;
+        variance = leafIndices.length > 1 ? variance / (leafWeightSum-1) : 0;
         DimensionTuple leafPred = new DimensionTuple(dimName,mean,variance);
         return new LeafNode<>(impurityScore,leafPred,Collections.emptyMap(),false);
     }


### PR DESCRIPTION
### Description
Save Computation in Known Leaf Nodes - makes leaf nodes immediately instead of creating TrainingNodes first and then converting them to LeafNodes. 
Fix minChildWeight bug - minChildWeight was previously being compared to the unweighted number of examples, but will now correctly be compared to the sum of weighted examples.

### Motivation
Save computation. Fix a bug.
