### PR TITLE
Add dense feature vector optimisations to CRF and LinearSGD models

### DIFF
--- a/Classification/Core/src/main/java/org/tribuo/classification/sequence/SeqTrainTest.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/sequence/SeqTrainTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.classification.sequence;
+
+import com.oracle.labs.mlrg.olcut.config.ConfigurationManager;
+import com.oracle.labs.mlrg.olcut.config.Option;
+import com.oracle.labs.mlrg.olcut.config.Options;
+import com.oracle.labs.mlrg.olcut.config.UsageException;
+import com.oracle.labs.mlrg.olcut.util.LabsLogFormatter;
+import org.tribuo.classification.Label;
+import org.tribuo.classification.sequence.example.SequenceDataGenerator;
+import org.tribuo.sequence.SequenceDataset;
+import org.tribuo.sequence.SequenceModel;
+import org.tribuo.sequence.SequenceTrainer;
+import org.tribuo.util.Util;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
+/**
+ * Build and run a sequence classifier on a generated or serialized dataset using the trainer specified in the configuration file.
+ */
+public class SeqTrainTest {
+
+    private static final Logger logger = Logger.getLogger(SeqTrainTest.class.getName());
+
+    public static class SeqTrainTestOptions implements Options {
+        @Override
+        public String getOptionsDescription() {
+            return "Trains and tests a sequence classification model on the specified dataset.";
+        }
+
+        @Option(charName = 'd', longName = "dataset-name", usage = "Name of the example dataset, options are {gorilla}.")
+        public String datasetName = "";
+        @Option(charName = 'f', longName = "output-path", usage = "Path to serialize model to.")
+        public Path outputPath;
+        @Option(charName = 'u', longName = "train-dataset", usage = "Path to a serialised SequenceDataset used for training.")
+        public Path trainDataset = null;
+        @Option(charName = 'v', longName = "test-dataset", usage = "Path to a serialised SequenceDataset used for testing.")
+        public Path testDataset = null;
+        @Option(charName = 't', longName = "trainer-name", usage = "Name of the trainer in the configuration file.")
+        public SequenceTrainer<Label> trainer;
+    }
+
+    /**
+     * @param args the command line arguments
+     * @throws ClassNotFoundException if it failed to load the model.
+     * @throws IOException            if there is any error reading the examples.
+     */
+    public static void main(String[] args) throws ClassNotFoundException, IOException {
+
+        //
+        // Use the labs format logging.
+        LabsLogFormatter.setAllLogFormatters();
+
+        SeqTrainTestOptions o = new SeqTrainTestOptions();
+        ConfigurationManager cm;
+        try {
+            cm = new ConfigurationManager(args, o);
+        } catch (UsageException e) {
+            logger.info(e.getMessage());
+            return;
+        }
+
+        SequenceDataset<Label> train;
+        SequenceDataset<Label> test;
+        switch (o.datasetName) {
+            case "Gorilla":
+            case "gorilla":
+                logger.info("Generating gorilla dataset");
+                train = SequenceDataGenerator.generateGorillaDataset(1);
+                test = SequenceDataGenerator.generateGorillaDataset(1);
+                break;
+            default:
+                if ((o.trainDataset != null) && (o.testDataset != null)) {
+                    logger.info("Loading training data from " + o.trainDataset);
+                    try (ObjectInputStream ois = new ObjectInputStream(new BufferedInputStream(new FileInputStream(o.trainDataset.toFile())));
+                         ObjectInputStream oits = new ObjectInputStream(new BufferedInputStream(new FileInputStream(o.testDataset.toFile())))) {
+                        @SuppressWarnings("unchecked") // deserialising a generic dataset.
+                        SequenceDataset<Label> tmpTrain = (SequenceDataset<Label>) ois.readObject();
+                        train = tmpTrain;
+                        logger.info(String.format("Loaded %d training examples for %s", train.size(), train.getOutputs().toString()));
+                        logger.info("Found " + train.getFeatureIDMap().size() + " features");
+                        logger.info("Loading testing data from " + o.testDataset);
+                        @SuppressWarnings("unchecked") // deserialising a generic dataset.
+                        SequenceDataset<Label> tmpTest = (SequenceDataset<Label>) oits.readObject();
+                        test = tmpTest;
+                        logger.info(String.format("Loaded %d testing examples", test.size()));
+                    }
+                } else {
+                    logger.warning("Unknown dataset " + o.datasetName);
+                    logger.info(cm.usage());
+                    return;
+                }
+        }
+
+        logger.info("Training using " + o.trainer.toString());
+        final long trainStart = System.currentTimeMillis();
+        SequenceModel<Label> model = o.trainer.train(train);
+        final long trainStop = System.currentTimeMillis();
+        logger.info("Finished training classifier " + Util.formatDuration(trainStart, trainStop));
+
+        LabelSequenceEvaluator labelEvaluator = new LabelSequenceEvaluator();
+        final long testStart = System.currentTimeMillis();
+        LabelSequenceEvaluation evaluation = labelEvaluator.evaluate(model,test);
+        final long testStop = System.currentTimeMillis();
+        logger.info("Finished evaluating model " + Util.formatDuration(testStart, testStop));
+        System.out.println(evaluation.toString());
+        System.out.println();
+        System.out.println(evaluation.getConfusionMatrix().toString());
+
+        if (o.outputPath != null) {
+            try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(o.outputPath.toFile()))) {
+                oos.writeObject(model);
+                logger.info("Serialized model to file: " + o.outputPath);
+            }
+        }
+    }
+}

--- a/Classification/Core/src/main/java/org/tribuo/classification/sequence/viterbi/ViterbiTrainer.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/sequence/viterbi/ViterbiTrainer.java
@@ -74,6 +74,11 @@ public final class ViterbiTrainer implements SequenceTrainer<Label> {
     }
 
     /**
+     * For OLCUT.
+     */
+    private ViterbiTrainer() { }
+
+    /**
      * The viterbi train method is unique because it delegates to a regular
      * {@link Model} train method, but before it does, it adds features derived
      * from preceding labels. The pipeline upstream of this call should not care

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/Util.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/Util.java
@@ -27,11 +27,13 @@ import java.util.SplittableRandom;
 public class Util {
     /**
      * In place shuffle of the features, labels and weights.
+     * @deprecated In favour of {@link org.tribuo.common.sgd.AbstractLinearSGDTrainer#shuffleInPlace}.
      * @param features Input features.
      * @param labels Input labels.
      * @param weights Input weights.
      * @param rng SplittableRandom number generator.
      */
