### PR TITLE
Updates to improve the performance and logging of the transformer inf…

### DIFF
--- a/Core/src/main/java/org/tribuo/MutableDataset.java
+++ b/Core/src/main/java/org/tribuo/MutableDataset.java
@@ -28,6 +28,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A MutableDataset is a {@link Dataset} with a {@link MutableFeatureMap} which grows over time.
@@ -35,6 +37,9 @@ import java.util.Set;
  * keeping appropriate statistics in the {@link FeatureMap} and {@link OutputInfo}.
  */
 public class MutableDataset<T extends Output<T>> extends Dataset<T> {
+    
+    private static final Logger logger = Logger.getLogger(MutableDataset.class.getName());
+    
     private static final long serialVersionUID = 1L;
 
     /**
@@ -193,10 +198,16 @@ public class MutableDataset<T extends Output<T>> extends Dataset<T> {
      */
     public void transform(TransformerMap transformerMap) {
         featureMap.clear();
+        logger.fine(String.format("Transforming %,d examples", data.size()));
+        int nt = 0;
         for (Example<T> example : data) {
             example.transform(transformerMap);
             for (Feature f : example) {
                 featureMap.add(f.getName(),f.getValue());
+            }
+            nt++;
+            if(logger.isLoggable(Level.FINE) && nt % 10000 == 0) {
+                logger.fine(String.format("Transformed %,d/%,d", nt, data.size()));
             }
         }
         transformProvenances.add(transformerMap.getProvenance());

--- a/Core/src/main/java/org/tribuo/impl/ArrayExample.java
+++ b/Core/src/main/java/org/tribuo/impl/ArrayExample.java
@@ -159,12 +159,19 @@ public class ArrayExample<T extends Output<T>> extends Example<T> {
      */
     public ArrayExample(Example<T> other) {
         super(other);
-        featureNames = new String[other.size()];
-        featureValues = new double[other.size()];
-        for (Feature f : other) {
-            featureNames[size] = f.getName();
-            featureValues[size] = f.getValue();
-            size++;
+        if(other instanceof ArrayExample) {
+            ArrayExample< T> otherArr = (ArrayExample<T>) other;
+            featureNames = Arrays.copyOf(otherArr.featureNames, otherArr.featureNames.length);
+            featureValues = Arrays.copyOf(otherArr.featureValues, otherArr.featureValues.length);
+            size = otherArr.size;
+        } else {
+            featureNames = new String[other.size()];
+            featureValues = new double[other.size()];
+            for(Feature f : other) {
+                featureNames[size] = f.getName();
+                featureValues[size] = f.getValue();
+                size++;
+            }
         }
     }
 
@@ -408,14 +415,33 @@ public class ArrayExample<T extends Output<T>> extends Example<T> {
 
     @Override
     public void transform(TransformerMap transformerMap) {
-        for (Map.Entry<String,List<Transformer>> e : transformerMap.entrySet()) {
-            int index = Arrays.binarySearch(featureNames,0,size,e.getKey());
-            if (index >= 0) {
-                double value = featureValues[index];
-                for (Transformer t : e.getValue()) {
+        if(transformerMap.size() < featureNames.length) {
+            //
+            // We have transformers than feature names, so let's
+            // iterate through the map and find the features.
+            for(Map.Entry<String, List<Transformer>> e : transformerMap.entrySet()) {
+                int index = Arrays.binarySearch(featureNames, 0, size, e.getKey());
+                if(index >= 0) {
+                    double value = featureValues[index];
+                    for(Transformer t : e.getValue()) {
+                        value = t.transform(value);
+                    }
+                    featureValues[index] = value;
+                }
+            }
+        } else {
+            //
+            // We have more transformers, so let's fetch them by name.
+            for(int i = 0; i < size; i++) {
+                List<Transformer> l = transformerMap.get(featureNames[i]);
+                if(l == null) {
+                    continue;
+                }
+                double value = featureValues[i];
+                for(Transformer t : l) {
                     value = t.transform(value);
                 }
-                featureValues[index] = value;
+                featureValues[i] = value;
             }
         }
     }

--- a/Core/src/main/java/org/tribuo/impl/ArrayExample.java
+++ b/Core/src/main/java/org/tribuo/impl/ArrayExample.java
@@ -161,8 +161,8 @@ public class ArrayExample<T extends Output<T>> extends Example<T> {
         super(other);
         if(other instanceof ArrayExample) {
             ArrayExample< T> otherArr = (ArrayExample<T>) other;
-            featureNames = Arrays.copyOf(otherArr.featureNames, otherArr.featureNames.length);
-            featureValues = Arrays.copyOf(otherArr.featureValues, otherArr.featureValues.length);
+            featureNames = Arrays.copyOf(otherArr.featureNames, otherArr.size);
+            featureValues = Arrays.copyOf(otherArr.featureValues, otherArr.size);
             size = otherArr.size;
         } else {
             featureNames = new String[other.size()];
@@ -417,7 +417,7 @@ public class ArrayExample<T extends Output<T>> extends Example<T> {
     public void transform(TransformerMap transformerMap) {
         if(transformerMap.size() < featureNames.length) {
             //
-            // We have transformers than feature names, so let's
+            // We have fewer transformers than feature names, so let's
             // iterate through the map and find the features.
             for(Map.Entry<String, List<Transformer>> e : transformerMap.entrySet()) {
                 int index = Arrays.binarySearch(featureNames, 0, size, e.getKey());
@@ -434,14 +434,13 @@ public class ArrayExample<T extends Output<T>> extends Example<T> {
             // We have more transformers, so let's fetch them by name.
             for(int i = 0; i < size; i++) {
                 List<Transformer> l = transformerMap.get(featureNames[i]);
-                if(l == null) {
-                    continue;
+                if(l != null) {
+                    double value = featureValues[i];
+                    for(Transformer t : l) {
+                        value = t.transform(value);
+                    }
+                    featureValues[i] = value;
                 }
-                double value = featureValues[i];
-                for(Transformer t : l) {
-                    value = t.transform(value);
-                }
-                featureValues[i] = value;
             }
         }
     }

--- a/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
@@ -29,6 +29,9 @@ import org.tribuo.provenance.impl.TrainerProvenanceImpl;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A {@link Trainer} which encapsulates another trainer plus a {@link TransformationMap} object
@@ -38,6 +41,8 @@ import java.util.Map;
  * first call {@link MutableDataset#densify} on the datasets.
  */
 public final class TransformTrainer<T extends Output<T>> implements Trainer<T> {
+    
+    private static final Logger logger = Logger.getLogger(TransformTrainer.class.getName());
 
     @Config(mandatory = true,description="Trainer to use.")
     private Trainer<T> innerTrainer;
@@ -81,10 +86,24 @@ public final class TransformTrainer<T extends Output<T>> implements Trainer<T> {
 
     @Override
     public TransformedModel<T> train(Dataset<T> examples, Map<String, Provenance> instanceProvenance) {
+        
+        logger.info(String.format("%s %s", TransformTrainer.class.getName(), logger.getLevel()));
+        if(logger.isLoggable(Level.FINE)) {
+            logger.info(String.format("It says fine is loggable?"));
+        }
+        logger.fine(String.format("Creating transformers"));
+        logger.fine("Really doing it, though. Like for real");
+        for(Handler h : logger.getHandlers()) {
+            h.flush();
+        }
         TransformerMap transformerMap = examples.createTransformers(transformations);
 
+        logger.fine("Transforming data set");
+        
         Dataset<T> transformedDataset = transformerMap.transformDataset(examples,densify);
 
+        logger.fine("Running inner trainer");
+        
         Model<T> innerModel = innerTrainer.train(transformedDataset);
 
         ModelProvenance provenance = new ModelProvenance(TransformedModel.class.getName(), OffsetDateTime.now(), transformedDataset.getProvenance(), getProvenance(), instanceProvenance);

--- a/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
@@ -29,8 +29,6 @@ import org.tribuo.provenance.impl.TrainerProvenanceImpl;
 
 import java.time.OffsetDateTime;
 import java.util.Map;
-import java.util.logging.Handler;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -87,15 +85,7 @@ public final class TransformTrainer<T extends Output<T>> implements Trainer<T> {
     @Override
     public TransformedModel<T> train(Dataset<T> examples, Map<String, Provenance> instanceProvenance) {
         
-        logger.info(String.format("%s %s", TransformTrainer.class.getName(), logger.getLevel()));
-        if(logger.isLoggable(Level.FINE)) {
-            logger.info(String.format("It says fine is loggable?"));
-        }
         logger.fine(String.format("Creating transformers"));
-        logger.fine("Really doing it, though. Like for real");
-        for(Handler h : logger.getHandlers()) {
-            h.flush();
-        }
         TransformerMap transformerMap = examples.createTransformers(transformations);
 
         logger.fine("Transforming data set");

--- a/Core/src/main/java/org/tribuo/transform/TransformationMap.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformationMap.java
@@ -52,7 +52,7 @@ import java.util.regex.Pattern;
 public class TransformationMap implements Configurable, Provenancable<ConfiguredObjectProvenance> {
 
     @Config(mandatory = true,description="Global transformations to apply after the feature specific transforms.")
-    private List<Transformation> globalTransformations = new ArrayList<>();
+    private List<Transformation> globalTransformations;
 
     @Config(description="Feature specific transformations. Accepts regexes for feature names.")
     private Map<String,TransformationList> featureTransformationList = new HashMap<>();
@@ -67,7 +67,7 @@ public class TransformationMap implements Configurable, Provenancable<Configured
     private TransformationMap() {}
 
     public TransformationMap(List<Transformation> globalTransformations, Map<String,List<Transformation>> featureTransformations) {
-        this.globalTransformations = globalTransformations;
+        this.globalTransformations = new ArrayList<>(globalTransformations);
         this.featureTransformations.putAll(featureTransformations);
 
         // Copy values out for provenance

--- a/Core/src/main/java/org/tribuo/transform/TransformerMap.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformerMap.java
@@ -149,10 +149,21 @@ public final class TransformerMap implements Provenancable<TransformerMapProvena
         return newDataset;
     }
     
+    /**
+     * Gets the size of the map.
+     * 
+     * @return the size of the map of feature names to transformers.
+     */
     public int size() {
         return map.size();
     }
     
+    /**
+     * Gets the transformer associated with a given feature name.
+     * @param featureName the name of the feature for which we want the transformer
+     * @return the transformer associated with the feature name, which may be <code>null</code> 
+     * if there is no feature with that name.
+     */
     public List<Transformer> get(String featureName) {
         return map.get(featureName);
     }

--- a/Core/src/main/java/org/tribuo/transform/TransformerMap.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformerMap.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * A collection of {@link Transformer}s which can be applied to a {@link Dataset}
@@ -49,6 +50,9 @@ import java.util.Set;
  * first call {@link MutableDataset#densify} on the datasets.
  */
 public final class TransformerMap implements Provenancable<TransformerMapProvenance>, Serializable {
+    
+    private static final Logger logger = Logger.getLogger(TransformerMap.class.getName());
+    
     private static final long serialVersionUID = 2L;
 
     private final Map<String, List<Transformer>> map;
@@ -129,15 +133,28 @@ public final class TransformerMap implements Provenancable<TransformerMapProvena
      * @return A deep copy of the dataset (and it's examples) with the transformers applied to it's features.
      */
     public <T extends Output<T>> MutableDataset<T> transformDataset(Dataset<T> dataset, boolean densify) {
+        
+        logger.fine("Creating deep copy of data set");
+        
         MutableDataset<T> newDataset = MutableDataset.createDeepCopy(dataset);
 
         if (densify) {
             newDataset.densify();
         }
 
+        logger.fine(String.format("Transforming data set copy"));
+        
         newDataset.transform(this);
 
         return newDataset;
+    }
+    
+    public int size() {
+        return map.size();
+    }
+    
+    public List<Transformer> get(String featureName) {
+        return map.get(featureName);
     }
 
     @Override

--- a/Core/src/main/java/org/tribuo/transform/transformations/IDFTransformation.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/IDFTransformation.java
@@ -1,0 +1,103 @@
+package org.tribuo.transform.transformations;
+
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.tribuo.transform.TransformStatistics;
+import org.tribuo.transform.Transformation;
+import org.tribuo.transform.TransformationProvenance;
+import org.tribuo.transform.Transformer;
+
+/**
+ * A feature transformation that computes the IDF for features and then transforms
+ * them with a TF-IDF weighting.
+ */
+public class IDFTransformation implements Transformation {
+    
+    private TransformationProvenance provenance;
+
+    @Override
+    public TransformStatistics createStats() {
+        return new IDFStatistics();
+    }
+
+    @Override
+    public TransformationProvenance getProvenance() {
+        if(provenance == null) {
+            provenance = new IDFTransformationProvenance();
+        }
+        return provenance;
+    }
+    
+    private static class IDFStatistics implements TransformStatistics {
+        
+        /**
+         * The document frequency for the feature that this statistic is
+         * associated with. This is a count of the number of examples that the
+         * feature occurs in.
+         */
+        private int df;
+        
+        /**
+         * The number of examples that the feature did not occur in.
+         */
+        private int sparseObservances;
+        
+
+        @Override
+        public void observeValue(double value) {
+            //
+            // One more document (i.e., an example) has this feature.
+            df++;
+        }
+
+        @Override
+        public void observeSparse() {
+        }
+
+        @Override
+        public void observeSparse(int count) {
+            sparseObservances = count;
+        }
+
+        @Override
+        public Transformer generateTransformer() {
+            return new IDFTransformer(df, df+sparseObservances);
+        }
+        
+    }
+    
+    private static class IDFTransformer implements Transformer {
+        
+        private double df;
+        
+        private double N;
+        
+        public IDFTransformer(int df, int N) {
+            this.df = df;
+            this.N = N;
+        }
+
+        @Override
+        public double transform(double tf) {
+            return Math.log(N / df) * (1 + Math.log(tf));
+        }
+        
+    }
+    
+    public final static class IDFTransformationProvenance implements TransformationProvenance {
+
+        @Override
+        public Map<String, Provenance> getConfiguredParameters() {
+            return Collections.unmodifiableMap(new HashMap<>());
+        }
+
+        @Override
+        public String getClassName() {
+            return IDFTransformation.class.getName();
+        }
+        
+    }
+
+}

--- a/Core/src/test/java/org/tribuo/transform/SimpleTransformTest.java
+++ b/Core/src/test/java/org/tribuo/transform/SimpleTransformTest.java
@@ -232,7 +232,7 @@ public class SimpleTransformTest {
         map.put("F6",Arrays.asList(SimpleTransform.exp(),SimpleTransform.log(),SimpleTransform.add(5)));
         map.put("F8",Arrays.asList(SimpleTransform.exp(),SimpleTransform.log()));
 
-        TransformationMap t = new TransformationMap(new ArrayList<>(),map);
+        TransformationMap t = new TransformationMap(new ArrayList<Transformation>(),map);
 
         TransformerMap transMap = dataset.createTransformers(t);
 

--- a/Core/src/test/java/org/tribuo/transform/SimpleTransformTest.java
+++ b/Core/src/test/java/org/tribuo/transform/SimpleTransformTest.java
@@ -232,7 +232,7 @@ public class SimpleTransformTest {
         map.put("F6",Arrays.asList(SimpleTransform.exp(),SimpleTransform.log(),SimpleTransform.add(5)));
         map.put("F8",Arrays.asList(SimpleTransform.exp(),SimpleTransform.log()));
 
-        TransformationMap t = new TransformationMap(new ArrayList<Transformation>(),map);
+        TransformationMap t = new TransformationMap(new ArrayList<>(),map);
 
         TransformerMap transMap = dataset.createTransformers(t);
 


### PR DESCRIPTION
…rastructure

### Description

The performance of the transformers was suboptimal when there was a large number of features. Got the transformation time for a large text classification problem down from more than two hours to less than two minutes. Along the way, I added some logging (at Level.FINE) so you can see what's happening, if you choose to do so.

As I was working on a text classification problem, I added and IDFTransformation that can set TFIDF weights in the example.

### Motivation

Transformer performance was far too slow in some cases.

