### PR TITLE
Tutorials: updating the version to the Tribuo JAR files in the respective cells

### DIFF
--- a/tutorials/anomaly-tribuo-v4.ipynb
+++ b/tutorials/anomaly-tribuo-v4.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-anomaly-libsvm-4.0.0-jar-with-dependencies.jar"
+    "%jars ./tribuo-anomaly-libsvm-4.0.2-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/anomaly-tribuo-v4.ipynb
+++ b/tutorials/anomaly-tribuo-v4.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-anomaly-libsvm-4.0.2-jar-with-dependencies.jar"
+    "%jars ./tribuo-anomaly-libsvm-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/clustering-tribuo-v4.ipynb
+++ b/tutorials/clustering-tribuo-v4.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-clustering-kmeans-4.0.2-jar-with-dependencies.jar"
+    "%jars ./tribuo-clustering-kmeans-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/clustering-tribuo-v4.ipynb
+++ b/tutorials/clustering-tribuo-v4.ipynb
@@ -19,7 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-clustering-kmeans-4.0.0-jar-with-dependencies.jar"
+    "%jars ./tribuo-clustering-kmeans-4.0.2-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/columnar-tribuo-v4.ipynb
+++ b/tutorials/columnar-tribuo-v4.ipynb
@@ -38,8 +38,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-classification-experiments-4.0.2-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-json-4.0.2-jar-with-dependencies.jar"
+    "%jars ./tribuo-classification-experiments-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-json-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/columnar-tribuo-v4.ipynb
+++ b/tutorials/columnar-tribuo-v4.ipynb
@@ -38,8 +38,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-classification-experiments-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-json-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
+    "%jars ./tribuo-classification-experiments-4.0.2-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-json-4.0.2-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/configuration-tribuo-v4.ipynb
+++ b/tutorials/configuration-tribuo-v4.ipynb
@@ -32,8 +32,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-classification-experiments-4.0.2-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-json-4.0.2-jar-with-dependencies.jar"
+    "%jars ./tribuo-classification-experiments-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-json-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
    ]
   },
   {
@@ -817,7 +817,7 @@
       "\t\t\t\t\tnum-examples = 60000\n",
       "\t\t\t\t\tnum-features = 717\n",
       "\t\t\t\t\tnum-outputs = 10\n",
-      "\t\t\t\t\ttribuo-version = 4.0.2\n",
+      "\t\t\t\t\ttribuo-version = 4.1.0-SNAPSHOT\n",
       "\t\t\t\t)\n",
       "\t\t\ttrainer = LinearSGDTrainer(\n",
       "\t\t\t\t\tclass-name = org.tribuo.classification.sgd.linear.LinearSGDTrainer\n",
@@ -845,7 +845,7 @@
       "\t\t\tinstance-values = Map{\n",
       "\t\t\t\treconfigured-model=true\n",
       "\t\t\t}\n",
-      "\t\t\ttribuo-version = 4.0.2\n",
+      "\t\t\ttribuo-version = 4.1.0-SNAPSHOT\n",
       "\t\t)\n",
       "\tdataset-provenance = MutableDataset(\n",
       "\t\t\tclass-name = org.tribuo.MutableDataset\n",
@@ -870,9 +870,9 @@
       "\t\t\tnum-examples = 10000\n",
       "\t\t\tnum-features = 668\n",
       "\t\t\tnum-outputs = 10\n",
-      "\t\t\ttribuo-version = 4.0.2\n",
+      "\t\t\ttribuo-version = 4.1.0-SNAPSHOT\n",
       "\t\t)\n",
-      "\ttribuo-version = 4.0.2\n",
+      "\ttribuo-version = 4.1.0-SNAPSHOT\n",
       ")\n"
      ]
     }

