### PR TITLE
Adds support for standardising regression values in LibSVM

### DIFF
--- a/Core/src/main/java/org/tribuo/util/HTMLOutput.java
+++ b/Core/src/main/java/org/tribuo/util/HTMLOutput.java
@@ -32,6 +32,11 @@ public final class HTMLOutput {
 
     private HTMLOutput() { }
 
+    /**
+     * Formats a pair as a HTML table entry.
+     * @param p The pair to format.
+     * @return A string containing the HTML representation of the input.
+     */
     public static String toHTML(Pair<String, Double> p) {
         String cleanName = p.getA().replace("&", "&amp;")
                 .replace("<", "&lt;")
@@ -41,6 +46,12 @@ public final class HTMLOutput {
                 cleanName, p.getB());
     }
 
+    /**
+     * Formats a feature ranking as a HTML table.
+     * @param m The ranking to format.
+     * @param keys The classes to format.
+     * @param s The stream to write to.
+     */
     public static void printFeatureMap(Map<String, List<Pair<String, Double>>> m, List<String> keys, PrintStream s) {
         List<String> realKeys = new ArrayList<>(keys);
         realKeys.add(Model.ALL_OUTPUTS);

--- a/Core/src/main/java/org/tribuo/util/IntDoublePair.java
+++ b/Core/src/main/java/org/tribuo/util/IntDoublePair.java
@@ -17,15 +17,28 @@
 package org.tribuo.util;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * A Pair of a primitive int and a primitive double.
  */
 public final class IntDoublePair {
 
+    /**
+     * The key.
+     */
     public final int index;
+
+    /**
+     * The value.
+     */
     public final double value;
 
+    /**
+     * Constructs a tuple out of an int and a double.
+     * @param index The int.
+     * @param value The double
+     */
     public IntDoublePair(int index, double value) {
         this.index = index;
         this.value = value;
@@ -53,6 +66,20 @@ public final class IntDoublePair {
      */
     public static Comparator<IntDoublePair> pairDescendingValueComparator() {
         return (IntDoublePair a, IntDoublePair b) -> Double.compare(Math.abs(b.value), Math.abs(a.value));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IntDoublePair that = (IntDoublePair) o;
+        return index == that.index &&
+                Double.compare(that.value, value) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, value);
     }
 
     @Override

--- a/Core/src/main/java/org/tribuo/util/MeanVarianceAccumulator.java
+++ b/Core/src/main/java/org/tribuo/util/MeanVarianceAccumulator.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tribuo.util;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * An accumulator for online calculation of the mean and variance of a
+ * stream of doubles.
+ * <p>
+ * Note this class is not thread safe.
+ */
+public final class MeanVarianceAccumulator implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private double max = Double.NEGATIVE_INFINITY;
+    private double min = Double.POSITIVE_INFINITY;
+
+    private double mean = 0.0;
+    private double sumSquares = 0.0;
+
+    private long count = 0;
+
+    /**
+     * Constructs an empty mean/variance accumulator.
+     */
+    public MeanVarianceAccumulator() {}
+
+    /**
+     * Constructs a mean/variance accumulator and observes the supplied array.
+     * @param values The array to operate on.
+     */
+    public MeanVarianceAccumulator(double[] values) {
+        observe(values);
+    }
+
+    /**
+     * Copy constructor.
+     * @param other The MeanVarianceAccumulator to copy.
+     */
+    public MeanVarianceAccumulator(MeanVarianceAccumulator other) {
+        this.max = other.max;
+        this.min = other.min;
+        this.mean = other.mean;
+        this.sumSquares = other.sumSquares;
+        this.count = other.count;
+    }
+
+    /**
+     * Resets this accumulator to the starting state.
+     */
+    public void reset() {
+        this.max = Double.NEGATIVE_INFINITY;
+        this.min = Double.POSITIVE_INFINITY;
+        this.mean = 0;
+        this.sumSquares = 0;
+        this.count = 0;
+    }
+
+    /**
+     * Observes a value, i.e. updates the mean, variance, max and min statistics.
+     * @param value The value to observe.
+     */
+    public void observe(double value) {
+        if (value < min) {
+            min = value;
+        }
+        if (value > max) {
+            max = value;
+        }
+        count++;
+        double delta = value - mean;
+        mean += delta / count;
+        double delta2 = value - mean;
+        sumSquares += delta * delta2;
+    }
+
+    /**
+     * Observes an array of values, i.e. updates the mean, variance, max and min statistics.
+     * @param values The values to observe.
+     */
+    public void observe(double[] values) {
+        for (int i = 0; i < values.length; i++) {
+            observe(values[i]);
+        }
+    }
+
+    /**
+     * Gets the minimum observed value.
+     * @return The minimum value.
+     */
+    public double getMin() {
+        return min;
+    }
+
+    /**
+     * Gets the maximum observed value.
+     * @return The maximum value.
+     */
+    public double getMax() {
+        return max;
+    }
+
+    /**
+     * Gets the sample mean.
+     * @return The sample mean.
+     */
+    public double getMean() {
+        return mean;
+    }
+
+    /**
+     * Gets the sample variance.
+     * @return The sample variance.
+     */
+    public double getVariance() {
+        return sumSquares / (count-1);
+    }
+
+    /**
+     * Gets the observation count.
+     * @return The observation count.
+     */
+    public long getCount() {
+        return count;
+    }
+
+    /**
+     * Gets the sample standard deviation.
+     * @return The sample standard deviation.
+     */
+    public double getStdDev() {
+        return Math.sqrt(getVariance());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MeanVarianceAccumulator that = (MeanVarianceAccumulator) o;
+        return Double.compare(that.max, max) == 0 &&
+                Double.compare(that.min, min) == 0 &&
+                Double.compare(that.mean, mean) == 0 &&
+                Double.compare(that.sumSquares, sumSquares) == 0 &&
+                count == that.count;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(max, min, mean, sumSquares, count);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Variable(count=%d,max=%f,min=%f,mean=%f,variance=%f)",count,max,min,mean,getVariance());
+    }
+}

--- a/Core/src/main/java/org/tribuo/util/MeanVarianceAccumulator.java
+++ b/Core/src/main/java/org/tribuo/util/MeanVarianceAccumulator.java
@@ -72,7 +72,7 @@ public final class MeanVarianceAccumulator implements Serializable {
     }
 
     /**
-     * Observes a value, i.e. updates the mean, variance, max and min statistics.
+     * Observes a value, i.e., updates the sufficient statistics for computing mean, variance, max and min.
      * @param value The value to observe.
      */
     public void observe(double value) {
@@ -90,7 +90,7 @@ public final class MeanVarianceAccumulator implements Serializable {
     }
 
     /**
-     * Observes an array of values, i.e. updates the mean, variance, max and min statistics.
+     * Observes a value, i.e., updates the sufficient statistics for computing mean, variance, max and min.
      * @param values The values to observe.
      */
     public void observe(double[] values) {
@@ -166,6 +166,25 @@ public final class MeanVarianceAccumulator implements Serializable {
 
     @Override
     public String toString() {
-        return String.format("Variable(count=%d,max=%f,min=%f,mean=%f,variance=%f)",count,max,min,mean,getVariance());
+        return String.format("MeanVarianceAccumulator(count=%d,max=%f,min=%f,mean=%f,variance=%f)",count,max,min,mean,getVariance());
+    }
+
+    /**
+     * Standardizes the input using the computed mean and variance in this accumulator.
+     * Standardization means subtracting the mean and dividing by the variance.
+     * @param input The input to standardize.
+     * @return The standardized input.
+     */
+    public double[] standardize(double[] input) {
+        return Util.standardize(input,getMean(),getVariance());
+    }
+
+    /**
+     * Standardizes the input using the computed mean and variance in this accumulator.
+     * Standardization means subtracting the mean and dividing by the variance.
+     * @param input The input to standardize.
+     */
+    public void standardizeInPlace(double[] input) {
+        Util.standardizeInPlace(input,getMean(),getVariance());
     }
 }

--- a/Core/src/main/java/org/tribuo/util/Util.java
+++ b/Core/src/main/java/org/tribuo/util/Util.java
@@ -1055,4 +1055,36 @@ public final class Util {
         return diffIndicesList.stream().mapToInt(Integer::intValue).toArray();
     }
 
+    /**
+     * Standardizes the input, i.e. divides it by the variance and subtracts the mean.
+     * @param input The input to standardize.
+     * @param mean The mean.
+     * @param variance The variance.
+     * @return The standardized input.
+     */
+    public static double[] standardize(double[] input, double mean, double variance) {
+        if (variance <= 0.0) {
+            throw new IllegalArgumentException("Variance must be positive, found " + variance);
+        }
+        double[] output = new double[input.length];
+        for (int i = 0; i < input.length; i++) {
+            output[i] = (input[i] - mean) / variance;
+        }
+        return output;
+    }
+
+    /**
+     * Standardizes the input, i.e. divides it by the variance and subtracts the mean.
+     * @param input The input to standardize.
+     * @param mean The mean.
+     * @param variance The variance.
+     */
+    public static void standardizeInPlace(double[] input, double mean, double variance) {
+        if (variance <= 0.0) {
+            throw new IllegalArgumentException("Variance must be positive, found " + variance);
+        }
+        for (int i = 0; i < input.length; i++) {
+            input[i] = (input[i] - mean) / variance;
+        }
+    }
 }

--- a/Core/src/main/java/org/tribuo/util/Util.java
+++ b/Core/src/main/java/org/tribuo/util/Util.java
@@ -191,6 +191,21 @@ public final class Util {
     }
 
     /**
+     * Shuffles the input.
+     * @param input The array to shuffle.
+     * @param rng The random number generator to use.
+     */
+    public static void randpermInPlace(double[] input, SplittableRandom rng) {
+        // Shuffle array
+        for (int i = input.length; i > 1; i--) {
+            int j = rng.nextInt(i);
+            double tmp = input[i-1];
+            input[i-1] = input[j];
+            input[j] = tmp;
+        }
+    }
+
+    /**
      * Draws a bootstrap sample of indices.
      * @param size Size of the sample to generate.
      * @param rng The RNG to use.

--- a/Core/src/main/java/org/tribuo/util/Util.java
+++ b/Core/src/main/java/org/tribuo/util/Util.java
@@ -1056,7 +1056,7 @@ public final class Util {
     }
 
     /**
-     * Standardizes the input, i.e. divides it by the variance and subtracts the mean.
+     * Standardizes the input so it has zero mean and unit variance, i.e., subtracts the mean and divides by the variance.
      * @param input The input to standardize.
      * @param mean The mean.
      * @param variance The variance.
@@ -1074,7 +1074,8 @@ public final class Util {
     }
 
     /**
-     * Standardizes the input, i.e. divides it by the variance and subtracts the mean.
+     * Standardizes the input so it has zero mean and unit variance, i.e., subtracts the mean and divides by the variance.
+     * Operates in place on the input array.
      * @param input The input to standardize.
      * @param mean The mean.
      * @param variance The variance.

--- a/Core/src/test/java/org/tribuo/util/MeanVarianceAccumulatorTest.java
+++ b/Core/src/test/java/org/tribuo/util/MeanVarianceAccumulatorTest.java
@@ -1,0 +1,77 @@
+package org.tribuo.util;
+
+import com.oracle.labs.mlrg.olcut.util.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.tribuo.Trainer;
+
+import java.util.SplittableRandom;
+
+public class MeanVarianceAccumulatorTest {
+
+    private static final double DELTA = 1e-14;
+
+    @Test
+    public void testDifferentMethods() {
+        double[] values = new double[] {1, -2, 3, -4, 5, -5, 4, -3, 2, -1};
+
+        MeanVarianceAccumulator zeroed = new MeanVarianceAccumulator();
+        for (int i = 0; i < values.length; i++) {
+            zeroed.observe(values[i]);
+        }
+
+        MeanVarianceAccumulator zeroedObserveArray = new MeanVarianceAccumulator();
+        zeroedObserveArray.observe(values);
+
+        MeanVarianceAccumulator observed = new MeanVarianceAccumulator(values);
+
+        // Test ordering
+        Assertions.assertEquals(observed,zeroed);
+        Assertions.assertEquals(zeroed,zeroedObserveArray);
+
+        // Test outputs
+        Assertions.assertEquals(0.0,zeroed.getMean(), DELTA);
+        Assertions.assertEquals(5,zeroed.getMax(), DELTA);
+        Assertions.assertEquals(-5,zeroed.getMin(), DELTA);
+    }
+
+    @Test
+    public void testDifferentOrder() {
+        double[] values = new double[] {1, -2, 3, -4, 5, -5, 4, -3, 2, -1};
+
+        MeanVarianceAccumulator base = new MeanVarianceAccumulator(values);
+
+        SplittableRandom rng = new SplittableRandom(Trainer.DEFAULT_SEED);
+
+        for (int i = 0; i < 100; i++) {
+            Util.randpermInPlace(values,rng);
+            MeanVarianceAccumulator shuffled = new MeanVarianceAccumulator(values);
+            Assertions.assertEquals(base.getMin(),shuffled.getMin(),DELTA);
+            Assertions.assertEquals(base.getMax(),shuffled.getMax(),DELTA);
+            Assertions.assertEquals(base.getMean(),shuffled.getMean(),DELTA);
+            Assertions.assertEquals(base.getVariance(),shuffled.getVariance(),DELTA);
+            Assertions.assertEquals(base.getCount(),shuffled.getCount(),DELTA);
+        }
+    }
+
+    @Test
+    public void testRandomized() {
+        SplittableRandom rng = new SplittableRandom(Trainer.DEFAULT_SEED);
+
+        double[] values = new double[4096];
+
+        for (int i = 0; i < values.length; i++) {
+            values[i] = rng.nextDouble();
+        }
+
+        MeanVarianceAccumulator accumulator = new MeanVarianceAccumulator(values);
+
+        double mean = Util.mean(values);
+        Assertions.assertEquals(mean,accumulator.getMean(), DELTA);
+
+        Pair<Double, Double> meanVarPair = Util.meanAndVariance(values);
+        Assertions.assertEquals(meanVarPair.getA(),accumulator.getMean(), DELTA);
+        Assertions.assertEquals(meanVarPair.getB(),accumulator.getVariance(), DELTA);
+    }
+
+}

--- a/Data/src/main/java/org/tribuo/data/CompletelyConfigurableTrainTest.java
+++ b/Data/src/main/java/org/tribuo/data/CompletelyConfigurableTrainTest.java
@@ -60,10 +60,10 @@ public final class CompletelyConfigurableTrainTest {
         @Option(charName='f',longName="model-output-path",usage="Path to serialize model to.")
         public Path outputPath;
 
-        @Option(charName='u',longName="train-source",usage="Load the training DataSource from the config file. Overrides the training path.")
+        @Option(charName='u',longName="train-source",usage="Load the training DataSource from the config file.")
         public ConfigurableDataSource<?> trainSource;
 
-        @Option(charName='v',longName="test-source",usage="Load the testing DataSource from the config file. Overrides the testing path.")
+        @Option(charName='v',longName="test-source",usage="Load the testing DataSource from the config file.")
         public ConfigurableDataSource<?> testSource;
 
         @Option(charName='t',longName="trainer",usage="Load a trainer from the config file.")

--- a/Regression/Core/config/example-datasource-config.xml
+++ b/Regression/Core/config/example-datasource-config.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+    Description:
+        An example configuration file for the example data generators used to test out regression models.
+-->
+<config>
+    <component name="single-gauss-train" type="org.tribuo.regression.example.GaussianDataSource">
+        <property name="numSamples" value="1000"/>
+        <property name="slope" value="5.0"/>
+        <property name="intercept" value="0.0"/>
+        <property name="variance" value="1.0"/>
+        <property name="xMin" value="-5.0"/>
+        <property name="xMax" value="5.0"/>
+        <property name="seed" value="1234"/>
+    </component>
+
+    <component name="single-gauss-test" type="org.tribuo.regression.example.GaussianDataSource"
+               inherit="single-gauss-train">
+        <property name="seed" value="4"/>
+    </component>
+
+    <component name="multi-gauss-train" type="org.tribuo.regression.example.NonlinearGaussianDataSource">
+        <property name="numSamples" value="1000"/>
+        <propertylist name="weights">
+            <item>1.0</item>
+            <item>1.0</item>
+            <item>1.0</item>
+            <item>1.0</item>
+        </propertylist>
+        <property name="intercept" value="0.0"/>
+        <property name="variance" value="1.0"/>
+        <property name="xZeroMin" value="-5.0"/>
+        <property name="xZeroMax" value="5.0"/>
+        <property name="xOneMin" value="-3.0"/>
+        <property name="xOneMax" value="3.0"/>
+        <property name="seed" value="1234"/>
+    </component>
+
+    <component name="multi-gauss-test" type="org.tribuo.regression.example.NonlinearGaussianDataSource"
+               inherit="multi-gauss-train">
+        <property name="seed" value="4"/>
+    </component>
+
+    <component name="non-uniform-multi-gauss-train" type="org.tribuo.regression.example.NonlinearGaussianDataSource">
+        <property name="numSamples" value="1000"/>
+        <propertylist name="weights">
+            <item>4.0</item>
+            <item>-5.0</item>
+            <item>10.0</item>
+            <item>1.0</item>
+        </propertylist>
+        <property name="intercept" value="0.0"/>
+        <property name="variance" value="1.0"/>
+        <property name="xZeroMin" value="-5.0"/>
+        <property name="xZeroMax" value="5.0"/>
+        <property name="xOneMin" value="-3.0"/>
+        <property name="xOneMax" value="3.0"/>
+        <property name="seed" value="1234"/>
+    </component>
+
+    <component name="non-uniform-multi-gauss-test" type="org.tribuo.regression.example.NonlinearGaussianDataSource"
+               inherit="non-uniform-multi-gauss-train">
+        <property name="seed" value="4"/>
+    </component>
+</config>

--- a/Regression/Core/src/main/java/org/tribuo/regression/ImmutableRegressionInfo.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/ImmutableRegressionInfo.java
@@ -150,7 +150,7 @@ public class ImmutableRegressionInfo extends RegressionInfo implements Immutable
         for (Map.Entry<String,MutableLong> e : countMap.entrySet()) {
             String name = e.getKey();
             long count = e.getValue().longValue();
-            builder.append(String.format("{name=%s,id=%d,count=%d,maxMap=%f,min=%f,mean=%f,variance=%f},",
+            builder.append(String.format("{name=%s,id=%d,count=%d,max=%f,min=%f,mean=%f,variance=%f},",
                     name,
                     labelIDMap.get(name),
                     count,

--- a/Regression/Core/src/main/java/org/tribuo/regression/MutableRegressionInfo.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/MutableRegressionInfo.java
@@ -101,7 +101,7 @@ public class MutableRegressionInfo extends RegressionInfo implements MutableOutp
         for (Map.Entry<String,MutableLong> e : countMap.entrySet()) {
             String name = e.getKey();
             long count = e.getValue().longValue();
-            builder.append(String.format("{name=%s,count=%d,maxMap=%f,min=%f,mean=%f,variance=%f},",
+            builder.append(String.format("{name=%s,count=%d,max=%f,min=%f,mean=%f,variance=%f},",
                     name,
                     count,
                     maxMap.get(name).doubleValue(),

--- a/Regression/Core/src/main/java/org/tribuo/regression/evaluation/RegressionEvaluationImpl.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/evaluation/RegressionEvaluationImpl.java
@@ -124,8 +124,24 @@ final class RegressionEvaluationImpl implements RegressionEvaluation {
 
     @Override
     public String toString() {
-        return "Multi-dimensional Regression Evaluation\nRMSE = " + rmse() + "\nMean Absolute Error = " + mae() +
-                "\nR^2 = " + r2() + "\nexplained variance = " + explainedVariance();
+        return "Multi-dimensional Regression Evaluation\nRMSE = " + convertKeys(rmse()) + "\nMean Absolute Error = " + convertKeys(mae()) +
+                "\nR^2 = " + convertKeys(r2()) + "\nexplained variance = " + convertKeys(explainedVariance());
+    }
+
+    /**
+     * The default toString on DimensionTuple emits the regressors minimum value.
+     * This tidies it up by using the name as the key.
+     * @param map The map to tidy.
+     * @return A map with the dimension names as keys.
+     */
+    private static Map<String, Double> convertKeys(Map<Regressor, Double> map) {
+        Map<String, Double> outputMap = new HashMap<>(map.size());
+
+        for (Map.Entry<Regressor, Double> e : map.entrySet()) {
+            outputMap.put(e.getKey().getDimensionNamesString(),e.getValue());
+        }
+
+        return outputMap;
     }
 
     private double get(MetricTarget<Regressor> target, RegressionMetrics metric) {

--- a/Regression/Core/src/main/java/org/tribuo/regression/example/GaussianDataSource.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/example/GaussianDataSource.java
@@ -54,10 +54,10 @@ public class GaussianDataSource implements ConfigurableDataSource<Regressor> {
     private int numSamples;
 
     @Config
-    private float slope;
+    private float slope = 0.0f;
 
     @Config
-    private float intercept;
+    private float intercept = 0.0f;
 
     @Config
     private float variance = 1.0f;

--- a/Regression/Core/src/main/java/org/tribuo/regression/example/GaussianDataSource.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/example/GaussianDataSource.java
@@ -50,25 +50,25 @@ import java.util.Random;
  * Set slope to zero to draw from a gaussian.
  */
 public class GaussianDataSource implements ConfigurableDataSource<Regressor> {
-    @Config(mandatory=true)
+    @Config(mandatory=true,description = "The number of samples to draw.")
     private int numSamples;
 
-    @Config
+    @Config(description="The slope of the line.")
     private float slope = 0.0f;
 
-    @Config
+    @Config(description="The y-intercept of the line.")
     private float intercept = 0.0f;
 
-    @Config
+    @Config(description="The variance of the gaussian.")
     private float variance = 1.0f;
 
-    @Config(mandatory=true)
+    @Config(mandatory=true,description="The minimum feature value.")
     private float xMin;
 
-    @Config(mandatory=true)
+    @Config(mandatory=true,description="The maximum feature value.")
     private float xMax;
 
-    @Config
+    @Config(description="The RNG seed.")
     private long seed = Trainer.DEFAULT_SEED;
 
     private List<Example<Regressor>> examples;
@@ -110,6 +110,7 @@ public class GaussianDataSource implements ConfigurableDataSource<Regressor> {
      */
     @Override
     public void postConfig() {
+        // We use java.util.Random here because SplittableRandom doesn't have nextGaussian yet.
         Random rng = new Random(seed);
         List<Example<Regressor>> examples = new ArrayList<>(numSamples);
         if (xMax <= xMin) {

--- a/Regression/Core/src/main/java/org/tribuo/regression/example/NonlinearGaussianDataSource.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/example/NonlinearGaussianDataSource.java
@@ -44,36 +44,36 @@ import java.util.Random;
 
 /**
  * Generates a single dimensional output drawn from
- * N(w_0*x_0 - w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
+ * N(w_0*x_0 + w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
  * <p>
  * The features are drawn from a uniform distribution over the range.
  */
 public class NonlinearGaussianDataSource implements ConfigurableDataSource<Regressor> {
-    @Config(mandatory=true)
+    @Config(mandatory=true,description = "The number of samples to draw.")
     private int numSamples;
 
-    @Config
+    @Config(description = "The feature weights. Must be a 4 element array.")
     private float[] weights = new float[]{1.0f,1.0f,1.0f,1.0f};
 
-    @Config
+    @Config(description="The y-intercept of the line.")
     private float intercept = 0.0f;
 
-    @Config
+    @Config(description="The variance of the noise gaussian.")
     private float variance = 1.0f;
 
-    @Config
+    @Config(description = "The minimum value of x_0.")
     private float xZeroMin = -2.0f;
 
-    @Config
+    @Config(description = "The maximum value of x_0.")
     private float xZeroMax = 2.0f;
 
-    @Config
+    @Config(description = "The minimum value of x_1.")
     private float xOneMin = -2.0f;
 
-    @Config
+    @Config(description = "The maximum value of x_1.")
     private float xOneMax = 2.0f;
 
-    @Config
+    @Config(description="The RNG seed.")
     private long seed = Trainer.DEFAULT_SEED;
 
     private List<Example<Regressor>> examples;
@@ -89,7 +89,7 @@ public class NonlinearGaussianDataSource implements ConfigurableDataSource<Regre
 
     /**
      * Generates a single dimensional output drawn from
-     * N(w_0*x_0 - w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
+     * N(w_0*x_0 + w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
      * <p>
      * The features are drawn from a uniform distribution over the range.
      * @param numSamples The size of the output dataset.
@@ -122,6 +122,7 @@ public class NonlinearGaussianDataSource implements ConfigurableDataSource<Regre
      */
     @Override
     public void postConfig() {
+        // We use java.util.Random here because SplittableRandom doesn't have nextGaussian yet.
         Random rng = new Random(seed);
         if (weights.length != 4) {
             throw new PropertyException("","weights","Must supply 4 weights, found " + weights.length);
@@ -141,7 +142,7 @@ public class NonlinearGaussianDataSource implements ConfigurableDataSource<Regre
         for (int i = 0; i < numSamples; i++) {
             double xZero = (rng.nextDouble() * zeroRange) + xZeroMin;
             double xOne = (rng.nextDouble() * oneRange) + xOneMin;
-            // N(w_0*x_0 - w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
+            // N(w_0*x_0 + w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
             double outputValue = (weights[0] * xZero) + (weights[1]*xOne) + (weights[2]*xZero*xOne) + (weights[3]*Math.pow(xOne,3)) + intercept;
             Regressor output = new Regressor("Y",(rng.nextGaussian() * variance) + outputValue);
             ArrayExample<Regressor> e = new ArrayExample<>(output,featureNames,new double[]{xZero,xOne});

--- a/Regression/Core/src/main/java/org/tribuo/regression/example/NonlinearGaussianDataSource.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/example/NonlinearGaussianDataSource.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.regression.example;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
+import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import com.oracle.labs.mlrg.olcut.provenance.impl.SkeletalConfiguredObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
+import org.tribuo.ConfigurableDataSource;
+import org.tribuo.Dataset;
+import org.tribuo.Example;
+import org.tribuo.MutableDataset;
+import org.tribuo.OutputFactory;
+import org.tribuo.Trainer;
+import org.tribuo.impl.ArrayExample;
+import org.tribuo.provenance.ConfiguredDataSourceProvenance;
+import org.tribuo.provenance.DataSourceProvenance;
+import org.tribuo.regression.RegressionFactory;
+import org.tribuo.regression.Regressor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Generates a single dimensional output drawn from
+ * N(w_0*x_0 - w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
+ * <p>
+ * The features are drawn from a uniform distribution over the range.
+ */
+public class NonlinearGaussianDataSource implements ConfigurableDataSource<Regressor> {
+    @Config(mandatory=true)
+    private int numSamples;
+
+    @Config
+    private float[] weights = new float[]{1.0f,1.0f,1.0f,1.0f};
+
+    @Config
+    private float intercept = 0.0f;
+
+    @Config
+    private float variance = 1.0f;
+
+    @Config
+    private float xZeroMin = -2.0f;
+
+    @Config
+    private float xZeroMax = 2.0f;
+
+    @Config
+    private float xOneMin = -2.0f;
+
+    @Config
+    private float xOneMax = 2.0f;
+
+    @Config
+    private long seed = Trainer.DEFAULT_SEED;
+
+    private List<Example<Regressor>> examples;
+
+    private final RegressionFactory factory = new RegressionFactory();
+
+    private static final String[] featureNames = new String[]{"X_0","X_1"};
+
+    /**
+     * For OLCUT
+     */
+    private NonlinearGaussianDataSource() {}
+
+    /**
+     * Generates a single dimensional output drawn from
+     * N(w_0*x_0 - w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
+     * <p>
+     * The features are drawn from a uniform distribution over the range.
+     * @param numSamples The size of the output dataset.
+     * @param weights The feature weights.
+     * @param intercept The y intercept of the line.
+     * @param variance The variance of the gaussian.
+     * @param xZeroMin The minimum x_0 value (inclusive).
+     * @param xZeroMax The maximum x_0 value (exclusive).
+     * @param xOneMin The minimum x_1 value (inclusive).
+     * @param xOneMax The maximum x_1 value (exclusive).
+     * @param seed The rng seed to use.
+     */
+    public NonlinearGaussianDataSource(int numSamples, float[] weights, float intercept, float variance,
+                                       float xZeroMin, float xZeroMax, float xOneMin, float xOneMax,
+                                       long seed) {
+        this.numSamples = numSamples;
+        this.weights = weights;
+        this.intercept = intercept;
+        this.variance = variance;
+        this.xZeroMin = xZeroMin;
+        this.xZeroMax = xZeroMax;
+        this.xOneMin = xOneMin;
+        this.xOneMax = xOneMax;
+        this.seed = seed;
+        postConfig();
+    }
+
+    /**
+     * Used by the OLCUT configuration system, and should not be called by external code.
+     */
+    @Override
+    public void postConfig() {
+        Random rng = new Random(seed);
+        if (weights.length != 4) {
+            throw new PropertyException("","weights","Must supply 4 weights, found " + weights.length);
+        }
+        if (xZeroMax <= xZeroMin) {
+            throw new PropertyException("","xZeroMax","xZeroMax must be greater than xZeroMin, found xZeroMax = " + xZeroMax + ", xZeroMin = " + xZeroMin);
+        }
+        if (xOneMax <= xOneMin) {
+            throw new PropertyException("","xOneMax","xOneMax must be greater than xOneMin, found xOneMax = " + xOneMax + ", xOneMin = " + xOneMin);
+        }
+        if (variance <= 0.0) {
+            throw new PropertyException("","variance","Variance must be positive, found variance = " + variance);
+        }
+        List<Example<Regressor>> examples = new ArrayList<>(numSamples);
+        double zeroRange = xZeroMax - xZeroMin;
+        double oneRange = xOneMax - xOneMin;
+        for (int i = 0; i < numSamples; i++) {
+            double xZero = (rng.nextDouble() * zeroRange) + xZeroMin;
+            double xOne = (rng.nextDouble() * oneRange) + xOneMin;
+            // N(w_0*x_0 - w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
+            double outputValue = (weights[0] * xZero) + (weights[1]*xOne) + (weights[2]*xZero*xOne) + (weights[3]*Math.pow(xOne,3)) + intercept;
+            Regressor output = new Regressor("Y",(rng.nextGaussian() * variance) + outputValue);
+            ArrayExample<Regressor> e = new ArrayExample<>(output,featureNames,new double[]{xZero,xOne});
+            examples.add(e);
+        }
+        this.examples = Collections.unmodifiableList(examples);
+    }
+
+    @Override
+    public OutputFactory<Regressor> getOutputFactory() {
+        return factory;
+    }
+
+    @Override
+    public DataSourceProvenance getProvenance() {
+        return new NonlinearGaussianDataSourceProvenance(this);
+    }
+
+    @Override
+    public Iterator<Example<Regressor>> iterator() {
+        return examples.iterator();
+    }
+
+    /**
+     * Generates a single dimensional output drawn from
+     * N(w_0*x_0 - w_1*x_1 + w_2*x_1*x_0 + w_3*x_1*x_1*x_1 + intercept,variance).
+     * <p>
+     * The features are drawn from a uniform distribution over the range.
+     * @param numSamples The size of the output dataset.
+     * @param weights The feature weights.
+     * @param intercept The y intercept of the line.
+     * @param variance The variance of the gaussian.
+     * @param xZeroMin The minimum x_0 value (inclusive).
+     * @param xZeroMax The maximum x_0 value (exclusive).
+     * @param xOneMin The minimum x_1 value (inclusive).
+     * @param xOneMax The maximum x_1 value (exclusive).
+     * @param seed The rng seed to use.
+     * @return A dataset drawn from a gaussian.
+     */
+    public static Dataset<Regressor> generateDataset(int numSamples, float[] weights, float intercept, float variance,
+                                                     float xZeroMin, float xZeroMax, float xOneMin, float xOneMax,
+                                                     long seed) {
+        NonlinearGaussianDataSource source = new NonlinearGaussianDataSource(numSamples,weights,intercept,variance,
+                xZeroMin,xZeroMax,xOneMin,xOneMax,seed);
+        return new MutableDataset<>(source);
+    }
+
+    /**
+     * Provenance for {@link NonlinearGaussianDataSource}.
+     */
+    public static class NonlinearGaussianDataSourceProvenance extends SkeletalConfiguredObjectProvenance implements ConfiguredDataSourceProvenance {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Constructs a provenance from the host data source.
+         * @param host The host to read.
+         */
+        NonlinearGaussianDataSourceProvenance(NonlinearGaussianDataSource host) {
+            super(host,"DataSource");
+        }
+
+        /**
+         * Constructs a provenance from the marshalled form.
+         * @param map The map of field values.
+         */
+        public NonlinearGaussianDataSourceProvenance(Map<String, Provenance> map) {
+            this(extractProvenanceInfo(map));
+        }
+
+        private NonlinearGaussianDataSourceProvenance(ExtractedInfo info) {
+            super(info);
+        }
+
+        /**
+         * Extracts the relevant provenance information fields for this class.
+         * @param map The map to remove values from.
+         * @return The extracted information.
+         */
+        protected static ExtractedInfo extractProvenanceInfo(Map<String,Provenance> map) {
+            Map<String,Provenance> configuredParameters = new HashMap<>(map);
+            String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters,CLASS_NAME, StringProvenance.class, NonlinearGaussianDataSourceProvenance.class.getSimpleName()).getValue();
+            String hostTypeStringName = ObjectProvenance.checkAndExtractProvenance(configuredParameters,HOST_SHORT_NAME, StringProvenance.class, NonlinearGaussianDataSourceProvenance.class.getSimpleName()).getValue();
+
+            return new ExtractedInfo(className,hostTypeStringName,configuredParameters,Collections.emptyMap());
+        }
+    }
+}

--- a/Regression/Core/src/main/java/org/tribuo/regression/example/RegressionDataGenerator.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/example/RegressionDataGenerator.java
@@ -45,6 +45,11 @@ public abstract class RegressionDataGenerator {
     private static final RegressionFactory REGRESSION_FACTORY = new RegressionFactory();
     private static final String[] dimensionNames = new String[]{firstDimensionName,secondDimensionName};
 
+    /**
+     * Abstract utility class with private constructor.
+     */
+    private RegressionDataGenerator() {}
+
     public static Pair<Dataset<Regressor>,Dataset<Regressor>> multiDimDenseTrainTest() {
         return multiDimDenseTrainTest(-1.0);
     }

--- a/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/TrainTest.java
+++ b/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/TrainTest.java
@@ -61,6 +61,8 @@ public class TrainTest {
         public KernelType kernelType = KernelType.LINEAR;
         @Option(charName='t',longName="type",usage="Type of SVM.")
         public SVMRegressionType.SVMMode svmType = SVMMode.EPSILON_SVR;
+        @Option(longName="standardize",usage="Standardize the regression outputs internally to the SVM")
+        public boolean standardize = false;
     }
 
     /**
@@ -97,7 +99,7 @@ public class TrainTest {
         parameters.setGamma(o.gamma);
         parameters.setCoeff(o.coeff);
         parameters.setDegree(o.degree);
-        Trainer<Regressor> trainer = new LibSVMRegressionTrainer(parameters);
+        Trainer<Regressor> trainer = new LibSVMRegressionTrainer(parameters, o.standardize);
         logger.info("Training using " + trainer.toString());
 
         final long trainStart = System.currentTimeMillis();


### PR DESCRIPTION
### Description
Adds an option to LibSVMRegressionTrainer which standardises the input (i.e. ensures it's mean zero variance one) before training a model. It then applies the inverse transformation to the predictions to map them back into the correct output space. It also adds a non-linear regression data generator for testing, adds a couple of related methods in `org.tribuo.util.Util` and tidies up some related comments.

The internal implementation is quite ugly as it extends `svm_model` to poke in the mean and variance, because the types in the base `LibSVMTrainer` are too restrictive. When we have a breaking version it might be worth refactoring this and `LibLinearTrainer` (which is similar) to make the internal types controlled by Tribuo so they can be more easily extended if necessary (or just make them `Map<String,Object>`).

The standardization is off by default to preserve compatibility with Tribuo 4.0, but the performance is pretty poor on non-linear problems with it turned off, so it might be better to turn it on by default.

### Motivation
LibSVM has a real problem with non-standardized regression inputs, and performs very poorly. Using the new non-linear data generator an RBF SVM gets:
```
Multi-dimensional Regression Evaluation
RMSE = {Y=24.412388852859543}
Mean Absolute Error = {Y=11.827119549115682}
R^2 = {Y=0.7729975961406879}
explained variance = {Y=0.773032506305136}
```
and with standardization it gets:
```
Multi-dimensional Regression Evaluation
RMSE = {Y=1.214990405958973}
Mean Absolute Error = {Y=0.9604027608577747}
R^2 = {Y=0.9994377161686859}
explained variance = {Y=0.9994384243963165}
```

Fixes #73. I tested the other regressors and none of them exhibit the same issue on non-standardized data. If there are future reports of a similar issue in the other regressors we can roll out a similar solution.