### PR TITLE
Bumping OLCUT to 5.1.5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- MLRG dependencies -->
-        <olcut.version>5.1.4</olcut.version>
+        <olcut.version>5.1.5</olcut.version>
 
         <!-- 3rd party backend dependencies -->
         <liblinear.version>2.30</liblinear.version>


### PR DESCRIPTION
### Description
Bumps OLCUT to 5.1.5 to bring in a provenance fix. This also bumps the version of Jackson used to 2.11.3 from 2.11.2, and the version of jline3 from 3.15.0 to 3.16.0.