--- a/tutorials/configuration-tribuo-v4.ipynb
+++ b/tutorials/configuration-tribuo-v4.ipynb
@@ -32,8 +32,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-classification-experiments-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-json-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
+    "%jars ./tribuo-classification-experiments-4.0.2-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-json-4.0.2-jar-with-dependencies.jar"
    ]
   },
   {
@@ -817,7 +817,7 @@
       "\t\t\t\t\tnum-examples = 60000\n",
       "\t\t\t\t\tnum-features = 717\n",
       "\t\t\t\t\tnum-outputs = 10\n",
-      "\t\t\t\t\ttribuo-version = 4.1.0-SNAPSHOT\n",
+      "\t\t\t\t\ttribuo-version = 4.0.2\n",
       "\t\t\t\t)\n",
       "\t\t\ttrainer = LinearSGDTrainer(\n",
       "\t\t\t\t\tclass-name = org.tribuo.classification.sgd.linear.LinearSGDTrainer\n",
@@ -845,7 +845,7 @@
       "\t\t\tinstance-values = Map{\n",
       "\t\t\t\treconfigured-model=true\n",
       "\t\t\t}\n",
-      "\t\t\ttribuo-version = 4.1.0-SNAPSHOT\n",
+      "\t\t\ttribuo-version = 4.0.2\n",
       "\t\t)\n",
       "\tdataset-provenance = MutableDataset(\n",
       "\t\t\tclass-name = org.tribuo.MutableDataset\n",
@@ -870,9 +870,9 @@
       "\t\t\tnum-examples = 10000\n",
       "\t\t\tnum-features = 668\n",
       "\t\t\tnum-outputs = 10\n",
-      "\t\t\ttribuo-version = 4.1.0-SNAPSHOT\n",
+      "\t\t\ttribuo-version = 4.0.2\n",
       "\t\t)\n",
-      "\ttribuo-version = 4.1.0-SNAPSHOT\n",
+      "\ttribuo-version = 4.0.2\n",
       ")\n"
      ]
     }