+    @Deprecated
     public static void shuffleInPlace(SparseVector[] features, int[] labels, double[] weights, SplittableRandom rng) {
         int size = features.length;
         // Shuffle array

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/Util.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/Util.java
@@ -16,6 +16,7 @@
 
 package org.tribuo.classification.sgd;
 
+import org.tribuo.math.la.SGDVector;
 import org.tribuo.math.la.SparseVector;
 
 import java.util.SplittableRandom;
@@ -142,13 +143,13 @@ public class Util {
      * @param weights Input weights.
      * @param rng SplittableRandom number generator.
      */
-    public static void shuffleInPlace(SparseVector[][] features, int[][] labels, double[] weights, SplittableRandom rng) {
+    public static void shuffleInPlace(SGDVector[][] features, int[][] labels, double[] weights, SplittableRandom rng) {
         int size = features.length;
         // Shuffle array
         for (int i = size; i > 1; i--) {
             int j = rng.nextInt(i);
             //swap features
-            SparseVector[] tmpFeature = features[i-1];
+            SGDVector[] tmpFeature = features[i-1];
             features[i-1] = features[j];
             features[j] = tmpFeature;
             //swap labels
@@ -170,9 +171,9 @@ public class Util {
      * @param rng SplittableRandom number generator.
      * @return A tuple of shuffled features, labels and weights.
      */
-    public static SequenceExampleArray shuffle(SparseVector[][] features, int[][] labels, double[] weights, SplittableRandom rng) {
+    public static SequenceExampleArray shuffle(SGDVector[][] features, int[][] labels, double[] weights, SplittableRandom rng) {
         int size = features.length;
-        SparseVector[][] newFeatures = new SparseVector[size][];
+        SGDVector[][] newFeatures = new SGDVector[size][];
         int[][] newLabels = new int[size][];
         double[] newWeights = new double[size];
         for (int i = 0; i < newFeatures.length; i++) {
@@ -184,7 +185,7 @@ public class Util {
         for (int i = size; i > 1; i--) {
             int j = rng.nextInt(i);
             //swap features
-            SparseVector[] tmpFeature = newFeatures[i-1];
+            SGDVector[] tmpFeature = newFeatures[i-1];
             newFeatures[i-1] = newFeatures[j];
             newFeatures[j] = tmpFeature;
             //swap labels
@@ -203,11 +204,11 @@ public class Util {
      * A nominal tuple. One day it'll be a record, but not today.
      */
     public static class SequenceExampleArray {
-        public final SparseVector[][] features;
+        public final SGDVector[][] features;
         public final int[][] labels;
         public final double[] weights;
 
-        public SequenceExampleArray(SparseVector[][] features, int[][] labels, double[] weights) {
+        SequenceExampleArray(SGDVector[][] features, int[][] labels, double[] weights) {
             this.features = features;
             this.labels = labels;
             this.weights = weights;

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFModel.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFModel.java
@@ -25,6 +25,7 @@ import org.tribuo.Prediction;
 import org.tribuo.classification.Label;
 import org.tribuo.classification.sequence.ConfidencePredictingSequenceModel;
 import org.tribuo.math.la.DenseVector;
+import org.tribuo.math.la.SGDVector;
 import org.tribuo.math.la.SparseVector;
 import org.tribuo.math.la.Tensor;
 import org.tribuo.provenance.ModelProvenance;
@@ -43,9 +44,9 @@ import java.util.logging.Logger;
 import static org.tribuo.Model.BIAS_FEATURE;
 
 /**
- * An inference time model for a CRF trained using SGD.
+ * An inference time model for a linear chain CRF trained using SGD.
  * <p>
- * Can be switched to use belief propagation, or constrained BP, at test time instead of the standard Viterbi.
+ * Can be switched to use Viterbi, belief propagation, or constrained BP at test time. By default it uses Viterbi.
  * <p>
  * See:
  * <pre>
@@ -128,7 +129,7 @@ public class CRFModel extends ConfidencePredictingSequenceModel {
 
     @Override
     public List<Prediction<Label>> predict(SequenceExample<Label> example) {
-        SparseVector[] features = convert(example,featureIDMap);
+        SGDVector[] features = convertToVector(example,featureIDMap);
         List<Prediction<Label>> output = new ArrayList<>();
         if (confidenceType == ConfidenceType.MULTIPLY) {
             DenseVector[] marginals = parameters.predictMarginals(features);
@@ -193,7 +194,7 @@ public class CRFModel extends ConfidencePredictingSequenceModel {
                 q.poll();
                 q.offer(curr);
             }
-            ArrayList<Pair<String,Double>> b = new ArrayList<>();
+            List<Pair<String,Double>> b = new ArrayList<>();
             while (q.size() > 0) {
                 b.add(q.poll());
             }
@@ -228,7 +229,7 @@ public class CRFModel extends ConfidencePredictingSequenceModel {
      * @return The scores.
      */
     public List<Double> scoreChunks(SequenceExample<Label> example, List<Chunk> chunks) {
-        SparseVector[] features = convert(example,featureIDMap);
+        SGDVector[] features = convertToVector(example,featureIDMap);
         return parameters.predictConfidenceUsingCBP(features,chunks);
     }
 
@@ -258,11 +259,13 @@ public class CRFModel extends ConfidencePredictingSequenceModel {
 
     /**
      * Converts a {@link SequenceExample} into an array of {@link SparseVector}s suitable for CRF prediction.
+     * @deprecated As it's replaced with {@link #convertToVector} which is more flexible.
      * @param example The sequence example to convert
      * @param featureIDMap The feature id map, used to discover the number of features.
      * @param <T> The type parameter of the sequence example.
      * @return An array of {@link SparseVector}.
      */
+    @Deprecated
     public static <T extends Output<T>> SparseVector[] convert(SequenceExample<T> example, ImmutableFeatureMap featureIDMap) {
         int length = example.size();
         if (length == 0) {
@@ -282,11 +285,13 @@ public class CRFModel extends ConfidencePredictingSequenceModel {
 
     /**
      * Converts a {@link SequenceExample} into an array of {@link SparseVector}s and labels suitable for CRF prediction.
+     * @deprecated As it's replaced with {@link #convertToVector} which is more flexible.
      * @param example The sequence example to convert
      * @param featureIDMap The feature id map, used to discover the number of features.
      * @param labelIDMap The label id map, used to get the index of the labels.
      * @return A {@link Pair} of an int array of labels and an array of {@link SparseVector}.
      */
+    @Deprecated
     public static Pair<int[],SparseVector[]> convert(SequenceExample<Label> example, ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<Label> labelIDMap) {
         int length = example.size();
         if (length == 0) {
@@ -294,6 +299,56 @@ public class CRFModel extends ConfidencePredictingSequenceModel {
         }
         int[] labels = new int[length];
         SparseVector[] features = new SparseVector[length];
+        int i = 0;
+        for (Example<Label> e : example) {
+            labels[i] = labelIDMap.getID(e.getOutput());
+            features[i] = SparseVector.createSparseVector(e,featureIDMap,false);
+            if (features[i].numActiveElements() == 0) {
+                throw new IllegalArgumentException("No features found in Example " + e.toString());
+            }
+            i++;
+        }
+        return new Pair<>(labels,features);
+    }
+
+    /**
+     * Converts a {@link SequenceExample} into an array of {@link SGDVector}s suitable for CRF prediction.
+     * @param example The sequence example to convert
+     * @param featureIDMap The feature id map, used to discover the number of features.
+     * @param <T> The type parameter of the sequence example.
+     * @return An array of {@link SGDVector}.
+     */
+    public static <T extends Output<T>> SGDVector[] convertToVector(SequenceExample<T> example, ImmutableFeatureMap featureIDMap) {
+        int length = example.size();
+        if (length == 0) {
+            throw new IllegalArgumentException("SequenceExample is empty, " + example.toString());
+        }
+        SGDVector[] features = new SGDVector[length];
+        int i = 0;
+        for (Example<T> e : example) {
+            features[i] = SparseVector.createSparseVector(e,featureIDMap,false);
+            if (features[i].numActiveElements() == 0) {
+                throw new IllegalArgumentException("No features found in Example " + e.toString());
+            }
+            i++;
+        }
+        return features;
+    }
+
+    /**
+     * Converts a {@link SequenceExample} into an array of {@link SGDVector}s and labels suitable for CRF prediction.
+     * @param example The sequence example to convert
+     * @param featureIDMap The feature id map, used to discover the number of features.
+     * @param labelIDMap The label id map, used to get the index of the labels.
+     * @return A {@link Pair} of an int array of labels and an array of {@link SparseVector}.
+     */
+    public static Pair<int[],SGDVector[]> convertToVector(SequenceExample<Label> example, ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<Label> labelIDMap) {
+        int length = example.size();
+        if (length == 0) {
+            throw new IllegalArgumentException("SequenceExample is empty, " + example.toString());
+        }
+        int[] labels = new int[length];
+        SGDVector[] features = new SGDVector[length];
         int i = 0;
         for (Example<Label> e : example) {
             labels[i] = labelIDMap.getID(e.getOutput());

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFModel.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFModel.java
@@ -323,10 +323,15 @@ public class CRFModel extends ConfidencePredictingSequenceModel {
         if (length == 0) {
             throw new IllegalArgumentException("SequenceExample is empty, " + example.toString());
         }
+        int featureSpaceSize = featureIDMap.size();
         SGDVector[] features = new SGDVector[length];
         int i = 0;
         for (Example<T> e : example) {
-            features[i] = SparseVector.createSparseVector(e,featureIDMap,false);
+            if (e.size() == featureSpaceSize) {
+                features[i] = DenseVector.createDenseVector(e, featureIDMap, false);
+            } else {
+                features[i] = SparseVector.createSparseVector(e, featureIDMap, false);
+            }
             if (features[i].numActiveElements() == 0) {
                 throw new IllegalArgumentException("No features found in Example " + e.toString());
             }
@@ -347,12 +352,17 @@ public class CRFModel extends ConfidencePredictingSequenceModel {
         if (length == 0) {
             throw new IllegalArgumentException("SequenceExample is empty, " + example.toString());
         }
+        int featureSpaceSize = featureIDMap.size();
         int[] labels = new int[length];
         SGDVector[] features = new SGDVector[length];
         int i = 0;
         for (Example<Label> e : example) {
             labels[i] = labelIDMap.getID(e.getOutput());
-            features[i] = SparseVector.createSparseVector(e,featureIDMap,false);
+            if (e.size() == featureSpaceSize) {
+                features[i] = DenseVector.createDenseVector(e, featureIDMap, false);
+            } else {
+                features[i] = SparseVector.createSparseVector(e, featureIDMap, false);
+            }
             if (features[i].numActiveElements() == 0) {
                 throw new IllegalArgumentException("No features found in Example " + e.toString());
             }

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFTrainer.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFTrainer.java
@@ -25,6 +25,7 @@ import org.tribuo.WeightedExamples;
 import org.tribuo.classification.Label;
 import org.tribuo.classification.sgd.Util;
 import org.tribuo.math.StochasticGradientOptimiser;
+import org.tribuo.math.la.SGDVector;
 import org.tribuo.math.la.SparseVector;
 import org.tribuo.math.la.Tensor;
 import org.tribuo.provenance.ModelProvenance;
@@ -150,13 +151,13 @@ public class CRFTrainer implements SequenceTrainer<Label>, WeightedExamples {
         }
         ImmutableOutputInfo<Label> labelIDMap = sequenceExamples.getOutputIDInfo();
         ImmutableFeatureMap featureIDMap = sequenceExamples.getFeatureIDMap();
-        SparseVector[][] sgdFeatures = new SparseVector[sequenceExamples.size()][];
+        SGDVector[][] sgdFeatures = new SGDVector[sequenceExamples.size()][];
         int[][] sgdLabels = new int[sequenceExamples.size()][];
         double[] weights = new double[sequenceExamples.size()];
         int n = 0;
         for (SequenceExample<Label> example : sequenceExamples) {
             weights[n] = example.getWeight();
-            Pair<int[],SparseVector[]> pair = CRFModel.convert(example,featureIDMap,labelIDMap);
+            Pair<int[],SGDVector[]> pair = CRFModel.convertToVector(example,featureIDMap,labelIDMap);
             sgdFeatures[n] = pair.getB();
             sgdLabels[n] = pair.getA();
             n++;

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFTrainer.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/CRFTrainer.java
@@ -26,7 +26,6 @@ import org.tribuo.classification.Label;
 import org.tribuo.classification.sgd.Util;
 import org.tribuo.math.StochasticGradientOptimiser;
 import org.tribuo.math.la.SGDVector;
-import org.tribuo.math.la.SparseVector;
 import org.tribuo.math.la.Tensor;
 import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.provenance.TrainerProvenance;

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/ChainHelper.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/ChainHelper.java
@@ -250,13 +250,13 @@ public final class ChainHelper {
     /**
      * Belief Propagation results. One day it'll be a record, but not today.
      */
-    public static class ChainBPResults {
+    public static final class ChainBPResults {
         public final double logZ;
         public final DenseVector[] alphas;
         public final DenseVector[] betas;
         public final ChainCliqueValues scores;
 
-        public ChainBPResults(double logZ, DenseVector[] alphas, DenseVector[] betas, ChainCliqueValues scores) {
+        ChainBPResults(double logZ, DenseVector[] alphas, DenseVector[] betas, ChainCliqueValues scores) {
             this.logZ = logZ;
             this.alphas = alphas;
             this.betas = betas;
@@ -267,11 +267,11 @@ public final class ChainHelper {
     /**
      * Clique scores within a chain. One day it'll be a record, but not today.
      */
-    public static class ChainCliqueValues {
+    public static final class ChainCliqueValues {
         public final DenseVector[] localValues;
         public final DenseMatrix transitionValues;
 
-        public ChainCliqueValues(DenseVector[] localValues, DenseMatrix transitionValues) {
+        ChainCliqueValues(DenseVector[] localValues, DenseMatrix transitionValues) {
             this.localValues = localValues;
             this.transitionValues = transitionValues;
         }
@@ -280,12 +280,12 @@ public final class ChainHelper {
     /**
      * Viterbi output from a linear chain. One day it'll be a record, but not today.
      */
-    public static class ChainViterbiResults {
+    public static final class ChainViterbiResults {
         public final double mapScore;
         public final int[] mapValues;
         public final ChainCliqueValues scores;
 
-        public ChainViterbiResults(double mapScore, int[] mapValues, ChainCliqueValues scores) {
+        ChainViterbiResults(double mapScore, int[] mapValues, ChainCliqueValues scores) {
             this.mapScore = mapScore;
             this.mapValues = mapValues;
             this.scores = scores;

--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/SeqTest.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/crf/SeqTest.java
@@ -34,6 +34,7 @@ import org.tribuo.sequence.HashingSequenceTrainer;
 import org.tribuo.sequence.ImmutableSequenceDataset;
 import org.tribuo.sequence.SequenceDataset;
 import org.tribuo.sequence.SequenceTrainer;
+import org.tribuo.util.Util;
 
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
@@ -156,8 +157,10 @@ public class SeqTest {
         }
 
         logger.info("Training using " + trainer.toString());
+        final long trainStart = System.currentTimeMillis();
         CRFModel model = (CRFModel) trainer.train(train);
-        logger.info("Finished training");
+        final long trainStop = System.currentTimeMillis();
+        logger.info("Finished training classifier " + Util.formatDuration(trainStart, trainStop));
 
         if (o.logModel) {
             System.out.println("FeatureMap = " + model.getFeatureIDMap().toString());
@@ -166,8 +169,10 @@ public class SeqTest {
         }
 
         LabelSequenceEvaluator labelEvaluator = new LabelSequenceEvaluator();
+        final long testStart = System.currentTimeMillis();
         LabelSequenceEvaluation evaluation = labelEvaluator.evaluate(model,test);
-        logger.info("Finished evaluating model");
+        final long testStop = System.currentTimeMillis();
+        logger.info("Finished evaluating model " + Util.formatDuration(testStart, testStop));
         System.out.println(evaluation.toString());
         System.out.println();
         System.out.println(evaluation.getConfusionMatrix().toString());

--- a/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractLinearSGDModel.java
+++ b/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractLinearSGDModel.java
@@ -27,6 +27,7 @@ import org.tribuo.Output;
 import org.tribuo.Prediction;
 import org.tribuo.math.la.DenseMatrix;
 import org.tribuo.math.la.DenseVector;
+import org.tribuo.math.la.SGDVector;
 import org.tribuo.math.la.SparseVector;
 import org.tribuo.provenance.ModelProvenance;
 
@@ -70,7 +71,12 @@ public abstract class AbstractLinearSGDModel<T extends Output<T>> extends Model<
      * @return The prediction and the number of features involved.
      */
     protected PredAndActive predictSingle(Example<T> example) {
-        SparseVector features = SparseVector.createSparseVector(example,featureIDMap,true);
+        SGDVector features;
+        if (example.size() == featureIDMap.size()) {
+            features = DenseVector.createDenseVector(example, featureIDMap, true);
+        } else {
+            features = SparseVector.createSparseVector(example, featureIDMap, true);
+        }
         if (features.numActiveElements() == 1) {
             throw new IllegalArgumentException("No features found in Example " + example.toString());
         }

--- a/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractLinearSGDTrainer.java
+++ b/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractLinearSGDTrainer.java
@@ -29,6 +29,7 @@ import org.tribuo.Trainer;
 import org.tribuo.WeightedExamples;
 import org.tribuo.math.LinearParameters;
 import org.tribuo.math.StochasticGradientOptimiser;
+import org.tribuo.math.la.DenseVector;
 import org.tribuo.math.la.SGDVector;
 import org.tribuo.math.la.SparseVector;
 import org.tribuo.math.la.Tensor;
@@ -168,14 +169,20 @@ public abstract class AbstractLinearSGDTrainer<T extends Output<T>,U> implements
         SGDObjective<U> objective = getObjective();
         ImmutableOutputInfo<T> outputIDInfo = examples.getOutputIDInfo();
         ImmutableFeatureMap featureIDMap = examples.getFeatureIDMap();
-        SparseVector[] sgdFeatures = new SparseVector[examples.size()];
+        int featureSpaceSize = featureIDMap.size();
+
+        SGDVector[] sgdFeatures = new SGDVector[examples.size()];
         @SuppressWarnings("unchecked")
         U[] sgdTargets = (U[]) new Object[examples.size()];
         double[] weights = new double[examples.size()];
         int n = 0;
         for (Example<T> example : examples) {
             weights[n] = example.getWeight();
-            sgdFeatures[n] = SparseVector.createSparseVector(example,featureIDMap,true);
+            if (example.size() == featureSpaceSize) {
+                sgdFeatures[n] = DenseVector.createDenseVector(example, featureIDMap, true);
+            } else {
+                sgdFeatures[n] = SparseVector.createSparseVector(example, featureIDMap, true);
+            }
             sgdTargets[n] = getTarget(outputIDInfo,example.getOutput());
             n++;
         }

--- a/Core/src/main/java/org/tribuo/Example.java
+++ b/Core/src/main/java/org/tribuo/Example.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,10 +290,20 @@ public abstract class Example<T extends Output<T>> implements Iterable<Feature>,
     }
 
     /**
+     * Is this example dense wrt the supplied feature map.
+     * <p>
+     * An example is "dense" if it contains all the features in the map,
+     * and only those features.
+     * @param fMap The feature map to check against.
+     * @return True if this example contains only the features in the map, and all the features in the map.
+     */
+    public abstract boolean isDense(FeatureMap fMap);
+
+    /**
      * Converts all implicit zeros into explicit zeros based on the supplied feature map.
      * @param fMap The feature map to use for densification.
      */
-    protected void densify(FeatureMap fMap) {
+    public void densify(FeatureMap fMap) {
         // Densify! - guitar solo
         List<String> featureNames = new ArrayList<>(fMap.keySet());
         Collections.sort(featureNames);

--- a/Core/src/main/java/org/tribuo/MutableDataset.java
+++ b/Core/src/main/java/org/tribuo/MutableDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class MutableDataset<T extends Output<T>> extends Dataset<T> {
     /**
      * Denotes if this dataset contains implicit zeros or not.
      */
-    protected boolean dense = false;
+    protected boolean dense = true;
 
     /**
      * Creates an empty dataset.
@@ -112,11 +112,16 @@ public class MutableDataset<T extends Output<T>> extends Dataset<T> {
         }
         outputMap.observe(ex.getOutput());
         data.add(ex);
+        int oldNumFeatures = featureMap.size();
         for (Feature f : ex) {
             featureMap.add(f.getName(),f.getValue());
         }
         ex.canonicalize(featureMap);
-        dense = false;
+        // If we've observed a new feature, or this example doesn't contain all the features then
+        // the dataset stops being dense.
+        if ((oldNumFeatures != 0) && (oldNumFeatures < featureMap.size() || ex.size() != featureMap.size())) {
+            dense = false;
+        }
     }
 
     /**
@@ -233,6 +238,7 @@ public class MutableDataset<T extends Output<T>> extends Dataset<T> {
         featureMap.clear();
         data.clear();
         transformProvenances.clear();
+        dense = true;
     }
 
     @Override

--- a/Core/src/main/java/org/tribuo/impl/ArrayExample.java
+++ b/Core/src/main/java/org/tribuo/impl/ArrayExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -442,6 +442,21 @@ public class ArrayExample<T extends Output<T>> extends Example<T> {
                     featureValues[i] = value;
                 }
             }
+        }
+    }
+
+    @Override
+    public boolean isDense(FeatureMap fMap) {
+        if (fMap.size() == size()) {
+            // We've got the right number of features
+            for (String name : featureNames) {
+                if (fMap.get(name) == null) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/Core/src/main/java/org/tribuo/impl/BinaryFeaturesExample.java
+++ b/Core/src/main/java/org/tribuo/impl/BinaryFeaturesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -402,12 +402,27 @@ public final class BinaryFeaturesExample<T extends Output<T>> extends Example<T>
     }
 
     @Override
-    public void densify(List<String> featureList) {
+    public boolean isDense(FeatureMap fMap) {
+        if (fMap.size() == size()) {
+            // We've got the right number of features
+            for (String name : featureNames) {
+                if (fMap.get(name) == null) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    protected void densify(List<String> featureList) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void densify(FeatureMap fMap) {
+    public void densify(FeatureMap fMap) {
         throw new UnsupportedOperationException();
     }
 

--- a/Core/src/main/java/org/tribuo/impl/ListExample.java
+++ b/Core/src/main/java/org/tribuo/impl/ListExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -229,6 +229,21 @@ public class ListExample<T extends Output<T>> extends Example<T> implements Seri
                 }
                 features.set(index,new Feature(e.getKey(),value));
             }
+        }
+    }
+
+    @Override
+    public boolean isDense(FeatureMap fMap) {
+        if (fMap.size() == size()) {
+            // We've got the right number of features
+            for (Feature feature : features) {
+                if (fMap.get(feature.getName()) == null) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/Core/src/main/java/org/tribuo/provenance/DatasetProvenance.java
+++ b/Core/src/main/java/org/tribuo/provenance/DatasetProvenance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.tribuo.Dataset;
 import org.tribuo.MutableDataset;
 import org.tribuo.Output;
 import org.tribuo.Tribuo;
+import org.tribuo.sequence.MutableSequenceDataset;
 import org.tribuo.sequence.SequenceDataset;
 
 import java.util.ArrayList;
@@ -77,7 +78,7 @@ public class DatasetProvenance implements DataProvenance, ObjectProvenance {
     }
 
     public <T extends Output<T>> DatasetProvenance(DataProvenance sourceProvenance, ListProvenance<ObjectProvenance> transformationProvenance, SequenceDataset<T> dataset) {
-        this(sourceProvenance,transformationProvenance,dataset.getClass().getName(),false,true,dataset.size(),dataset.getFeatureMap().size(),dataset.getOutputInfo().size());
+        this(sourceProvenance,transformationProvenance,dataset.getClass().getName(),dataset instanceof MutableSequenceDataset && ((MutableSequenceDataset<T>) dataset).isDense(),true,dataset.size(),dataset.getFeatureMap().size(),dataset.getOutputInfo().size());
     }
 
     protected DatasetProvenance(DataProvenance sourceProvenance, ListProvenance<ObjectProvenance> transformationProvenance, String datasetClassName, boolean isDense, boolean isSequence, int numExamples, int numFeatures, int numOutputs) {

--- a/Core/src/main/java/org/tribuo/sequence/IndependentSequenceModel.java
+++ b/Core/src/main/java/org/tribuo/sequence/IndependentSequenceModel.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.sequence;
+
+import com.oracle.labs.mlrg.olcut.util.Pair;
+import org.tribuo.Example;
+import org.tribuo.Model;
+import org.tribuo.Output;
+import org.tribuo.Prediction;
+import org.tribuo.provenance.ModelProvenance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * A SequenceModel which independently predicts each element of the sequence.
+ * @param <T> The output type.
+ */
+public class IndependentSequenceModel<T extends Output<T>> extends SequenceModel<T> {
+    private static final Logger logger = Logger.getLogger(IndependentSequenceModel.class.getName());
+    private static final long serialVersionUID = 1L;
+
+    private final Model<T> model;
+
+    IndependentSequenceModel(String name, ModelProvenance description, Model<T> model) {
+        super(name, description, model.getFeatureIDMap(), model.getOutputIDInfo());
+        this.model = model;
+    }
+
+    @Override
+    public List<Prediction<T>> predict(SequenceExample<T> example) {
+        List<Prediction<T>> output = new ArrayList<>();
+        for (Example<T> e : example) {
+            output.add(model.predict(e));
+        }
+        return output;
+    }
+
+    @Override
+    public Map<String, List<Pair<String, Double>>> getTopFeatures(int n) {
+        return model.getTopFeatures(n);
+    }
+}

--- a/Core/src/main/java/org/tribuo/sequence/IndependentSequenceTrainer.java
+++ b/Core/src/main/java/org/tribuo/sequence/IndependentSequenceTrainer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.sequence;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import org.tribuo.Dataset;
+import org.tribuo.Model;
+import org.tribuo.Output;
+import org.tribuo.Trainer;
+import org.tribuo.provenance.ModelProvenance;
+import org.tribuo.provenance.TrainerProvenance;
+import org.tribuo.provenance.impl.TrainerProvenanceImpl;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Trains a sequence model by training a regular model to independently predict every example in each sequence.
+ * @param <T> The output type.
+ */
+public class IndependentSequenceTrainer<T extends Output<T>> implements SequenceTrainer<T> {
+    private static final Logger logger = Logger.getLogger(IndependentSequenceTrainer.class.getName());
+
+    @Config(mandatory = true, description = "The trainer to use.")
+    private Trainer<T> innerTrainer;
+
+    private int trainInvocationCounter;
+
+    /**
+     * Builds a sequence trainer which uses a {@link Trainer} to independently predict each sequence element.
+     * @param innerTrainer The trainer to use.
+     */
+    public IndependentSequenceTrainer(Trainer<T> innerTrainer) {
+        this.innerTrainer = innerTrainer;
+    }
+
+    /**
+     * For olcut.
+     */
+    private IndependentSequenceTrainer() { }
+
+    @Override
+    public IndependentSequenceModel<T> train(SequenceDataset<T> sequenceExamples, Map<String, Provenance> runProvenance) {
+        if (sequenceExamples.getOutputInfo().getUnknownCount() > 0) {
+            throw new IllegalArgumentException("The supplied Dataset contained unknown Outputs, and this Trainer is supervised.");
+        }
+        // Generates the provenance and increments the trainInvocationCounter.
+        TrainerProvenance trainerProvenance;
+        synchronized (this) {
+            trainerProvenance = getProvenance();
+            trainInvocationCounter++;
+        }
+        Dataset<T> flatDataset = sequenceExamples.getFlatDataset();
+
+        logger.info(String.format("Training inner trainer with %d examples", flatDataset.size()));
+        Model<T> model = innerTrainer.train(flatDataset);
+
+        ModelProvenance provenance = new ModelProvenance(IndependentSequenceModel.class.getName(), OffsetDateTime.now(), sequenceExamples.getProvenance(), trainerProvenance, runProvenance);
+        return new IndependentSequenceModel<>("independent-sequence-model", provenance, model);
+    }
+
+    @Override
+    public int getInvocationCount() {
+        return trainInvocationCounter;
+    }
+
+    @Override
+    public String toString() {
+        return "IndependentSequenceTrainer(innerTrainer=" + innerTrainer.toString() + ")";
+    }
+
+    @Override
+    public TrainerProvenance getProvenance() {
+        return new TrainerProvenanceImpl(this);
+    }
+}

--- a/Core/src/main/java/org/tribuo/sequence/SequenceExample.java
+++ b/Core/src/main/java/org/tribuo/sequence/SequenceExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,6 +238,34 @@ public class SequenceExample<T extends Output<T>> implements Iterable<Example<T>
      */
     public Iterator<Feature> featureIterator() {
         return new FeatureIterator<>(iterator());
+    }
+
+    /**
+     * Is this sequence example dense wrt the supplied feature map.
+     * <p>
+     * A sequence example is "dense" if each example inside it contains all the features in the map,
+     * and only those features.
+     * @param fMap The feature map to check against.
+     * @return True if this sequence example contains only the features in the map, and all the features in the map.
+     */
+    public boolean isDense(FeatureMap fMap) {
+        for (Example<T> e : examples) {
+            if (!e.isDense(fMap)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Converts all implicit zeros into explicit zeros based on the supplied feature map.
+     * @param fMap The feature map to use for densification.
+     */
+    public void densify(FeatureMap fMap) {
+        // Densify! - guitar solo
+        for (Example<T> e : examples) {
+            e.densify(fMap);
+        }
     }
 
     /**

--- a/Core/src/main/java/org/tribuo/sequence/SequenceModel.java
+++ b/Core/src/main/java/org/tribuo/sequence/SequenceModel.java
@@ -33,8 +33,7 @@ import java.util.stream.Collectors;
 
 /**
  * A prediction model, which is used to predict outputs for unseen instances.
- * @param <T> the type of the outputs used to train the model. SequenceModel implementations
- * must be serializable!
+ * @param <T> the type of the outputs used to train the model.
  */
 public abstract class SequenceModel<T extends Output<T>> implements Provenancable<ModelProvenance>, Serializable {
     private static final long serialVersionUID = 1L;

--- a/Core/src/test/java/org/tribuo/test/Helpers.java
+++ b/Core/src/test/java/org/tribuo/test/Helpers.java
@@ -19,7 +19,9 @@ package org.tribuo.test;
 import org.junit.jupiter.api.Assertions;
 import org.tribuo.Example;
 import org.tribuo.Feature;
+import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.Model;
+import org.tribuo.MutableFeatureMap;
 import org.tribuo.Output;
 import org.tribuo.impl.ListExample;
 import org.tribuo.sequence.SequenceModel;
@@ -46,6 +48,19 @@ public final class Helpers {
     private static final Logger logger = Logger.getLogger(Helpers.class.getName());
 
     private Helpers() {}
+
+    /**
+     * Makes a feature map by observing each feature once with the value 1.0.
+     * @param features The feature names.
+     * @return An immutable feature map with all the features observed.
+     */
+    public static ImmutableFeatureMap mkFeatureMap(String... features) {
+        MutableFeatureMap fmap = new MutableFeatureMap();
+        for (String s : features) {
+            fmap.add(s,1.0);
+        }
+        return new ImmutableFeatureMap(fmap);
+    }
 
     public static Example<MockOutput> mkExample(MockOutput label, String... features) {
         Example<MockOutput> ex = new ListExample<>(label);

--- a/Core/src/test/java/org/tribuo/test/Helpers.java
+++ b/Core/src/test/java/org/tribuo/test/Helpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Math/src/main/java/org/tribuo/math/LinearParameters.java
+++ b/Math/src/main/java/org/tribuo/math/LinearParameters.java
@@ -20,7 +20,6 @@ import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.math.la.DenseMatrix;
 import org.tribuo.math.la.DenseSparseMatrix;
 import org.tribuo.math.la.SGDVector;
-import org.tribuo.math.la.SparseVector;
 import org.tribuo.math.la.Tensor;
 import org.tribuo.math.util.HeapMerger;
 import org.tribuo.math.util.Merger;
@@ -66,7 +65,7 @@ public class LinearParameters implements Parameters {
      * @param features The feature vector.
      * @return A {@link Tensor} array with a single {@link DenseSparseMatrix} containing all gradients.
      */
-    public Tensor[] gradients(Pair<Double, SGDVector> score, SparseVector features) {
+    public Tensor[] gradients(Pair<Double, SGDVector> score, SGDVector features) {
         Tensor[] output = new Tensor[1];
         output[0] = score.getB().outer(features);
         return output;

--- a/Math/src/main/java/org/tribuo/math/la/DenseVector.java
+++ b/Math/src/main/java/org/tribuo/math/la/DenseVector.java
@@ -331,7 +331,7 @@ public class DenseVector implements SGDVector {
         } else {
             // else must be sparse
             for (VectorTuple tuple : other) {
-                score += elements[tuple.index] * tuple.value;
+                score += get(tuple.index) * tuple.value;
             }
         }
         return score;
@@ -344,7 +344,7 @@ public class DenseVector implements SGDVector {
             DenseVector otherVec = (DenseVector) other;
             double[][] output = new double[elements.length][];
             for (int i = 0; i < elements.length; i++) {
-                DenseVector tmp = otherVec.scale(elements[i]);
+                DenseVector tmp = otherVec.scale(get(i));
                 output[i] = tmp.elements;
             }
             return new DenseMatrix(output);
@@ -353,7 +353,7 @@ public class DenseVector implements SGDVector {
             SparseVector otherVec = (SparseVector) other;
             SparseVector[] output = new SparseVector[elements.length];
             for (int i = 0; i < elements.length; i++) {
-                output[i] = otherVec.scale(elements[i]);
+                output[i] = otherVec.scale(get(i));
             }
             return new DenseSparseMatrix(output);
         } else {
@@ -365,7 +365,7 @@ public class DenseVector implements SGDVector {
     public double sum() {
         double sum = 0.0;
         for (int i = 0; i < elements.length; i++) {
-            sum += elements[i];
+            sum += get(i);
         }
         return sum;
     }
@@ -373,7 +373,7 @@ public class DenseVector implements SGDVector {
     public double sum(DoubleUnaryOperator f) {
         double sum = 0.0;
         for (int i = 0; i < elements.length; i++) {
-            sum += f.applyAsDouble(elements[i]);
+            sum += f.applyAsDouble(get(i));
         }
         return sum;
     }
@@ -382,7 +382,8 @@ public class DenseVector implements SGDVector {
     public double twoNorm() {
         double sum = 0.0;
         for (int i = 0; i < elements.length; i++) {
-            sum += elements[i] * elements[i];
+            double value = get(i);
+            sum += value * value;
         }
         return Math.sqrt(sum);
     }
@@ -391,7 +392,7 @@ public class DenseVector implements SGDVector {
     public double oneNorm() {
         double sum = 0.0;
         for (int i = 0; i < elements.length; i++) {
-            sum += Math.abs(elements[i]);
+            sum += Math.abs(get(i));
         }
         return sum;
     }
@@ -429,7 +430,7 @@ public class DenseVector implements SGDVector {
         int index = 0;
         double value = Double.NEGATIVE_INFINITY;
         for (int i = 0; i < elements.length; i++) {
-            double tmp = elements[i];
+            double tmp = get(i);
             if (tmp > value) {
                 index = i;
                 value = tmp;
@@ -442,7 +443,7 @@ public class DenseVector implements SGDVector {
     public double maxValue() {
         double value = Double.NEGATIVE_INFINITY;
         for (int i = 0; i < elements.length; i++) {
-            double tmp = elements[i];
+            double tmp = get(i);
             if (tmp > value) {
                 value = tmp;
             }
@@ -454,7 +455,7 @@ public class DenseVector implements SGDVector {
     public double minValue() {
         double value = Double.POSITIVE_INFINITY;
         for (int i = 0; i < elements.length; i++) {
-            double tmp = elements[i];
+            double tmp = get(i);
             if (tmp < value) {
                 value = tmp;
             }
@@ -489,7 +490,7 @@ public class DenseVector implements SGDVector {
         buffer.append(",values=[");
 
         for (int i = 0; i < elements.length; i++) {
-            buffer.append(elements[i]);
+            buffer.append(get(i));
             buffer.append(",");
         }
         buffer.setCharAt(buffer.length()-1,']');
@@ -502,7 +503,8 @@ public class DenseVector implements SGDVector {
     public double variance(double mean) {
         double variance = 0.0;
         for (int i = 0; i < elements.length; i++) {
-            variance += (elements[i] - mean) * (elements[i] - mean);
+            double value = get(i) - mean;
+            variance += value * value;
         }
         return variance;
     }
@@ -555,7 +557,7 @@ public class DenseVector implements SGDVector {
             double score = 0.0;
 
             for (int i = 0; i < elements.length; i++) {
-                double tmp = elements[i] - other.get(i);
+                double tmp = get(i) - other.get(i);
                 score += tmp * tmp;
             }
 
@@ -571,17 +573,19 @@ public class DenseVector implements SGDVector {
                 //after this loop, either itr is out or tuple.index >= otherTuple.index
                 while (i < elements.length && (i < otherTuple.index)) {
                     // as the other vector contains a zero.
-                    score += elements[i]*elements[i];
+                    double value = get(i);
+                    score += value*value;
                     i++;
                 }
                 if (i == otherTuple.index) {
-                    double tmp = elements[i] - otherTuple.value;
+                    double tmp = get(i) - otherTuple.value;
                     score += tmp * tmp;
                     i++;
                 }
             }
             for (; i < elements.length; i++) {
-                score += elements[i]*elements[i];
+                double value = get(i);
+                score += value*value;
             }
 
             return Math.sqrt(score);
@@ -603,7 +607,7 @@ public class DenseVector implements SGDVector {
             double score = 0.0;
 
             for (int i = 0; i < elements.length; i++) {
-                score += Math.abs(elements[i] - other.get(i));
+                score += Math.abs(get(i) - other.get(i));
             }
 
             return score;
@@ -618,16 +622,16 @@ public class DenseVector implements SGDVector {
                 //after this loop, either itr is out or tuple.index >= otherTuple.index
                 while (i < elements.length && (i < otherTuple.index)) {
                     // as the other vector contains a zero.
-                    score += Math.abs(elements[i]);
+                    score += Math.abs(get(i));
                     i++;
                 }
                 if (i == otherTuple.index) {
-                    score += Math.abs(elements[i] - otherTuple.value);
+                    score += Math.abs(get(i) - otherTuple.value);
                     i++;
                 }
             }
             for (; i < elements.length; i++) {
-                score += Math.abs(elements[i]);
+                score += Math.abs(get(i));
             }
 
             return score;

--- a/Math/src/main/java/org/tribuo/math/la/DenseVector.java
+++ b/Math/src/main/java/org/tribuo/math/la/DenseVector.java
@@ -59,7 +59,7 @@ public class DenseVector implements SGDVector {
     }
 
     /**
-     * Copy constructor, doesn't defensively copy the input as it's used internally.
+     * Copy constructor.
      * @param other The vector to copy.
      */
     protected DenseVector(DenseVector other) {
@@ -80,7 +80,8 @@ public class DenseVector implements SGDVector {
      * <p>
      * Used in training and inference.
      * <p>
-     * Throws {@link IllegalArgumentException} if the Example contains NaN-valued features.
+     * Throws {@link IllegalArgumentException} if the Example contains NaN-valued features or
+     * if no features in this Example are present in the feature map..
      * <p>
      * Unspecified features are set to zero.
      * @param example     The example to convert.
@@ -92,15 +93,20 @@ public class DenseVector implements SGDVector {
     public static <T extends Output<T>> DenseVector createDenseVector(Example<T> example, ImmutableFeatureMap featureInfo, boolean addBias) {
         int numFeatures = addBias ? featureInfo.size() + 1 : featureInfo.size();
         double[] values = new double[numFeatures];
+        boolean found = false;
         for (Feature f : example) {
             int index = featureInfo.getID(f.getName());
             // If it's a valid feature for this feature map.
             if (index != -1) {
                 values[index] = f.getValue();
+                found = true;
                 if (Double.isNaN(values[index])) {
                     throw new IllegalArgumentException("Example contained a NaN feature, " + f.toString());
                 }
             }
+        }
+        if (!found) {
+            throw new IllegalArgumentException("No features in this example were found in the feature map. Example - " + example.toString());
         }
         if (addBias) {
             values[numFeatures-1] = 1.0;

--- a/Math/src/main/java/org/tribuo/math/la/DenseVector.java
+++ b/Math/src/main/java/org/tribuo/math/la/DenseVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Math/src/main/java/org/tribuo/math/la/SparseVector.java
+++ b/Math/src/main/java/org/tribuo/math/la/SparseVector.java
@@ -564,7 +564,26 @@ public class SparseVector implements SGDVector {
             //TODO this is suboptimal if there are lots of missing rows.
             return new DenseSparseMatrix(output);
         } else if (other instanceof DenseVector) {
-            throw new IllegalArgumentException("sparse.outer(dense) is currently not implemented.");
+            //Outer product is a DenseMatrix because DenseSparseMatrix is the wrong way around.
+            DenseVector otherVec = (DenseVector) other;
+            int otherSize = otherVec.size();
+            double[][] output = new double[size][];
+            int i = 0;
+            for (VectorTuple tuple : this) {
+                while (i < tuple.index) {
+                    output[i] = new double[otherSize];
+                    i++;
+                }
+                DenseVector tmp = otherVec.scale(tuple.value);
+                output[tuple.index] = tmp.elements;
+                i++;
+            }
+            while (i < output.length) {
+                output[i] = new double[otherSize];
+                i++;
+            }
+            //TODO this is also suboptimal if there are lots of missing rows.
+            return new DenseMatrix(output);
         } else {
             throw new IllegalArgumentException("Unknown vector subclass " + other.getClass().getCanonicalName() + " for input");
         }

--- a/Math/src/main/java/org/tribuo/math/optimisers/AdaGradRDA.java
+++ b/Math/src/main/java/org/tribuo/math/optimisers/AdaGradRDA.java
@@ -69,7 +69,7 @@ public class AdaGradRDA implements StochasticGradientOptimiser {
     @Config(description="Number of examples to scale the l1 and l2 penalties by.")
     private int numExamples = 1;
 
-    private Parameters parameters;
+    private Parameters parameters = null;
 
     public AdaGradRDA(double initialLearningRate, double epsilon, double l1, double l2, int numExamples) {
         this.initialLearningRate = initialLearningRate;
@@ -134,7 +134,9 @@ public class AdaGradRDA implements StochasticGradientOptimiser {
     }
 
     @Override
-    public void reset() { }
+    public void reset() {
+        parameters = null;
+    }
 
     @Override
     public AdaGradRDA copy() {

--- a/Math/src/main/java/org/tribuo/math/optimisers/Pegasos.java
+++ b/Math/src/main/java/org/tribuo/math/optimisers/Pegasos.java
@@ -116,6 +116,7 @@ public class Pegasos implements StochasticGradientOptimiser {
 
     @Override
     public void reset() {
+        parameters = null;
         iteration = 1;
     }
 

--- a/Math/src/test/java/org/tribuo/math/la/DenseVectorTest.java
+++ b/Math/src/test/java/org/tribuo/math/la/DenseVectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/baseline/BinaryExample.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/baseline/BinaryExample.java
@@ -35,9 +35,15 @@ import java.util.logging.Logger;
 class BinaryExample extends Example<Label> {
     private static final Logger logger = Logger.getLogger(BinaryExample.class.getName());
 
-    private Example<MultiLabel> innerExample;
+    private final Example<MultiLabel> innerExample;
 
-    public BinaryExample(Example<MultiLabel> innerExample, Label newLabel) {
+    /**
+     * Creates a BinaryExample, which wraps a MultiLabel example and
+     * has a single Label inside.
+     * @param innerExample The example to wrap.
+     * @param newLabel The new Label.
+     */
+    BinaryExample(Example<MultiLabel> innerExample, Label newLabel) {
         super(newLabel);
         this.innerExample = innerExample;
     }
@@ -75,6 +81,11 @@ class BinaryExample extends Example<Label> {
     @Override
     public boolean validateExample() {
         return innerExample.validateExample();
+    }
+
+    @Override
+    public boolean isDense(FeatureMap fMap) {
+        return innerExample.isDense(fMap);
     }
 
     @Override


### PR DESCRIPTION
### Description
This PR adds support for dense feature vectors to the CRF trainer/model and the linear SGD trainer/model. The CRF & linear model only use dense feature vectors if the example is truly dense (i.e. it contains a feature for each entry in the model or dataset's feature map). At some point in the future we could make this a model/trainer parameter, as the dense representation is probably faster at the cost of additional memory in spaces which are moderately sparse. We should do some benchmarking to find a reasonable point to make the default if we do this change.

To support the CRF and linear model change then there were additional methods implemented in the `org.tribuo.math.la` package, along with extra cases inside those methods. Additionally the `ModelProvenance` now correctly tracks if the dataset was dense, and the dataset better understands if it is dense (rather than only assuming it is dense if it had `densify` called on it). Only `MutableDataset` and `MutableSequenceDataset` know if they are dense or not, we should probably move this check onto `Dataset` and `SequenceDataset` so immutable views can be considered dense, but the nature of the views mean this is a little more complicated to check.

Several classes were added to various sequence packages to build them out for further testing. The main ones are an `IndependentSequenceTrainer` and an `IndependentSequenceModel` which wrap a regular `Trainer`/`Model` and use it to make independent predictions for each element of the sequence. There is also a more useful sequence train test harness for comparing different sequence models (and a small fix for `ViterbiTrainer` which was not compatible with the configuration system).

### Motivation
Working with a dense feature space (e.g. an embedding vector space) is many times faster than treating the dense space as if it is sparse with the associated indirection on all the linear algebra operations. This greatly improves the speed of the CRF operating over embedding vectors, and of the linear model when operating on dense spaces. The output of the two systems is identical.

This density optimisation opens the path for further speedups either by making Tribuo's la package more amenable to autovectorisation, or by explicitly vectorising it using the Vector API in Java 16.