### PR TITLE
Upgrades XGBoost to 1.3.1

### DIFF
--- a/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostClassificationTrainer.java
+++ b/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostClassificationTrainer.java
@@ -103,6 +103,32 @@ public final class XGBoostClassificationTrainer extends XGBoostTrainer<Label> {
     }
 
     /**
+     * Create an XGBoost trainer.
+     *
+     * @param boosterType The base learning algorithm.
+     * @param treeMethod The tree building algorithm if using a tree booster.
+     * @param numTrees Number of trees to boost.
+     * @param eta Step size shrinkage parameter (default 0.3, range [0,1]).
+     * @param gamma Minimum loss reduction to make a split (default 0, range
+     * [0,inf]).
+     * @param maxDepth Maximum tree depth (default 6, range [1,inf]).
+     * @param minChildWeight Minimum sum of instance weights needed in a leaf
+     * (default 1, range [0, inf]).
+     * @param subsample Subsample size for each tree (default 1, range (0,1]).
+     * @param featureSubsample Subsample features for each tree (default 1,
+     * range (0,1]).
+     * @param lambda L2 regularization term on weights (default 1).
+     * @param alpha L1 regularization term on weights (default 0).
+     * @param nThread Number of threads to use (default 4).
+     * @param verbosity Set the logging verbosity of the native library.
+     * @param seed RNG seed.
+     */
+    public XGBoostClassificationTrainer(BoosterType boosterType, TreeMethod treeMethod, int numTrees, double eta, double gamma, int maxDepth, double minChildWeight, double subsample, double featureSubsample, double lambda, double alpha, int nThread, LoggingVerbosity verbosity, long seed) {
+        super(boosterType,treeMethod,numTrees,eta,gamma,maxDepth,minChildWeight,subsample,featureSubsample,lambda,alpha,nThread,verbosity,seed);
+        postConfig();
+    }
+
+    /**
      * This gives direct access to the XGBoost parameter map.
      * <p>
      * It lets you pick things that we haven't exposed like dropout trees, binary classification etc.
@@ -128,7 +154,7 @@ public final class XGBoostClassificationTrainer extends XGBoostTrainer<Label> {
     public void postConfig() {
         super.postConfig();
         parameters.put("objective", "multi:softprob");
-        if(!evalMetric.isEmpty()) {
+        if (!evalMetric.isEmpty()) {
             parameters.put("eval_metric", evalMetric);
         }
     }

--- a/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostOptions.java
+++ b/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostOptions.java
@@ -38,7 +38,7 @@ public class XGBoostOptions implements ClassificationOptions<XGBoostClassificati
     public int xgbEnsembleSize = -1;
     @Option(longName = "xgb-alpha", usage = "L1 regularization term for weights.")
     public float xbgAlpha = 0.0f;
-    @Option(longName = "xgb-min-weight", usage = "Minimum sum of instance weights needed in a leaf (range [0,inf]).")
+    @Option(longName = "xgb-min-weight", usage = "Minimum sum of instance weights needed in a leaf (range [0,Infinity]).")
     public float xgbMinWeight = 1;
     @Option(longName = "xgb-max-depth", usage = "Max tree depth (range (0,Integer.MAX_VALUE]).")
     public int xgbMaxDepth = 6;
@@ -46,7 +46,7 @@ public class XGBoostOptions implements ClassificationOptions<XGBoostClassificati
     public float xgbEta = 0.3f;
     @Option(longName = "xgb-subsample-features", usage = "Subsample features for each tree (range (0,1]).")
     public float xgbSubsampleFeatures = 0.0f;
-    @Option(longName = "xgb-gamma", usage = "Minimum loss reduction to make a split (range [0,inf]).")
+    @Option(longName = "xgb-gamma", usage = "Minimum loss reduction to make a split (range [0,Infinity]).")
     public float xgbGamma = 0.0f;
     @Option(longName = "xgb-lambda", usage = "L2 regularization term for weights.")
     public float xgbLambda = 1.0f;

--- a/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostOptions.java
+++ b/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostOptions.java
@@ -19,32 +19,44 @@ package org.tribuo.classification.xgboost;
 import com.oracle.labs.mlrg.olcut.config.Option;
 import org.tribuo.Trainer;
 import org.tribuo.classification.ClassificationOptions;
+import org.tribuo.common.xgboost.XGBoostTrainer;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * CLI options for training an XGBoost classifier.
  */
 public class XGBoostOptions implements ClassificationOptions<XGBoostClassificationTrainer> {
+    private static final Logger logger = Logger.getLogger(XGBoostOptions.class.getName());
+
+    @Option(longName = "xgb-booster-type", usage = "Weak learning algorithm.")
+    public XGBoostTrainer.BoosterType xgbBoosterType = XGBoostTrainer.BoosterType.GBTREE;
+    @Option(longName = "xgb-tree-method", usage = "Tree building algorithm.")
+    public XGBoostTrainer.TreeMethod xgbTreeMethod = XGBoostTrainer.TreeMethod.AUTO;
     @Option(longName = "xgb-ensemble-size", usage = "Number of trees in the ensemble.")
     public int xgbEnsembleSize = -1;
-    @Option(longName = "xgb-alpha", usage = "L1 regularization term for weights (default 0).")
+    @Option(longName = "xgb-alpha", usage = "L1 regularization term for weights.")
     public float xbgAlpha = 0.0f;
-    @Option(longName = "xgb-min-weight", usage = "Minimum sum of instance weights needed in a leaf (default 1, range [0,inf]).")
+    @Option(longName = "xgb-min-weight", usage = "Minimum sum of instance weights needed in a leaf (range [0,inf]).")
     public float xgbMinWeight = 1;
-    @Option(longName = "xgb-max-depth", usage = "Max tree depth (default 6, range (0,inf]).")
+    @Option(longName = "xgb-max-depth", usage = "Max tree depth (range (0,inf]).")
     public int xgbMaxDepth = 6;
-    @Option(longName = "xgb-eta", usage = "Step size shrinkage parameter (default 0.3, range [0,1]).")
+    @Option(longName = "xgb-eta", usage = "Step size shrinkage parameter (range [0,1]).")
     public float xgbEta = 0.3f;
-    @Option(longName = "xgb-subsample-features", usage = "Subsample features for each tree (default 1, range (0,1]).")
+    @Option(longName = "xgb-subsample-features", usage = "Subsample features for each tree (range (0,1]).")
     public float xgbSubsampleFeatures;
-    @Option(longName = "xgb-gamma", usage = "Minimum loss reduction to make a split (default 0, range [0,inf]).")
+    @Option(longName = "xgb-gamma", usage = "Minimum loss reduction to make a split (range [0,inf]).")
     public float xgbGamma = 0.0f;
-    @Option(longName = "xgb-lambda", usage = "L2 regularization term for weights (default 1).")
+    @Option(longName = "xgb-lambda", usage = "L2 regularization term for weights.")
     public float xgbLambda = 1.0f;
-    @Option(longName = "xgb-quiet", usage = "Make the XGBoost training procedure quiet.")
+    @Option(longName = "xgb-quiet", usage = "Deprecated, use xgb-loglevel.")
     public boolean xgbQuiet;
-    @Option(longName = "xgb-subsample", usage = "Subsample size for each tree (default 1, range (0,1]).")
+    @Option(longName = "xgb-loglevel", usage = "Make the XGBoost training procedure quiet.")
+    public XGBoostTrainer.LoggingVerbosity xgbLogLevel = XGBoostTrainer.LoggingVerbosity.WARNING;
+    @Option(longName = "xgb-subsample", usage = "Subsample size for each tree (range (0,1]).")
     public float xgbSubsample = 1.0f;
-    @Option(longName = "xgb-num-threads", usage = "Number of threads to use (default 4, range (1, num hw threads)).")
+    @Option(longName = "xgb-num-threads", usage = "Number of threads to use (range (1, num hw threads)).")
     public int xgbNumThreads;
     @Option(longName = "xgb-seed", usage = "Sets the random seed for XGBoost.")
     private long xgbSeed = Trainer.DEFAULT_SEED;
@@ -54,6 +66,10 @@ public class XGBoostOptions implements ClassificationOptions<XGBoostClassificati
         if (xgbEnsembleSize == -1) {
             throw new IllegalArgumentException("Please supply the number of trees.");
         }
-        return new XGBoostClassificationTrainer(xgbEnsembleSize, xgbEta, xgbGamma, xgbMaxDepth, xgbMinWeight, xgbSubsample, xgbSubsampleFeatures, xgbLambda, xbgAlpha, xgbNumThreads, xgbQuiet, xgbSeed);
+        if (xgbQuiet) {
+            logger.log(Level.WARNING,"Silencing XGBoost, overriding logging verbosity. Please switch to the 'xgb-loglevel' argument.");
+            xgbLogLevel = XGBoostTrainer.LoggingVerbosity.SILENT;
+        }
+        return new XGBoostClassificationTrainer(xgbBoosterType, xgbTreeMethod, xgbEnsembleSize, xgbEta, xgbGamma, xgbMaxDepth, xgbMinWeight, xgbSubsample, xgbSubsampleFeatures, xgbLambda, xbgAlpha, xgbNumThreads, xgbLogLevel, xgbSeed);
     }
 }

