### PR TITLE
Add an option to quiesce ONNX tests

### DIFF
--- a/Interop/ONNX/pom.xml
+++ b/Interop/ONNX/pom.xml
@@ -100,6 +100,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                     <skipTests>${skipONNXTests}</skipTests>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
              XGBoost 1.0.0 binary on Maven Central doesn't
              include Windows support -->
         <skipXGBoostTests>false</skipXGBoostTests>
+        <skipONNXTests>false</skipONNXTests>
     </properties>
 
     <name>Tribuo</name>


### PR DESCRIPTION
### Description
Adds a flag to the pom file which quiesces the ONNX tests.

### Motivation
The ONNX tests don't pass on Apple Silicon as I've only just added the support for it to the upstream release.