--- a/tutorials/external-models-tribuo-v4.ipynb
+++ b/tutorials/external-models-tribuo-v4.ipynb
@@ -24,8 +24,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars tribuo-classification-experiments-4.0.2-jar-with-dependencies.jar\n",
-    "%jars tribuo-onnx-4.0.2-jar-with-dependencies.jar"
+    "%jars tribuo-classification-experiments-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
+    "%jars tribuo-onnx-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/external-models-tribuo-v4.ipynb
+++ b/tutorials/external-models-tribuo-v4.ipynb
@@ -24,8 +24,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars tribuo-classification-experiments-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
-    "%jars tribuo-onnx-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
+    "%jars tribuo-classification-experiments-4.0.2-jar-with-dependencies.jar\n",
+    "%jars tribuo-onnx-4.0.2-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/irises-tribuo-v4.ipynb
+++ b/tutorials/irises-tribuo-v4.ipynb
@@ -27,8 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-classification-experiments-4.0.1-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-json-4.0.1-jar-with-dependencies.jar"
+    "%jars ./tribuo-classification-experiments-4.0.2-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-json-4.0.2-jar-with-dependencies.jar"
    ]
   },
   {
@@ -439,7 +439,7 @@
       "    \"tribuo-version\" : {\n",
       "      \"marshalled-class\" : \"com.oracle.labs.mlrg.olcut.provenance.io.SimpleMarshalledProvenance\",\n",
       "      \"key\" : \"tribuo-version\",\n",
-      "      \"value\" : \"4.0.1\",\n",
+      "      \"value\" : \"4.0.2\",\n",
       "      \"provenance-class\" : \"com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance\",\n",
       "      \"additional\" : \"\",\n",
       "      \"is-reference\" : false\n",
@@ -510,7 +510,7 @@
       "    \"tribuo-version\" : {\n",
       "      \"marshalled-class\" : \"com.oracle.labs.mlrg.olcut.provenance.io.SimpleMarshalledProvenance\",\n",
       "      \"key\" : \"tribuo-version\",\n",
-      "      \"value\" : \"4.0.1\",\n",
+      "      \"value\" : \"4.0.2\",\n",
       "      \"provenance-class\" : \"com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance\",\n",
       "      \"additional\" : \"\",\n",
       "      \"is-reference\" : false\n",
@@ -889,7 +889,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "linear-sgd-model - Model(class-name=org.tribuo.classification.sgd.linear.LinearSGDModel,dataset=Dataset(class-name=org.tribuo.MutableDataset,datasource=SplitDataSourceProvenance(className=org.tribuo.evaluation.TrainTestSplitter,innerSourceProvenance=CSV(class-name=org.tribuo.data.csv.CSVLoader,outputFactory=OutputFactory(class-name=org.tribuo.classification.LabelFactory),response-name=species,separator=,,quote=\",path=file:/Users/apocock/Development/Tribuo/tutorials/bezdekIris.data,file-modified-time=1999-12-14T15:12:39-05:00,resource-hash=SHA-256[0FED2A99DB77EC533A62DC66894D3EC6DF3B58B6A8F3CF4A6B47E4086B7F97DC]),trainProportion=0.7,seed=1,size=150,isTrain=true),transformations=[],is-sequence=false,is-dense=false,num-examples=105,num-features=4,num-outputs=3,tribuo-version=4.0.1),trainer=Trainer(class-name=org.tribuo.classification.sgd.linear.LogisticRegressionTrainer,seed=12345,minibatchSize=1,shuffle=true,epochs=5,optimiser=StochasticGradientOptimiser(class-name=org.tribuo.math.optimisers.AdaGrad,epsilon=0.1,initialLearningRate=1.0,initialValue=0.0,host-short-name=StochasticGradientOptimiser),objective=LabelObjective(class-name=org.tribuo.classification.sgd.objectives.LogMulticlass,host-short-name=LabelObjective),loggingInterval=1000,train-invocation-count=0,is-sequence=false,host-short-name=Trainer),trained-at=2020-09-29T18:03:58.789235-04:00,instance-values={},tribuo-version=4.0.1)\n"
+      "linear-sgd-model - Model(class-name=org.tribuo.classification.sgd.linear.LinearSGDModel,dataset=Dataset(class-name=org.tribuo.MutableDataset,datasource=SplitDataSourceProvenance(className=org.tribuo.evaluation.TrainTestSplitter,innerSourceProvenance=CSV(class-name=org.tribuo.data.csv.CSVLoader,outputFactory=OutputFactory(class-name=org.tribuo.classification.LabelFactory),response-name=species,separator=,,quote=\",path=file:/Users/apocock/Development/Tribuo/tutorials/bezdekIris.data,file-modified-time=1999-12-14T15:12:39-05:00,resource-hash=SHA-256[0FED2A99DB77EC533A62DC66894D3EC6DF3B58B6A8F3CF4A6B47E4086B7F97DC]),trainProportion=0.7,seed=1,size=150,isTrain=true),transformations=[],is-sequence=false,is-dense=false,num-examples=105,num-features=4,num-outputs=3,tribuo-version=4.0.2),trainer=Trainer(class-name=org.tribuo.classification.sgd.linear.LogisticRegressionTrainer,seed=12345,minibatchSize=1,shuffle=true,epochs=5,optimiser=StochasticGradientOptimiser(class-name=org.tribuo.math.optimisers.AdaGrad,epsilon=0.1,initialLearningRate=1.0,initialValue=0.0,host-short-name=StochasticGradientOptimiser),objective=LabelObjective(class-name=org.tribuo.classification.sgd.objectives.LogMulticlass,host-short-name=LabelObjective),loggingInterval=1000,train-invocation-count=0,is-sequence=false,host-short-name=Trainer),trained-at=2020-09-29T18:03:58.789235-04:00,instance-values={},tribuo-version=4.0.2)\n"
      ]
     }
    ],
