### PR TITLE
Fixing a bug in the configuration tutorial example XML file.

### DIFF
--- a/tutorials/configuration/example-config.xml
+++ b/tutorials/configuration/example-config.xml
@@ -46,7 +46,7 @@
         <property name="outputFactory" value="label-factory"/>
     </component>
 
-    <component name="mnist-test" type="org.tribuo.datasource.LibSVMDataSource">
+    <component name="mnist-test" type="org.tribuo.datasource.IDXDataSource">
         <property name="featuresPath" value="t10k-images-idx3-ubyte.gz"/>
         <property name="outputPath" value="t10k-labels-idx1-ubyte.gz"/>
         <property name="outputFactory" value="label-factory"/>


### PR DESCRIPTION
The example xml file for the tutorial has the wrong type for the MNIST test datasource. This PR fixes it.
