### PR TITLE
Adds a getter which returns a copy of the inner model

### DIFF
--- a/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMModel.java
+++ b/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMModel.java
@@ -28,6 +28,7 @@ import libsvm.svm_model;
 import libsvm.svm_node;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -71,11 +72,28 @@ public abstract class LibSVMModel<T extends Output<T>> extends Model<T> implemen
     }
 
     /**
-     * Gets the underlying list of libsvm models.
+     * Returns an unmodifiable copy of the underlying list of libsvm models.
+     * <p>
+     * Deprecated to unify the names across LibLinear, LibSVM and XGBoost.
      * @return The underlying model list.
      */
+    @Deprecated
     public List<svm_model> getModel() {
-        return models;
+        return getInnerModels();
+    }
+
+    /**
+     * Returns an unmodifiable copy of the underlying list of libsvm models.
+     * @return The underlying model list.
+     */
+    public List<svm_model> getInnerModels() {
+        List<svm_model> copy = new ArrayList<>();
+
+        for (svm_model m : models) {
+            copy.add(copyModel(m));
+        }
+
+        return Collections.unmodifiableList(copy);
     }
 
     @Override

--- a/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostExternalModel.java
+++ b/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostExternalModel.java
@@ -17,6 +17,10 @@
 package org.tribuo.common.xgboost;
 
 import com.oracle.labs.mlrg.olcut.util.Pair;
+import ml.dmlc.xgboost4j.java.Booster;
+import ml.dmlc.xgboost4j.java.DMatrix;
+import ml.dmlc.xgboost4j.java.XGBoost;
+import ml.dmlc.xgboost4j.java.XGBoostError;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
@@ -30,10 +34,6 @@ import org.tribuo.interop.ExternalTrainerProvenance;
 import org.tribuo.math.la.SparseVector;
 import org.tribuo.provenance.DatasetProvenance;
 import org.tribuo.provenance.ModelProvenance;
-import ml.dmlc.xgboost4j.java.Booster;
-import ml.dmlc.xgboost4j.java.DMatrix;
-import ml.dmlc.xgboost4j.java.XGBoost;
-import ml.dmlc.xgboost4j.java.XGBoostError;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * A {@link Model} which wraps around a XGBoost.Booster which was trained by a system other than Tribuo.
@@ -196,15 +195,9 @@ public final class XGBoostExternalModel<T extends Output<T>> extends ExternalMod
 
     @Override
     protected XGBoostExternalModel<T> copy(String newName, ModelProvenance newProvenance) {
-        try {
-            byte[] serialisedBooster = model.toByteArray();
-            Booster newModel = XGBoost.loadModel(new ByteArrayInputStream(serialisedBooster));
-            return new XGBoostExternalModel<>(newName,newProvenance,featureIDMap,outputIDInfo,
-                                              featureForwardMapping, featureBackwardMapping,
-                                              newModel,converter);
-        } catch (XGBoostError | IOException e) {
-            throw new IllegalStateException("Unable to copy XGBoost model.",e);
-        }
+        return new XGBoostExternalModel<>(newName, newProvenance, featureIDMap, outputIDInfo,
+                                          featureForwardMapping, featureBackwardMapping,
+                                          XGBoostModel.copyModel(model), converter);
     }
 
     /**

--- a/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostFeatureImportance.java
+++ b/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostFeatureImportance.java
@@ -60,30 +60,55 @@ public class XGBoostFeatureImportance {
             this.totalCover = totalCover;
         }
 
+        /**
+         * The feature name.
+         * @return The feature name.
+         */
         public String getFeatureName() {
             return featureName;
         }
 
+        /**
+         * The information gain a feature provides when split on.
+         * @return The gain.
+         */
         public double getGain() {
             return gain;
         }
 
+        /**
+         * The number of examples a feature discriminates between.
+         * @return The cover.
+         */
         public double getCover() {
             return cover;
         }
 
+        /**
+         * The number of times a feature is used in the model.
+         * @return The number of times the feature is used to split.
+         */
         public double getWeight() {
             return weight;
         }
 
+        /**
+         * The total gain across all times the feature is used to split.
+         * @return The total gain.
+         */
         public double getTotalGain() {
             return totalGain;
         }
 
+        /**
+         * The total number of examples a feature discrimnates between.
+         * @return The total cover.
+         */
         public double getTotalCover() {
             return totalCover;
         }
 