@@ -914,12 +914,12 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "  \"tribuo-version\" : \"4.0.1\",\n",
+      "  \"tribuo-version\" : \"4.0.2\",\n",
       "  \"dataset-provenance\" : {\n",
       "    \"num-features\" : \"4\",\n",
       "    \"num-examples\" : \"45\",\n",
       "    \"num-outputs\" : \"3\",\n",
-      "    \"tribuo-version\" : \"4.0.1\",\n",
+      "    \"tribuo-version\" : \"4.0.2\",\n",
       "    \"datasource\" : {\n",
       "      \"train-proportion\" : \"0.7\",\n",
       "      \"seed\" : \"1\",\n",
@@ -947,7 +947,7 @@
       "  \"class-name\" : \"org.tribuo.provenance.EvaluationProvenance\",\n",
       "  \"model-provenance\" : {\n",
       "    \"instance-values\" : { },\n",
-      "    \"tribuo-version\" : \"4.0.1\",\n",
+      "    \"tribuo-version\" : \"4.0.2\",\n",
       "    \"trainer\" : {\n",
       "      \"seed\" : \"12345\",\n",
       "      \"minibatchSize\" : \"1\",\n",
@@ -975,7 +975,7 @@
       "      \"num-features\" : \"4\",\n",
       "      \"num-examples\" : \"105\",\n",
       "      \"num-outputs\" : \"3\",\n",
-      "      \"tribuo-version\" : \"4.0.1\",\n",
+      "      \"tribuo-version\" : \"4.0.2\",\n",
       "      \"datasource\" : {\n",
       "        \"train-proportion\" : \"0.7\",\n",
       "        \"seed\" : \"1\",\n",

