### PR TITLE
Adding an OffsetDateTimeExtractor, deprecating a DateExtractor constructor

### DIFF
--- a/Data/src/main/java/org/tribuo/data/columnar/extractors/DateExtractor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/extractors/DateExtractor.java
@@ -50,20 +50,20 @@ public class DateExtractor extends SimpleFieldExtractor<LocalDate> {
         postConfig();
     }
 
+    @Deprecated
     public DateExtractor(String fieldName, String metadataName, DateTimeFormatter formatter) {
         super(fieldName, metadataName);
         this.formatter = formatter;
+        this.dateFormat = formatter.toString();
     }
 
     @Override
     public void postConfig() {
+        super.postConfig();
         if (dateFormat != null) {
             formatter = DateTimeFormatter.ofPattern(dateFormat);
         } else {
             formatter = DateTimeFormatter.BASIC_ISO_DATE;
-        }
-        if (metadataName == null || metadataName.isEmpty()) {
-            metadataName = fieldName;
         }
     }
 

--- a/Data/src/main/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.data.columnar.extractors;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
+import com.oracle.labs.mlrg.olcut.provenance.ConfiguredObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.impl.ConfiguredObjectProvenanceImpl;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Extracts the field value and translates it to an {@link OffsetDateTime} based on the specified {@link DateTimeFormatter}.
+ * <p>
+ * The formatter is supplied as a String to ensure it is tracked properly in the provenance.
+ * <p>
+ * Returns an empty optional if the date failed to parse.
+ */
+public class OffsetDateTimeExtractor extends SimpleFieldExtractor<OffsetDateTime> {
+    private static final Logger logger = Logger.getLogger(OffsetDateTimeExtractor.class.getName());
+
+    @Config(mandatory = true, description = "The expected date format.")
+    private String dateTimeFormat;
+    private DateTimeFormatter formatter;
+
+    /**
+     * for olcut
+     */
+    private OffsetDateTimeExtractor() {}
+
+    /**
+     * Constructs a date time extractor that emits an OffsetDateTime by applying the supplied format to the specified field.
+     * @param fieldName The field to read.
+     * @param metadataName The metadata field to write.
+     * @param dateTimeFormat The date/time format (supplied to {@link DateTimeFormatter}.
+     */
+    public OffsetDateTimeExtractor(String fieldName, String metadataName, String dateTimeFormat) {
+        super(fieldName, metadataName);
+        this.dateTimeFormat = dateTimeFormat;
+        postConfig();
+    }
+
+    @Override
+    public void postConfig() {
+        super.postConfig();
+        if (dateTimeFormat != null) {
+            formatter = DateTimeFormatter.ofPattern(dateTimeFormat);
+        } else {
+            throw new PropertyException("","dateTimeFormat", "Invalid Date/Time format string supplied");
+        }
+    }
+
+    @Override
+    public Class<OffsetDateTime> getValueType() {
+        return OffsetDateTime.class;
+    }
+
+    @Override
+    protected Optional<OffsetDateTime> extractField(String s) {
+        try {
+            return Optional.of(OffsetDateTime.parse(s, formatter));
+        } catch (DateTimeParseException e) {
+            logger.log(Level.WARNING, e.getParsedString());
+            logger.log(Level.WARNING, String.format("Unable to parse date/time %s with formatter %s", s, dateTimeFormat));
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "OffsetDateTimeExtractor(fieldName=" + fieldName + ", metadataName=" + metadataName + ", dateTimeFormat=" + dateTimeFormat + ")";
+    }
+
+    @Override
+    public ConfiguredObjectProvenance getProvenance() {
+        return new ConfiguredObjectProvenanceImpl(this, "FieldExtractor");
+    }
+}

--- a/Data/src/test/java/org/tribuo/data/columnar/RowProcessorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/RowProcessorTest.java
@@ -20,6 +20,7 @@ import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import org.tribuo.Example;
 import org.tribuo.Feature;
 import org.tribuo.data.columnar.extractors.DateExtractor;
+import org.tribuo.data.columnar.extractors.OffsetDateTimeExtractor;
 import org.tribuo.data.columnar.extractors.FloatExtractor;
 import org.tribuo.data.columnar.extractors.IdentityExtractor;
 import org.tribuo.data.columnar.extractors.IntExtractor;
@@ -29,7 +30,9 @@ import org.tribuo.test.MockOutput;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -100,8 +103,6 @@ public class RowProcessorTest {
 
     @Test
     public void metadataExtractorTest() {
-        List<String> fieldNames = Arrays.asList("Armadillos", "Armadas", "Archery", "Battleship", "Battles", "Carrots", "Mass", "Label");
-
         Map<String, FieldProcessor> fixed = new HashMap<>();
 
         fixed.put("Battles", new IdentityProcessor("Battles"));
@@ -110,7 +111,8 @@ public class RowProcessorTest {
         List<FieldExtractor<?>> metadataExtractors = new ArrayList<>();
         metadataExtractors.add(new IdentityExtractor("Armadillos", Example.NAME));
         metadataExtractors.add(new IntExtractor("Armadillos", "ID"));
-        metadataExtractors.add(new DateExtractor("Carrots","Date",DateTimeFormatter.BASIC_ISO_DATE));
+        metadataExtractors.add(new DateExtractor("Carrots","Date","uuuuMMdd"));
+        metadataExtractors.add(new OffsetDateTimeExtractor("Carrot-time","OffsetDateTime","dd/MM/yyyy HH:mmx"));
 
         FloatExtractor weightExtractor = new FloatExtractor("Mass");
 
@@ -123,6 +125,7 @@ public class RowProcessorTest {
         row.put("Battleship","4");
         row.put("Battles","5");
         row.put("Carrots","20010506");
+        row.put("Carrot-time","14/10/2020 16:07+01");
         row.put("Mass","9000");
         row.put("Label","Sheep");
 
@@ -144,23 +147,25 @@ public class RowProcessorTest {
 
         // Check metadata is extracted correctly
         Map<String,Object> metadata = example.getMetadata();
-        assertEquals(3,metadata.size());
+        assertEquals(4,metadata.size());
         assertEquals("1",metadata.get(Example.NAME));
         assertEquals(1,metadata.get("ID"));
         assertEquals(LocalDate.of(2001,5,6),metadata.get("Date"));
+        assertEquals(OffsetDateTime.of(LocalDate.of(2020,10,14), LocalTime.of(16,7), ZoneOffset.ofHours(1)),metadata.get("OffsetDateTime"));
 
         // Check metadata types
         Map<String,Class<?>> metadataTypes = processor.getMetadataTypes();
-        assertEquals(3,metadataTypes.size());
+        assertEquals(4,metadataTypes.size());
         assertEquals(String.class,metadataTypes.get(Example.NAME));
         assertEquals(Integer.class,metadataTypes.get("ID"));
         assertEquals(LocalDate.class,metadataTypes.get("Date"));
+        assertEquals(OffsetDateTime.class,metadataTypes.get("OffsetDateTime"));
 
         // Check an invalid metadata extractor throws IllegalArgumentException
         List<FieldExtractor<?>> badExtractors = new ArrayList<>();
         badExtractors.add(new IdentityExtractor("Armadillos", Example.NAME));
         badExtractors.add(new IntExtractor("Armadillos", "ID"));
-        badExtractors.add(new DateExtractor("Carrots", "ID",DateTimeFormatter.BASIC_ISO_DATE));
+        badExtractors.add(new DateExtractor("Carrots", "ID", "uuuuMMdd"));
 
         assertThrows(PropertyException.class, () -> new RowProcessor<>(badExtractors,weightExtractor,response,fixed,Collections.emptySet()));
     }


### PR DESCRIPTION
### Description
Adds a `FieldExtractor` that can process date times to go with the one that can process dates. This one uses `OffsetDateTime` to capture timezone information. It's possible we'll need a `LocalDateTime` one for fields without time zone information as `OffsetDateTime` requires it and will fail to parse otherwise.

Also it deprecates the `DateExtractor` constructor which accepts a `DateTimeFormatter` as it's not possible to recover the format string out of such an object, and so the provenance isn't convertible into a configuration. It does however add the toString of the formatter which should be useful for figuring out what the original date format string was even if it can't be automatically generated.

### Motivation
Fixes a bug in the `DateExtractor`s provenance and adds a timestamp capability to the `RowProcessor`s metadata extraction.
