### PR TITLE
Provenance updates

### DIFF
--- a/Core/src/main/java/org/tribuo/provenance/EnsembleModelProvenance.java
+++ b/Core/src/main/java/org/tribuo/provenance/EnsembleModelProvenance.java
@@ -19,13 +19,10 @@ package org.tribuo.provenance;
 import com.oracle.labs.mlrg.olcut.provenance.ListProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.Provenance;
-import com.oracle.labs.mlrg.olcut.provenance.primitives.DateTimeProvenance;
-import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -64,14 +61,9 @@ public class EnsembleModelProvenance extends ModelProvenance {
     }
 
     @Override
-    public Iterator<Pair<String, Provenance>> iterator() {
-        ArrayList<Pair<String,Provenance>> iterable = new ArrayList<>();
-        iterable.add(new Pair<>(CLASS_NAME,new StringProvenance(CLASS_NAME,className)));
-        iterable.add(new Pair<>(DATASET,datasetProvenance));
-        iterable.add(new Pair<>(TRAINER,trainerProvenance));
-        iterable.add(new Pair<>(TRAINING_TIME,new DateTimeProvenance(TRAINING_TIME,time)));
-        iterable.add(new Pair<>(INSTANCE_VALUES,instanceProvenance));
-        iterable.add(new Pair<>(MEMBERS,memberProvenance));
-        return iterable.iterator();
+    protected List<Pair<String, Provenance>> internalProvenances() {
+        List<Pair<String, Provenance>> superList = super.internalProvenances();
+        superList.add(new Pair<>(MEMBERS,memberProvenance));
+        return superList;
     }
 }

