### PR TITLE
LibSVMTrainer was insufficiently immutable

### DIFF
--- a/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/LibSVMAnomalyTrainer.java
+++ b/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/LibSVMAnomalyTrainer.java
@@ -102,8 +102,8 @@ public class LibSVMAnomalyTrainer extends LibSVMTrainer<Event> {
         problem.l = outputs[0].length;
         problem.x = features;
         problem.y = outputs[0];
-        if (parameters.gamma == 0) {
-            parameters.gamma = 1.0 / numFeatures;
+        if (curParams.gamma == 0) {
+            curParams.gamma = 1.0 / numFeatures;
         }
         String checkString = svm.svm_check_parameter(problem, curParams);
         if(checkString != null) {

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
@@ -120,9 +120,8 @@ public class LibSVMClassificationTrainer extends LibSVMTrainer<Label> implements
 
     @Override
     protected svm_parameter setupParameters(ImmutableOutputInfo<Label> outputIDInfo) {
-        svm_parameter curParams;
+        svm_parameter curParams = SVMParameters.copyParameters(parameters);
         if (!labelWeights.isEmpty()) {
-            curParams = (svm_parameter) parameters.clone();
             double[] weights = new double[outputIDInfo.size()];
             int[] indices = new int[outputIDInfo.size()];
             int i = 0;
@@ -141,8 +140,6 @@ public class LibSVMClassificationTrainer extends LibSVMTrainer<Label> implements
             curParams.weight = weights;
             curParams.weight_label = indices;
             //logger.info("Weights = " + Arrays.toString(weights) + ", labels = " + Arrays.toString(indices) + ", outputIDInfo = " + outputIDInfo);
-        } else {
-            curParams = parameters;
         }
         return curParams;
     }

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
@@ -94,8 +94,8 @@ public class LibSVMClassificationTrainer extends LibSVMTrainer<Label> implements
         problem.l = outputs[0].length;
         problem.x = features;
         problem.y = outputs[0];
-        if (parameters.gamma == 0) {
-            parameters.gamma = 1.0 / numFeatures;
+        if (curParams.gamma == 0) {
+            curParams.gamma = 1.0 / numFeatures;
         }
         String checkString = svm.svm_check_parameter(problem, curParams);
         if(checkString != null) {

--- a/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMTrainer.java
+++ b/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMTrainer.java
@@ -221,7 +221,7 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
      * @return The svm_parameters to use for training.
      */
     protected svm_parameter setupParameters(ImmutableOutputInfo<T> info) {
-        return parameters;
+        return SVMParameters.copyParameters(parameters);
     }
 
     @Override

--- a/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionTrainer.java
+++ b/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionTrainer.java
@@ -93,8 +93,8 @@ public class LibSVMRegressionTrainer extends LibSVMTrainer<Regressor> {
             problem.l = outputs[i].length;
             problem.x = features;
             problem.y = outputs[i];
-            if (parameters.gamma == 0) {
-                parameters.gamma = 1.0 / numFeatures;
+            if (curParams.gamma == 0) {
+                curParams.gamma = 1.0 / numFeatures;
             }
             String checkString = svm.svm_check_parameter(problem, curParams);
             if(checkString != null) {


### PR DESCRIPTION
### Description
The train methods on LibSVMTrainer mutated the state of the svm_parameters struct if gamma was zero (it's a sentinel to set the value to 1.0/numFeatures), but this isn't necessarily the parameters that are passed in (e.g. if label weights are used). This mutation also causes it to ignore the number of features in a second call to train as gamma is already non-zero. This is fixed by making each training run get a fresh set of the parameters.

### Motivation
Trainers should track their state properly and not mutate their parameters (except for the RNG, and we track that in the provenance system).