--- a/tutorials/irises-tribuo-v4.ipynb
+++ b/tutorials/irises-tribuo-v4.ipynb
@@ -27,8 +27,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-classification-experiments-4.0.2-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-json-4.0.2-jar-with-dependencies.jar"
+    "%jars ./tribuo-classification-experiments-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-json-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
    ]
   },
   {
@@ -439,7 +439,7 @@
       "    \"tribuo-version\" : {\n",
       "      \"marshalled-class\" : \"com.oracle.labs.mlrg.olcut.provenance.io.SimpleMarshalledProvenance\",\n",
       "      \"key\" : \"tribuo-version\",\n",
-      "      \"value\" : \"4.0.2\",\n",
+      "      \"value\" : \"4.1.0-SNAPSHOT\",\n",
       "      \"provenance-class\" : \"com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance\",\n",
       "      \"additional\" : \"\",\n",
       "      \"is-reference\" : false\n",
@@ -510,7 +510,7 @@
       "    \"tribuo-version\" : {\n",
       "      \"marshalled-class\" : \"com.oracle.labs.mlrg.olcut.provenance.io.SimpleMarshalledProvenance\",\n",
       "      \"key\" : \"tribuo-version\",\n",
-      "      \"value\" : \"4.0.2\",\n",
+      "      \"value\" : \"4.1.0-SNAPSHOT\",\n",
       "      \"provenance-class\" : \"com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance\",\n",
       "      \"additional\" : \"\",\n",
       "      \"is-reference\" : false\n",
@@ -889,7 +889,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "linear-sgd-model - Model(class-name=org.tribuo.classification.sgd.linear.LinearSGDModel,dataset=Dataset(class-name=org.tribuo.MutableDataset,datasource=SplitDataSourceProvenance(className=org.tribuo.evaluation.TrainTestSplitter,innerSourceProvenance=CSV(class-name=org.tribuo.data.csv.CSVLoader,outputFactory=OutputFactory(class-name=org.tribuo.classification.LabelFactory),response-name=species,separator=,,quote=\",path=file:/Users/apocock/Development/Tribuo/tutorials/bezdekIris.data,file-modified-time=1999-12-14T15:12:39-05:00,resource-hash=SHA-256[0FED2A99DB77EC533A62DC66894D3EC6DF3B58B6A8F3CF4A6B47E4086B7F97DC]),trainProportion=0.7,seed=1,size=150,isTrain=true),transformations=[],is-sequence=false,is-dense=false,num-examples=105,num-features=4,num-outputs=3,tribuo-version=4.0.2),trainer=Trainer(class-name=org.tribuo.classification.sgd.linear.LogisticRegressionTrainer,seed=12345,minibatchSize=1,shuffle=true,epochs=5,optimiser=StochasticGradientOptimiser(class-name=org.tribuo.math.optimisers.AdaGrad,epsilon=0.1,initialLearningRate=1.0,initialValue=0.0,host-short-name=StochasticGradientOptimiser),objective=LabelObjective(class-name=org.tribuo.classification.sgd.objectives.LogMulticlass,host-short-name=LabelObjective),loggingInterval=1000,train-invocation-count=0,is-sequence=false,host-short-name=Trainer),trained-at=2020-09-29T18:03:58.789235-04:00,instance-values={},tribuo-version=4.0.2)\n"
+      "linear-sgd-model - Model(class-name=org.tribuo.classification.sgd.linear.LinearSGDModel,dataset=Dataset(class-name=org.tribuo.MutableDataset,datasource=SplitDataSourceProvenance(className=org.tribuo.evaluation.TrainTestSplitter,innerSourceProvenance=CSV(class-name=org.tribuo.data.csv.CSVLoader,outputFactory=OutputFactory(class-name=org.tribuo.classification.LabelFactory),response-name=species,separator=,,quote=\",path=file:/Users/apocock/Development/Tribuo/tutorials/bezdekIris.data,file-modified-time=1999-12-14T15:12:39-05:00,resource-hash=SHA-256[0FED2A99DB77EC533A62DC66894D3EC6DF3B58B6A8F3CF4A6B47E4086B7F97DC]),trainProportion=0.7,seed=1,size=150,isTrain=true),transformations=[],is-sequence=false,is-dense=false,num-examples=105,num-features=4,num-outputs=3,tribuo-version=4.1.0-SNAPSHOT),trainer=Trainer(class-name=org.tribuo.classification.sgd.linear.LogisticRegressionTrainer,seed=12345,minibatchSize=1,shuffle=true,epochs=5,optimiser=StochasticGradientOptimiser(class-name=org.tribuo.math.optimisers.AdaGrad,epsilon=0.1,initialLearningRate=1.0,initialValue=0.0,host-short-name=StochasticGradientOptimiser),objective=LabelObjective(class-name=org.tribuo.classification.sgd.objectives.LogMulticlass,host-short-name=LabelObjective),loggingInterval=1000,train-invocation-count=0,is-sequence=false,host-short-name=Trainer),trained-at=2020-09-29T18:03:58.789235-04:00,instance-values={},tribuo-version=4.1.0-SNAPSHOT)\n"
      ]
     }
    ],
@@ -914,12 +914,12 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "  \"tribuo-version\" : \"4.0.2\",\n",
+      "  \"tribuo-version\" : \"4.1.0-SNAPSHOT\",\n",
       "  \"dataset-provenance\" : {\n",
       "    \"num-features\" : \"4\",\n",
       "    \"num-examples\" : \"45\",\n",
       "    \"num-outputs\" : \"3\",\n",
-      "    \"tribuo-version\" : \"4.0.2\",\n",
+      "    \"tribuo-version\" : \"4.1.0-SNAPSHOT\",\n",
       "    \"datasource\" : {\n",
       "      \"train-proportion\" : \"0.7\",\n",
       "      \"seed\" : \"1\",\n",
@@ -947,7 +947,7 @@
       "  \"class-name\" : \"org.tribuo.provenance.EvaluationProvenance\",\n",
       "  \"model-provenance\" : {\n",
       "    \"instance-values\" : { },\n",