--- a/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostOptions.java
+++ b/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostOptions.java
@@ -40,12 +40,12 @@ public class XGBoostOptions implements ClassificationOptions<XGBoostClassificati
     public float xbgAlpha = 0.0f;
     @Option(longName = "xgb-min-weight", usage = "Minimum sum of instance weights needed in a leaf (range [0,inf]).")
     public float xgbMinWeight = 1;
-    @Option(longName = "xgb-max-depth", usage = "Max tree depth (range (0,inf]).")
+    @Option(longName = "xgb-max-depth", usage = "Max tree depth (range (0,Integer.MAX_VALUE]).")
     public int xgbMaxDepth = 6;
     @Option(longName = "xgb-eta", usage = "Step size shrinkage parameter (range [0,1]).")
     public float xgbEta = 0.3f;
     @Option(longName = "xgb-subsample-features", usage = "Subsample features for each tree (range (0,1]).")
-    public float xgbSubsampleFeatures;
+    public float xgbSubsampleFeatures = 0.0f;
     @Option(longName = "xgb-gamma", usage = "Minimum loss reduction to make a split (range [0,inf]).")
     public float xgbGamma = 0.0f;
     @Option(longName = "xgb-lambda", usage = "L2 regularization term for weights.")
@@ -56,8 +56,8 @@ public class XGBoostOptions implements ClassificationOptions<XGBoostClassificati
     public XGBoostTrainer.LoggingVerbosity xgbLogLevel = XGBoostTrainer.LoggingVerbosity.WARNING;
     @Option(longName = "xgb-subsample", usage = "Subsample size for each tree (range (0,1]).")
     public float xgbSubsample = 1.0f;
