### PR TITLE
Ignore a UTF-8 byte order mark in the csv package

### DIFF
--- a/Data/src/test/java/org/tribuo/data/csv/CSVDataSourceTest.java
+++ b/Data/src/test/java/org/tribuo/data/csv/CSVDataSourceTest.java
@@ -77,7 +77,6 @@ public class CSVDataSourceTest {
 
     @Test
     public void testBasic() {
-
         CSVDataSource<MockOutput> dataSource = new CSVDataSource<>(dataFile, rowProcessor, true);
 
         MutableDataset<MockOutput> dataset = new MutableDataset<>(dataSource);
@@ -93,6 +92,31 @@ public class CSVDataSourceTest {
         ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(datasetProvenance);
 
         assertEquals(prov,unmarshalledProvenance);
+    }
+
+    @Test
+    public void testBOM() throws URISyntaxException {
+        // Excel inserts a BOM into UTF-8 formatted CSV files, this test checks that Tribuo correctly ignores it.
+        URI bomDataFile = CSVDataSourceTest.class.getResource("/org/tribuo/data/csv/test-bom.csv").toURI();
+
+        // Load the file with the BOM
+        CSVDataSource<MockOutput> bomSource = new CSVDataSource<>(bomDataFile, rowProcessor, true);
+        MutableDataset<MockOutput> bomDataset = new MutableDataset<>(bomSource);
+
+        // Check the rows loaded correctly
+        assertEquals(6,bomDataset.size(),"Found an incorrect number of rows when loading the csv.");
+
+        // Check the feature space is the same
+        assertEquals(13,bomDataset.getFeatureMap().size());
+
+        // Load the clean file
+        CSVDataSource<MockOutput> dataSource = new CSVDataSource<>(dataFile, rowProcessor, true);
+        MutableDataset<MockOutput> dataset = new MutableDataset<>(dataSource);
+
+        // Check the data is the same
+        for (int i = 0; i < 6; i++) {
+            assertEquals(dataset.getExample(i), bomDataset.getExample(i));
+        }
     }
 
     @Test

--- a/Data/src/test/java/org/tribuo/data/csv/CSVLoaderTest.java
+++ b/Data/src/test/java/org/tribuo/data/csv/CSVLoaderTest.java
@@ -44,8 +44,16 @@ public class CSVLoaderTest {
     public void testLoad() throws IOException {
         URL path = CSVLoaderTest.class.getResource("/org/tribuo/data/csv/test.csv");
         CSVLoader<MockOutput> loader = new CSVLoader<>(new MockOutputFactory());
-        checkData_test_csv(loader.loadDataSource(path, "RESPONSE"));
-        checkData_test_csv(loader.loadDataSource(path, Collections.singleton("RESPONSE")));
+        checkDataTestCsv(loader.loadDataSource(path, "RESPONSE"));
+        checkDataTestCsv(loader.loadDataSource(path, Collections.singleton("RESPONSE")));
+    }
+
+    @Test
+    public void testLoadBOM() throws IOException {
+        URL path = CSVLoaderTest.class.getResource("/org/tribuo/data/csv/test-bom.csv");
+        CSVLoader<MockOutput> loader = new CSVLoader<>(new MockOutputFactory());
+        checkDataTestCsv(loader.loadDataSource(path, "RESPONSE"));
+        checkDataTestCsv(loader.loadDataSource(path, Collections.singleton("RESPONSE")));
     }
 
     @Test
@@ -91,11 +99,11 @@ public class CSVLoaderTest {
         //
         // Test behavior when CSV file does not have a header row and the user instead supplies the header.
         URL noheader = CSVLoader.class.getResource("/org/tribuo/data/csv/test-noheader.csv");
-        checkData_test_csv(loader.loadDataSource(noheader, "RESPONSE", header));
-        checkData_test_csv(loader.loadDataSource(noheader, Collections.singleton("RESPONSE"), header));
+        checkDataTestCsv(loader.loadDataSource(noheader, "RESPONSE", header));
+        checkDataTestCsv(loader.loadDataSource(noheader, Collections.singleton("RESPONSE"), header));
     }
 
-    private void checkData_test_csv(DataSource<MockOutput> source) throws IOException {
+    private void checkDataTestCsv(DataSource<MockOutput> source) throws IOException {
         MutableDataset<MockOutput> data = new MutableDataset<>(source);
         assertEquals(6, data.size());
         assertEquals("monkey", data.getExample(0).getOutput().label);

--- a/Data/src/test/resources/org/tribuo/data/csv/test-bom.csv
+++ b/Data/src/test/resources/org/tribuo/data/csv/test-bom.csv
@@ -1,0 +1,7 @@
+﻿A,B,C,D,RESPONSE
+1,2,3,4,monkey
+2,5,3,4,monkey
+1,2,5,9,baboon
+3,5,8,4,monkey
+6,7,8,9,baboon
+0,7,8,9,baboon


### PR DESCRIPTION
### Description
This change reads the first few bytes into a `PushbackReader`, checks if they are a byte order mark for UTF-8 and discards them if they are. If they are regular bytes they are pushed back onto the reader and loading proceeds as normal.

The UTF-8 byte order mark is unnecessary as UTF-8 doesn't have ordered bytes. Tribuo doesn't support non-UTF-8 file formats in it's data loading.

### Motivation
If there is a byte order mark in a UTF-8 CSV file (as frequently inserted by Microsoft Excel), then OpenCSV will stitch it to the front of the first column, causing the name based parsing in `RowProcessor` among other places to fail. OpenCSV doesn't ignore these by default (unlike other CSV parsers) so here we patch the reader to do so.

Fixes #65.
