### PR TITLE
Fixing a classification tree bug

### DIFF
--- a/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractTrainingNode.java
@@ -108,7 +108,7 @@ public abstract class AbstractTrainingNode<T extends Output<T>> implements Node<
      * Transforms an {@link AbstractTrainingNode} into a {@link SplitNode}
      * @return A {@link SplitNode}
      */
-    public SplitNode<T> mkSplitNode() {
+    public SplitNode<T> createSplitNode() {
         Node<T> newGreaterThan = greaterThan;
         Node<T> newLessThan = lessThanOrEqual;
 

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/SplitNode.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/SplitNode.java
@@ -19,6 +19,8 @@ package org.tribuo.common.tree;
 import org.tribuo.Output;
 import org.tribuo.math.la.SparseVector;
 
+import java.util.Objects;
+
 /**
  * An immutable {@link Node} with a split and two child nodes.
  */
@@ -119,6 +121,22 @@ public class SplitNode<T extends Output<T>> implements Node<T> {
     public String toString() {
         return "SplitNode(feature="+splitFeature+",value="+splitValue+",impurity="+impurity+",\n\t\tleft="+lessThanOrEqual.toString()+",\n\t\tright="+greaterThan.toString()+")";
     }
-    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SplitNode<?> splitNode = (SplitNode<?>) o;
+        return splitFeature == splitNode.splitFeature &&
+                Double.compare(splitNode.splitValue, splitValue) == 0 &&
+                Double.compare(splitNode.impurity, impurity) == 0 &&
+                greaterThan.equals(splitNode.greaterThan) &&
+                lessThanOrEqual.equals(splitNode.lessThanOrEqual);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(greaterThan, lessThanOrEqual, splitFeature, splitValue, impurity);
+    }
 }
 

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/IndependentRegressionTreeModel.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/IndependentRegressionTreeModel.java
@@ -86,6 +86,21 @@ public final class IndependentRegressionTreeModel extends TreeModel<Regressor> {
         return outputMap;
     }
 
+    /**
+     * Probes the trees to find the depth.
+     * @return The maximum depth across the trees.
+     */
+    public int getDepth() {
+        int maxDepth = 0;
+        for (Node<Regressor> curRoot : roots.values()) {
+            int thisDepth = computeDepth(0,curRoot);
+            if (maxDepth < thisDepth) {
+                maxDepth = thisDepth;
+            }
+        }
+        return maxDepth;
+    }
+
     @Override
     public Prediction<Regressor> predict(Example<Regressor> example) {
         //

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/JointRegressorTrainingNode.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/JointRegressorTrainingNode.java
@@ -338,8 +338,8 @@ public class JointRegressorTrainingNode extends AbstractTrainingNode<Regressor> 
         boolean shouldMakeRightLeaf = shouldMakeLeaf(rightImpurityScore, rightWeightSum);
 
         if (shouldMakeLeftLeaf && shouldMakeRightLeaf) {
-            lessThanOrEqual = mkLeaf(leftImpurityScore, leftIndices);
-            greaterThan = mkLeaf(rightImpurityScore, rightIndices);
+            lessThanOrEqual = createLeaf(leftImpurityScore, leftIndices);
+            greaterThan = createLeaf(rightImpurityScore, rightIndices);
             return Collections.emptyList();
         }
         //logger.info("Splitting on feature " + bestID + " with value " + bestSplitValue + " at depth " + depth + ", " + numExamples + " examples in node.");
@@ -355,7 +355,7 @@ public class JointRegressorTrainingNode extends AbstractTrainingNode<Regressor> 
         List<AbstractTrainingNode<Regressor>> output = new ArrayList<>(2);
         AbstractTrainingNode<Regressor> tmpNode;
         if (shouldMakeLeftLeaf) {
-            lessThanOrEqual = mkLeaf(leftImpurityScore, leftIndices);
+            lessThanOrEqual = createLeaf(leftImpurityScore, leftIndices);
         } else {
             tmpNode = new JointRegressorTrainingNode(impurity, lessThanData, leftIndices, targets,
                     weights, leftIndices.length, depth + 1, featureIDMap, labelIDMap, normalize, leafDeterminer,
@@ -365,7 +365,7 @@ public class JointRegressorTrainingNode extends AbstractTrainingNode<Regressor> 
         }
 
         if (shouldMakeRightLeaf) {
-            greaterThan = mkLeaf(rightImpurityScore, rightIndices);
+            greaterThan = createLeaf(rightImpurityScore, rightIndices);
         } else {
             tmpNode = new JointRegressorTrainingNode(impurity, greaterThanData, rightIndices, targets,
                     weights, rightIndices.length, depth + 1, featureIDMap, labelIDMap, normalize, leafDeterminer,
@@ -383,9 +383,9 @@ public class JointRegressorTrainingNode extends AbstractTrainingNode<Regressor> 
     @Override
     public Node<Regressor> convertTree() {
         if (split) {
-            return mkSplitNode();
+            return createSplitNode();
         } else {
-            return mkLeaf(getImpurity(), indices);
+            return createLeaf(getImpurity(), indices);
         }
     }
 
@@ -395,7 +395,7 @@ public class JointRegressorTrainingNode extends AbstractTrainingNode<Regressor> 
      * @param leafIndices the indices of the examples to be placed in the node.
      * @return A {@link LeafNode}
      */
-    private LeafNode<Regressor> mkLeaf(double impurityScore, int[] leafIndices) {
+    private LeafNode<Regressor> createLeaf(double impurityScore, int[] leafIndices) {
         double leafWeightSum = 0.0;
         double[] mean = new double[targets.length];
         Regressor leafPred;

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/RegressorTrainingNode.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/RegressorTrainingNode.java
@@ -300,8 +300,8 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
         boolean shouldMakeRightLeaf = shouldMakeLeaf(rightImpurityScore, rightWeightSum);
 
         if (shouldMakeLeftLeaf && shouldMakeRightLeaf) {
-            lessThanOrEqual = mkLeaf(leftImpurityScore, leftIndices);
-            greaterThan = mkLeaf(rightImpurityScore, rightIndices);
+            lessThanOrEqual = createLeaf(leftImpurityScore, leftIndices);
+            greaterThan = createLeaf(rightImpurityScore, rightIndices);
             return Collections.emptyList();
         }
 
@@ -318,7 +318,7 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
         List<AbstractTrainingNode<Regressor>> output = new ArrayList<>(2);
         AbstractTrainingNode<Regressor> tmpNode;
         if (shouldMakeLeftLeaf) {
-            lessThanOrEqual = mkLeaf(leftImpurityScore, leftIndices);
+            lessThanOrEqual = createLeaf(leftImpurityScore, leftIndices);
         } else {
             tmpNode = new RegressorTrainingNode(impurity, lessThanData, leftIndices, targets, weights, dimName,
                     leftIndices.length, depth + 1, featureIDMap, labelIDMap, leafDeterminer, leftWeightSum, leftImpurityScore);
@@ -327,7 +327,7 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
         }
 
         if (shouldMakeRightLeaf) {
-            greaterThan = mkLeaf(rightImpurityScore, rightIndices);
+            greaterThan = createLeaf(rightImpurityScore, rightIndices);
         } else {
             tmpNode = new RegressorTrainingNode(impurity, greaterThanData, rightIndices, targets, weights, dimName,
                     rightIndices.length, depth + 1, featureIDMap, labelIDMap, leafDeterminer, rightWeightSum, rightImpurityScore);
@@ -344,9 +344,9 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
     @Override
     public Node<Regressor> convertTree() {
         if (split) {
-            return mkSplitNode();
+            return createSplitNode();
         } else {
-            return mkLeaf(getImpurity(), indices);
+            return createLeaf(getImpurity(), indices);
         }
     }
 
@@ -356,7 +356,7 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
      * @param leafIndices the indices of the examples to be placed in the node.
      * @return A {@link LeafNode}
      */
-    private LeafNode<Regressor> mkLeaf(double impurityScore, int[] leafIndices) {
+    private LeafNode<Regressor> createLeaf(double impurityScore, int[] leafIndices) {
         double mean = 0.0;
         double leafWeightSum = 0.0;
         double variance = 0.0;


### PR DESCRIPTION
### Description
Fixing an issue where classification trees split incorrectly, adding a method to get the depth of a built tree for debugging, renamed a couple of methods.

### Motivation
Classification trees mirrored the left indices into the right indices, so the trees were broken and performed poorly.