-    @Option(longName = "xgb-num-threads", usage = "Number of threads to use (range (1, num hw threads)).")
-    public int xgbNumThreads;
+    @Option(longName = "xgb-num-threads", usage = "Number of threads to use (range (1, num hw threads)). The default of 0 means use all hw threads.")
+    public int xgbNumThreads = 0;
     @Option(longName = "xgb-seed", usage = "Sets the random seed for XGBoost.")
     private long xgbSeed = Trainer.DEFAULT_SEED;
 

--- a/Classification/XGBoost/src/test/java/org/tribuo/classification/xgboost/TestXGBoost.java
+++ b/Classification/XGBoost/src/test/java/org/tribuo/classification/xgboost/TestXGBoost.java
@@ -30,6 +30,7 @@ import org.tribuo.classification.evaluation.LabelEvaluator;
 import org.tribuo.classification.example.LabelledDataGenerator;
 import org.tribuo.common.xgboost.XGBoostFeatureImportance;
 import org.tribuo.common.xgboost.XGBoostModel;
+import org.tribuo.common.xgboost.XGBoostTrainer;
 import org.tribuo.data.text.TextDataSource;
 import org.tribuo.data.text.TextFeatureExtractor;
 import org.tribuo.data.text.impl.BasicPipeline;
@@ -60,6 +61,15 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TestXGBoost {
 
     private static final XGBoostClassificationTrainer t = new XGBoostClassificationTrainer(50);
+
+    private static final XGBoostClassificationTrainer dart = new XGBoostClassificationTrainer(
+            XGBoostTrainer.BoosterType.DART,XGBoostTrainer.TreeMethod.AUTO,50,0.3,0,6,1,1,1,1,0,1, XGBoostTrainer.LoggingVerbosity.SILENT,42);
+
+    private static final XGBoostClassificationTrainer linear = new XGBoostClassificationTrainer(
+            XGBoostTrainer.BoosterType.LINEAR,XGBoostTrainer.TreeMethod.AUTO,50,0.3,0,6,1,1,1,1,0,1, XGBoostTrainer.LoggingVerbosity.SILENT,42);
+
+    private static final XGBoostClassificationTrainer gbtree = new XGBoostClassificationTrainer(
+            XGBoostTrainer.BoosterType.GBTREE,XGBoostTrainer.TreeMethod.HIST,50,0.3,0,6,1,1,1,1,0,1, XGBoostTrainer.LoggingVerbosity.SILENT,42);
 
     private static final int[] NUM_TREES = new int[]{1,5,10,50};
 
@@ -168,8 +178,8 @@ public class TestXGBoost {
         }
     }
 