+        @Override
         public String toString() {
             return String.format("XGBoostFeatureImportanceRecord(feature=%s, gain=%.2f, cover=%.2f, weight=%.2f, totalGain=%.2f, totalCover=%.2f)",
                     featureName, gain, cover, weight, totalGain, totalCover);
@@ -213,6 +238,7 @@ public class XGBoostFeatureImportance {
     }
 
     /**
+     * Gets all the feature importances for all the features.
      * @return records of all importance metrics for each feature, sorted by gain.
      */
     public List<XGBoostFeatureImportanceInstance> getImportances() {
@@ -231,6 +257,7 @@ public class XGBoostFeatureImportance {
     }
 
     /**
+     * Gets the feature importances for the top n features sorted by gain.
      * @param numFeatures number of features to return
      * @return records of all importance metrics for each feature, sorted by gain.
      */
@@ -249,6 +276,7 @@ public class XGBoostFeatureImportance {
                 .collect(Collectors.toList());
     }
 
+    @Override
     public String toString() {
         return String.format("XGBoostFeatureImportance(model=%s)", model.toString());
     }

--- a/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostModel.java
+++ b/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostModel.java
@@ -18,6 +18,9 @@ package org.tribuo.common.xgboost;
 
 import com.oracle.labs.mlrg.olcut.util.MutableDouble;
 import com.oracle.labs.mlrg.olcut.util.Pair;
+import ml.dmlc.xgboost4j.java.Booster;
+import ml.dmlc.xgboost4j.java.XGBoost;
+import ml.dmlc.xgboost4j.java.XGBoostError;
 import org.tribuo.Dataset;
 import org.tribuo.Example;
 import org.tribuo.Excuse;
@@ -28,9 +31,6 @@ import org.tribuo.Output;
 import org.tribuo.Prediction;
 import org.tribuo.common.xgboost.XGBoostTrainer.DMatrixTuple;
 import org.tribuo.provenance.ModelProvenance;
-import ml.dmlc.xgboost4j.java.Booster;
-import ml.dmlc.xgboost4j.java.XGBoost;
-import ml.dmlc.xgboost4j.java.XGBoostError;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -75,6 +75,9 @@ public final class XGBoostModel<T extends Output<T>> extends Model<T> {
 
     private final XGBoostOutputConverter<T> converter;
 
+    /**
+     * The XGBoost4J Boosters.
+     */
     protected transient List<Booster> models;
 
     XGBoostModel(String name, ModelProvenance description,
@@ -83,6 +86,23 @@ public final class XGBoostModel<T extends Output<T>> extends Model<T> {
         super(name,description,featureIDMap,labelIDMap,converter.generatesProbabilities());
         this.converter = converter;
         this.models = models;
+    }
+
+    /**
+     * Returns an unmodifiable list containing a copy of each model.
+     * <p>
+     * As XGBoost4J models don't expose a copy constructor this requires
+     * serializing each model to a byte array and rebuilding it, and is thus quite expensive.
+     * @return A copy of all of the models.
+     */
+    public List<Booster> getInnerModels() {
+        List<Booster> copy = new ArrayList<>();
+
+        for (Booster m : models) {
+            copy.add(copyModel(m));
+        }
+
+        return Collections.unmodifiableList(copy);
     }
 
     /**
@@ -233,18 +253,27 @@ public final class XGBoostModel<T extends Output<T>> extends Model<T> {
         return Optional.empty();
     }
 
-    @Override
-    protected Model<T> copy(String newName, ModelProvenance newProvenance) {
+    /**
+     * Copies a single XGBoost Booster by serializing and deserializing it.
+     * @param booster The booster to copy.
+     * @return A deep copy of the booster.
+     */
+    static Booster copyModel(Booster booster) {
         try {
-            List<Booster> newModels = new ArrayList<>();
-            for (Booster model : models) {
-                byte[] serialisedBooster = model.toByteArray();
-                newModels.add(XGBoost.loadModel(new ByteArrayInputStream(serialisedBooster)));
-            }
-            return new XGBoostModel<>(newName,newProvenance,featureIDMap,outputIDInfo,newModels,converter);
+            byte[] serialisedBooster = booster.toByteArray();
+            return XGBoost.loadModel(new ByteArrayInputStream(serialisedBooster));
         } catch (XGBoostError | IOException e) {
             throw new IllegalStateException("Unable to copy XGBoost model.",e);
         }
+    }
+
+    @Override
+    protected Model<T> copy(String newName, ModelProvenance newProvenance) {
+        List<Booster> newModels = new ArrayList<>();
+        for (Booster model : models) {
+            newModels.add(copyModel(model));
+        }
+        return new XGBoostModel<>(newName, newProvenance, featureIDMap, outputIDInfo, newModels, converter);
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {


### PR DESCRIPTION
### Description
LibLinear, LibSVM and XGBoost all have internal model representations which Tribuo hides. This PR adds an accessor which returns a deep copy of the trained models allowing users to use them outside of Tribuo.

### Motivation
LibSVMModel has exposed the internal models for a while, this change makes it return an unmodifiable copy of the internal models (as the svm_model class is mutable for some reason). It then adds similar methods to LibLinearModel and XGBoostModel as it seems unfair to not allow it everywhere. We could further allow people to load in externally trained LibSVM and LibLinear models, and easily test it using this support, but it's not clear if there is need for such support at the moment.

Fixes #78.