-      "    \"tribuo-version\" : \"4.0.2\",\n",
+      "    \"tribuo-version\" : \"4.1.0-SNAPSHOT\",\n",
       "    \"trainer\" : {\n",
       "      \"seed\" : \"12345\",\n",
       "      \"minibatchSize\" : \"1\",\n",
@@ -975,7 +975,7 @@
       "      \"num-features\" : \"4\",\n",
       "      \"num-examples\" : \"105\",\n",
       "      \"num-outputs\" : \"3\",\n",
-      "      \"tribuo-version\" : \"4.0.2\",\n",
+      "      \"tribuo-version\" : \"4.1.0-SNAPSHOT\",\n",
       "      \"datasource\" : {\n",
       "        \"train-proportion\" : \"0.7\",\n",
       "        \"seed\" : \"1\",\n",

--- a/tutorials/regression-tribuo-v4.ipynb
+++ b/tutorials/regression-tribuo-v4.ipynb
@@ -23,10 +23,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-json-4.0.0-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-regression-sgd-4.0.0-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-regression-xgboost-4.0.0-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-regression-tree-4.0.0-jar-with-dependencies.jar"
+    "%jars ./tribuo-json-4.0.2-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-regression-sgd-4.0.2-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-regression-xgboost-4.0.2-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-regression-tree-4.0.2-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/regression-tribuo-v4.ipynb
+++ b/tutorials/regression-tribuo-v4.ipynb
@@ -23,10 +23,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%jars ./tribuo-json-4.0.2-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-regression-sgd-4.0.2-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-regression-xgboost-4.0.2-jar-with-dependencies.jar\n",
-    "%jars ./tribuo-regression-tree-4.0.2-jar-with-dependencies.jar"
+    "%jars ./tribuo-json-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-regression-sgd-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-regression-xgboost-4.1.0-SNAPSHOT-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-regression-tree-4.1.0-SNAPSHOT-jar-with-dependencies.jar"
    ]
   },
   {

--- a/tutorials/regression-tribuo-v4.ipynb
+++ b/tutorials/regression-tribuo-v4.ipynb
@@ -323,7 +323,7 @@
    "source": [
     "Using a more robust optimizer got us a better fit in the same number of epochs. However, both the train and test R^2 scores are still substantially less than 1 and, as before, the train and test RMSE scores are very similar.\n",
     "\n",
-    "See [here](http://akyrillidis.github.io/notes/AdaGrad) and [here](http://ruder.io/optimizing-gradient-descent/index.html#adagrad) for more on AdaGrad. Also, there are many other implementations of various well-known optimizers in Tribuo, including [Adam](https://tribuo.org/javadoc/v4.0.0/org/tribuo/math/optimisers/Adam.html) and [RMSProp](https://tribuo.org/javadoc/v4.0.0/org/tribuo/math/optimisers/RMSProp.html). See the [math.optimisers](https://tribuo.org/javadoc/v4.0.0/org/tribuo/math/optimisers/package-summary.html) package."
+    "See [here](http://akyrillidis.github.io/notes/AdaGrad) and [here](http://ruder.io/optimizing-gradient-descent/index.html#adagrad) for more on AdaGrad. Also, there are many other implementations of various well-known optimizers in Tribuo, including [Adam](https://tribuo.org/learn/4.0/javadoc/org/tribuo/math/optimisers/Adam.html) and [RMSProp](https://tribuo.org/learn/4.0/javadoc/org/tribuo/math/optimisers/RMSProp.html). See the [math.optimisers](https://tribuo.org/learn/4.0/javadoc/org/tribuo/math/optimisers/package-summary.html) package."
    ]
   },
   {


### PR DESCRIPTION
### Description

Updating the version to the Tribuo JAR files in the Java-based tutorials to bring them in sync with the recently released 4.0.2 version

Also fixed JavaDoc links in the Regression Tutorial.

### Motivation

Raised as a fix on the back of #92 