--- a/Core/src/main/java/org/tribuo/provenance/EnsembleModelProvenance.java
+++ b/Core/src/main/java/org/tribuo/provenance/EnsembleModelProvenance.java
@@ -24,6 +24,7 @@ import com.oracle.labs.mlrg.olcut.util.Pair;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Model provenance for ensemble models.
@@ -35,24 +36,99 @@ public class EnsembleModelProvenance extends ModelProvenance {
 
     private final ListProvenance<? extends ModelProvenance> memberProvenance;
 
-    public EnsembleModelProvenance(String className, OffsetDateTime time, DatasetProvenance datasetProvenance, TrainerProvenance trainerProvenance, ListProvenance<? extends ModelProvenance> memberProvenance) {
+    /**
+     * Creates a provenance for an ensemble model tracking the class name, creation time, dataset provenance and
+     * trainer provenance along with the individual model provenances
+     * for each ensemble member.
+     * <p>
+     * Also tracks system details like the os name, os architecture, java version, and Tribuo version.
+     * @param className The model class name.
+     * @param time The model creation time.
+     * @param datasetProvenance The dataset provenance.
+     * @param trainerProvenance The trainer provenance.
+     * @param memberProvenance The ensemble member provenances.
+     */
+    public EnsembleModelProvenance(String className, OffsetDateTime time, DatasetProvenance datasetProvenance,
+                                   TrainerProvenance trainerProvenance,
+                                   ListProvenance<? extends ModelProvenance> memberProvenance) {
         super(className, time, datasetProvenance, trainerProvenance);
         this.memberProvenance = memberProvenance;
     }
 
-    public EnsembleModelProvenance(String className, OffsetDateTime time, DatasetProvenance datasetProvenance, TrainerProvenance trainerProvenance, Map<String, Provenance> instanceProvenance, ListProvenance<? extends ModelProvenance> memberProvenance) {
+    /**
+     * Creates a provenance for an ensemble model tracking the class name, creation time, dataset provenance,
+     * trainer provenance and any instance specific provenance along with the individual model provenances
+     * for each ensemble member.
+     * <p>
+     * Also tracks system details like the os name, os architecture, java version, and Tribuo version.
+     * @param className The model class name.
+     * @param time The model creation time.
+     * @param datasetProvenance The dataset provenance.
+     * @param trainerProvenance The trainer provenance.
+     * @param instanceProvenance Provenance for this specific model training run.
+     * @param memberProvenance The ensemble member provenances.
+     */
+    public EnsembleModelProvenance(String className, OffsetDateTime time, DatasetProvenance datasetProvenance,
+                                   TrainerProvenance trainerProvenance, Map<String, Provenance> instanceProvenance,
+                                   ListProvenance<? extends ModelProvenance> memberProvenance) {
         super(className, time, datasetProvenance, trainerProvenance, instanceProvenance);
         this.memberProvenance = memberProvenance;
     }
 
+    /**
+     * Creates a provenance for an ensemble model tracking the class name, creation time, dataset provenance,
+     * trainer provenance and any instance specific provenance along with the individual model provenances
+     * for each ensemble member.
+     * <p>
+     * Also optionally tracks system details like the os name, os architecture, java version, and Tribuo version.
+     * @param className The model class name.
+     * @param time The model creation time.
+     * @param datasetProvenance The dataset provenance.
+     * @param trainerProvenance The trainer provenance.
+     * @param instanceProvenance Provenance for this specific model training run.
+     * @param memberProvenance The ensemble member provenances.
+     * @param trackSystem If true then store the java version, os name and os arch in the provenance.
+     */
+    public EnsembleModelProvenance(String className, OffsetDateTime time, DatasetProvenance datasetProvenance,
+                                   TrainerProvenance trainerProvenance, Map<String, Provenance> instanceProvenance,
+                                   boolean trackSystem, ListProvenance<? extends ModelProvenance> memberProvenance) {
+        super(className, time, datasetProvenance, trainerProvenance, instanceProvenance, trackSystem);
+        this.memberProvenance = memberProvenance;
+    }
+
+    /**
+     * Used by the provenance unmarshalling system.
+     * <p>
+     * Throws {@link com.oracle.labs.mlrg.olcut.provenance.ProvenanceException} if there are missing
+     * fields.
+     * @param map The provenance map.
+     */
     @SuppressWarnings("unchecked") // member provenance cast.
     public EnsembleModelProvenance(Map<String, Provenance> map) {
         super(map);
         this.memberProvenance = (ListProvenance<? extends ModelProvenance>) ObjectProvenance.checkAndExtractProvenance(map,MEMBERS,ListProvenance.class, EnsembleModelProvenance.class.getSimpleName());
     }
 
+    /**
+     * Get the provenances for each ensemble member.
+     * @return The member provenances.
+     */
     public ListProvenance<? extends ModelProvenance> getMemberProvenance() {
         return memberProvenance;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EnsembleModelProvenance pairs = (EnsembleModelProvenance) o;
+        return memberProvenance.equals(pairs.memberProvenance);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), memberProvenance);
     }
 
     @Override

--- a/Core/src/main/java/org/tribuo/provenance/ModelProvenance.java
+++ b/Core/src/main/java/org/tribuo/provenance/ModelProvenance.java
@@ -27,6 +27,7 @@ import org.tribuo.Tribuo;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -43,7 +44,7 @@ public class ModelProvenance implements ObjectProvenance {
     protected static final String TRAINER = "trainer";
     protected static final String TRAINING_TIME = "trained-at";
     protected static final String INSTANCE_VALUES = "instance-values";
-    private static final String TRIBUO_VERSION_STRING = "tribuo-version";
+    protected static final String TRIBUO_VERSION_STRING = "tribuo-version";
 
     protected final String className;
 
@@ -81,7 +82,7 @@ public class ModelProvenance implements ObjectProvenance {
         this.trainerProvenance = ObjectProvenance.checkAndExtractProvenance(map,TRAINER,TrainerProvenance.class, ModelProvenance.class.getSimpleName());
         this.time = ObjectProvenance.checkAndExtractProvenance(map,TRAINING_TIME,DateTimeProvenance.class, ModelProvenance.class.getSimpleName()).getValue();
         this.instanceProvenance = (MapProvenance<?>) ObjectProvenance.checkAndExtractProvenance(map,INSTANCE_VALUES,MapProvenance.class, ModelProvenance.class.getSimpleName());
-        this.versionString = ObjectProvenance.checkAndExtractProvenance(map, TRIBUO_VERSION_STRING,StringProvenance.class, DatasetProvenance.class.getSimpleName()).getValue();
+        this.versionString = ObjectProvenance.checkAndExtractProvenance(map,TRIBUO_VERSION_STRING,StringProvenance.class,ModelProvenance.class.getSimpleName()).getValue();
     }
 
     /**
@@ -152,8 +153,12 @@ public class ModelProvenance implements ObjectProvenance {
         return Objects.hash(className, time, datasetProvenance, trainerProvenance, instanceProvenance, versionString);
     }
 
-    @Override
-    public Iterator<Pair<String, Provenance>> iterator() {
+    /**
+     * Returns a list of all the provenances in this model provenance so subclasses
+     * can append to the list.
+     * @return A list of all the provenances in this class.
+     */
+    protected List<Pair<String,Provenance>> internalProvenances() {
         ArrayList<Pair<String,Provenance>> iterable = new ArrayList<>();
         iterable.add(new Pair<>(CLASS_NAME,new StringProvenance(CLASS_NAME,className)));
         iterable.add(new Pair<>(DATASET,datasetProvenance));
@@ -161,6 +166,15 @@ public class ModelProvenance implements ObjectProvenance {
         iterable.add(new Pair<>(TRAINING_TIME,new DateTimeProvenance(TRAINING_TIME,time)));
         iterable.add(new Pair<>(INSTANCE_VALUES,instanceProvenance));
         iterable.add(new Pair<>(TRIBUO_VERSION_STRING,new StringProvenance(TRIBUO_VERSION_STRING,versionString)));
-        return iterable.iterator();
+        return iterable;
+    }
+
+    /**
+     * Calls {@link #internalProvenances()} and returns the iterator from that list.
+     * @return An iterator over all the provenances.
+     */
+    @Override
+    public Iterator<Pair<String, Provenance>> iterator() {
+        return internalProvenances().iterator();
     }
 }

--- a/Core/src/main/java/org/tribuo/provenance/SkeletalTrainerProvenance.java
+++ b/Core/src/main/java/org/tribuo/provenance/SkeletalTrainerProvenance.java
@@ -92,6 +92,7 @@ public abstract class SkeletalTrainerProvenance extends SkeletalConfiguredObject
 
         map.put(TRAIN_INVOCATION_COUNT, invocationCount);
         map.put(IS_SEQUENCE, isSequence);
+        map.put(TRIBUO_VERSION_STRING, version);
 
         return map;
     }

--- a/Core/src/test/java/org/tribuo/test/Helpers.java
+++ b/Core/src/test/java/org/tribuo/test/Helpers.java
@@ -16,25 +16,26 @@
 
 package org.tribuo.test;
 
+import com.oracle.labs.mlrg.olcut.provenance.ProvenanceUtil;
+import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import org.junit.jupiter.api.Assertions;
 import org.tribuo.Example;
 import org.tribuo.Feature;
 import org.tribuo.Model;
 import org.tribuo.Output;
 import org.tribuo.impl.ListExample;
+import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.sequence.SequenceModel;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -60,6 +61,11 @@ public final class Helpers {
     }
 
     public static <T extends Output<T>> void testModelSerialization(Model<T> model, Class<T> outputClazz) {
+        // test provenance marshalling
+        List<ObjectMarshalledProvenance> provenanceList = ProvenanceUtil.marshalProvenance(model.getProvenance());
+        ModelProvenance provenance = (ModelProvenance) ProvenanceUtil.unmarshalProvenance(provenanceList);
+        Assertions.assertEquals(provenance,model.getProvenance());
+
         // write to byte array
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ObjectOutputStream oos = new ObjectOutputStream(new BufferedOutputStream(baos))) {

--- a/Json/src/main/java/org/tribuo/json/StripProvenance.java
+++ b/Json/src/main/java/org/tribuo/json/StripProvenance.java
@@ -66,6 +66,7 @@ import java.util.logging.Logger;
 import static org.tribuo.json.StripProvenance.ProvenanceTypes.ALL;
 import static org.tribuo.json.StripProvenance.ProvenanceTypes.DATASET;
 import static org.tribuo.json.StripProvenance.ProvenanceTypes.INSTANCE;
+import static org.tribuo.json.StripProvenance.ProvenanceTypes.SYSTEM;
 import static org.tribuo.json.StripProvenance.ProvenanceTypes.TRAINER;
 
 /**
@@ -96,6 +97,10 @@ public final class StripProvenance {
          * Select any instance provenance from the specific training run that created this model.
          */
         INSTANCE,
+        /**
+         * Selects any system information provenance.
+         */
+        SYSTEM,
         /**
          * Selects all provenance stored in the model.
          */
@@ -139,7 +144,14 @@ public final class StripProvenance {
             instanceProvenance.put("original-provenance-hash",new HashProvenance(opt.hashType,"original-provenance-hash",provenanceHash));
         }
 
-        return new ModelProvenance(old.getClassName(),time,datasetProvenance,trainerProvenance,instanceProvenance);
+        boolean stripSystem;
+        if (opt.removeProvenances.contains(ALL) || opt.removeProvenances.contains(SYSTEM)) {
+            stripSystem = true;
+        } else {
+            stripSystem = false;
+        }
+
+        return new ModelProvenance(old.getClassName(),time,datasetProvenance,trainerProvenance,instanceProvenance,!stripSystem);
     }
 
     /**


### PR DESCRIPTION
### Description
Fixes a provenance marshalling bug in `ModelProvenance` and `EnsembleModelProvenance` and adds a test to ensure it doesn't happen again.

Also adds system information to `ModelProvenance` and `EnsembleModelProvenance`. Now these provenances track "java.version", "os.name" and "os.arch" from the Java properties. They can be removed by passing the appropriate flag on construction, or by stripping them using `StripProvenance` (and so StripProvenance gained the ability to remove system provenances). 

### Motivation
Tribuo 4.0.2 can produce different outputs on Java 8 x86_64, Java 9+ x86_64 and Java on aarch64, due to differences in the implementation of Math.exp, Math.log and Math.sqrt on those platforms. To ensure replicability we need to track what platform the model was created on until we've run it down and either switched to the slower StrictMath for correctness or learned to live with it. Future optimisations using the Vector API will also likely induce model divergence based on the hardware as the order of operations will be different when training models with SGD, so we might need this permanently. 