-    public Model<Label> testXGBoost(Pair<Dataset<Label>,Dataset<Label>> p) {
-        Model<Label> m = t.train(p.getA());
+    public static Model<Label> testXGBoost(XGBoostClassificationTrainer trainer, Pair<Dataset<Label>,Dataset<Label>> p) {
+        Model<Label> m = trainer.train(p.getA());
         LabelEvaluator e = new LabelEvaluator();
         LabelEvaluation evaluation = e.evaluate(m,p.getB());
         Map<String, List<Pair<String,Double>>> features = m.getTopFeatures(3);
@@ -205,20 +215,23 @@ public class TestXGBoost {
     @Test
     public void testDenseData() {
         Pair<Dataset<Label>,Dataset<Label>> p = LabelledDataGenerator.denseTrainTest();
-        Model<Label> model = testXGBoost(p);
+        Model<Label> model = testXGBoost(t,p);
         Helpers.testModelSerialization(model,Label.class);
+        testXGBoost(dart,p);
+        testXGBoost(linear,p);
+        testXGBoost(gbtree,p);
     }
 
     @Test
     public void testSparseData() {
         Pair<Dataset<Label>,Dataset<Label>> p = LabelledDataGenerator.sparseTrainTest();
-        testXGBoost(p);
+        testXGBoost(t,p);
     }
 
     @Test
     public void testSparseBinaryData() {
         Pair<Dataset<Label>,Dataset<Label>> p = LabelledDataGenerator.binarySparseTrainTest();
-        testXGBoost(p);
+        testXGBoost(t,p);
     }
 
     @Test

--- a/Common/XGBoost/pom.xml
+++ b/Common/XGBoost/pom.xml
@@ -31,6 +31,15 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>XGBoost4J Release Repo</id>
+            <name>XGBoost4J Release Repo</name>
+            <url>https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/release/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -67,6 +76,10 @@
                 <exclusion>
                     <groupId>com.typesafe.akka</groupId>
                     <artifactId>akka-actor_2.12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.scalatest</groupId>
+                    <artifactId>scalatest_2.12</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.scala-lang.modules</groupId>

--- a/Common/XGBoost/pom.xml
+++ b/Common/XGBoost/pom.xml
@@ -32,14 +32,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>XGBoost4J Release Repo</id>
-            <name>XGBoost4J Release Repo</name>
-            <url>https://s3-us-west-2.amazonaws.com/xgboost-maven-repo/release/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/Regression/XGBoost/src/main/java/org/tribuo/regression/xgboost/XGBoostRegressionTrainer.java
+++ b/Regression/XGBoost/src/main/java/org/tribuo/regression/xgboost/XGBoostRegressionTrainer.java
@@ -84,7 +84,11 @@ public final class XGBoostRegressionTrainer extends XGBoostTrainer<Regressor> {
         /**
          * Tweedie loss function.
          */
-        TWEEDIE("reg:tweedie");
+        TWEEDIE("reg:tweedie"),
+        /**
+         * Pseudo-huber loss, a differentiable approximation to absolute error
+         */
+        PSEUDOHUBER("reg:pseudohubererror");
 
         public final String paramName;
 

--- a/Regression/XGBoost/src/main/java/org/tribuo/regression/xgboost/XGBoostRegressionTrainer.java
+++ b/Regression/XGBoost/src/main/java/org/tribuo/regression/xgboost/XGBoostRegressionTrainer.java
@@ -140,6 +140,35 @@ public final class XGBoostRegressionTrainer extends XGBoostTrainer<Regressor> {
     }
 
     /**
+     * Create an XGBoost trainer.
+     *
+     * @param boosterType The base learning algorithm.
+     * @param treeMethod The tree building algorithm if using a tree booster.
+     * @param rType The type of regression to build.
+     * @param numTrees Number of trees to boost.
+     * @param eta Step size shrinkage parameter (default 0.3, range [0,1]).
+     * @param gamma Minimum loss reduction to make a split (default 0, range
+     * [0,inf]).
+     * @param maxDepth Maximum tree depth (default 6, range [1,inf]).
+     * @param minChildWeight Minimum sum of instance weights needed in a leaf
+     * (default 1, range [0, inf]).
+     * @param subsample Subsample size for each tree (default 1, range (0,1]).
+     * @param featureSubsample Subsample features for each tree (default 1,
+     * range (0,1]).
+     * @param lambda L2 regularization term on weights (default 1).
+     * @param alpha L1 regularization term on weights (default 0).
+     * @param nThread Number of threads to use (default 4).
+     * @param verbosity Set the logging verbosity of the native library.
+     * @param seed RNG seed.
+     */
+    public XGBoostRegressionTrainer(BoosterType boosterType, TreeMethod treeMethod, RegressionType rType, int numTrees, double eta, double gamma, int maxDepth, double minChildWeight, double subsample, double featureSubsample, double lambda, double alpha, int nThread, LoggingVerbosity verbosity, long seed) {
+        super(boosterType,treeMethod,numTrees,eta,gamma,maxDepth,minChildWeight,subsample,featureSubsample,lambda,alpha,nThread,verbosity,seed);
+        this.rType = rType;
+
+        postConfig();
+    }
+
+    /**
      * This gives direct access to the XGBoost parameter map.
      * <p>
      * It lets you pick things that we haven't exposed like dropout trees, binary classification etc.

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <libsvm.version>3.24</libsvm.version>
         <onnxruntime.version>1.4.0</onnxruntime.version>
         <tensorflow.version>1.14.0</tensorflow.version>
-        <xgboost.version>1.3.2</xgboost.version>
+        <xgboost.version>1.3.1</xgboost.version>
 
         <!-- 3rd party other dependencies -->
         <junit.version>5.6.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <libsvm.version>3.24</libsvm.version>
         <onnxruntime.version>1.4.0</onnxruntime.version>
         <tensorflow.version>1.14.0</tensorflow.version>
-        <xgboost.version>1.3.1</xgboost.version>
+        <xgboost.version>1.3.2</xgboost.version>
 
         <!-- 3rd party other dependencies -->
         <junit.version>5.6.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <libsvm.version>3.24</libsvm.version>
         <onnxruntime.version>1.4.0</onnxruntime.version>
         <tensorflow.version>1.14.0</tensorflow.version>
-        <xgboost.version>1.0.0</xgboost.version>
+        <xgboost.version>1.3.1</xgboost.version>
 
         <!-- 3rd party other dependencies -->
         <junit.version>5.6.2</junit.version>


### PR DESCRIPTION
### Description
Bumps XGBoost from 1.0.0 to 1.3.2. Also plumbs through additional XGBoost parameters, so now the booster type and tree method are controllable. Exposes the logging verbosity as a replacement for the deprecated silent parameter.
