### PR TITLE
Fixing the transformer behaviour on sparse features

### DIFF
--- a/Core/src/main/java/org/tribuo/Dataset.java
+++ b/Core/src/main/java/org/tribuo/Dataset.java
@@ -246,6 +246,7 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
      * Tribuo 4.0, but causes erroneous behaviour in
      * {@link org.tribuo.transform.transformations.IDFTransformation} so should be
      * avoided with that transformation.
+     * See {@link org.tribuo.transform} for a more detailed discussion of densify and includeImplicitZeroFeatures.
      * <p>
      * Throws {@link IllegalArgumentException} if the TransformationMap object has
      * regexes which apply to multiple features.
@@ -266,6 +267,7 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
      * TransformerMaps operate on feature values which are present, sparse values
      * are ignored and not transformed. If the zeros should be transformed, call
      * {@link MutableDataset#densify} on the datasets before applying a transformer.
+     * See {@link org.tribuo.transform} for a more detailed discussion of densify and includeImplicitZeroFeatures.
      * <p>
      * Throws {@link IllegalArgumentException} if the TransformationMap object has
      * regexes which apply to multiple features.

--- a/Core/src/main/java/org/tribuo/transform/TransformStatistics.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformStatistics.java
@@ -35,7 +35,9 @@ public interface TransformStatistics {
 
     /**
      * Observes a sparse (i.e., zero) value.
+     * @deprecated in 4.1 as it's unnecessary.
      */
+    @Deprecated
     public void observeSparse();
 
     /**

--- a/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
@@ -38,6 +38,7 @@ import java.util.logging.Logger;
  * By default transformations only operate on explicit feature values. To include implicit zeros
  * in transformation fitting set {@code includeImplicitZeroFeatures}. To convert implicit
  * zeros to explicit zeros before applying the transformations set {@code densify}.
+ * See {@link org.tribuo.transform} for a more detailed discussion of these parameters.
  */
 public final class TransformTrainer<T extends Output<T>> implements Trainer<T> {
     

--- a/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  * to apply to each {@link Dataset} before training each {@link Model}.
  * <p>
  * By default transformations only operate on explicit feature values. To include implicit zeros
- * in transformation fitting then set {@code includeImplicitZeroFeatures}, and to convert implicit
+ * in transformation fitting set {@code includeImplicitZeroFeatures}. To convert implicit
  * zeros to explicit zeros before applying the transformations set {@code densify}.
  */
 public final class TransformTrainer<T extends Output<T>> implements Trainer<T> {

--- a/Core/src/main/java/org/tribuo/transform/TransformationMap.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformationMap.java
@@ -48,6 +48,7 @@ import java.util.regex.Pattern;
  * <p>
  * Transformations only operate on observed values. To operate on implicit zeros then
  * first call {@link MutableDataset#densify} on the datasets.
+ * See {@link org.tribuo.transform} for a more detailed discussion of densify.
  */
 public class TransformationMap implements Configurable, Provenancable<ConfiguredObjectProvenance> {
 

--- a/Core/src/main/java/org/tribuo/transform/TransformedModel.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformedModel.java
@@ -65,6 +65,18 @@ public class TransformedModel<T extends Output<T>> extends Model<T> {
         Collections.sort(featureNames);
     }
 
+    /**
+     * Gets the transformers that this model applies to each example.
+     * <p>
+     * Note if you use these transformers to modify some data, and then
+     * feed that data to this model, the data will be transformed twice
+     * and this is not what you want.
+     * @return The transformers.
+     */
+    public TransformerMap getTransformerMap() {
+        return transformerMap;
+    }
+
     @Override
     public Prediction<T> predict(Example<T> example) {
         Example<T> transformedExample;

--- a/Core/src/main/java/org/tribuo/transform/TransformerMap.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformerMap.java
@@ -32,6 +32,7 @@ import org.tribuo.transform.TransformerMap.TransformerMapProvenance;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,7 @@ public final class TransformerMap implements Provenancable<TransformerMapProvena
      * @param transformationMapProvenance The provenance of the transformation map that was fit.
      */
     public TransformerMap(Map<String,List<Transformer>> map, DatasetProvenance datasetProvenance, ConfiguredObjectProvenance transformationMapProvenance) {
-        this.map = map;
+        this.map = Collections.unmodifiableMap(map);
         this.datasetProvenance = datasetProvenance;
         this.transformationMapProvenance = transformationMapProvenance;
     }

--- a/Core/src/main/java/org/tribuo/transform/TransformerMap.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformerMap.java
@@ -49,6 +49,7 @@ import java.util.logging.Logger;
  * <p>
  * Transformations only operate on observed values. To operate on implicit zeros then
  * first call {@link MutableDataset#densify} on the datasets.
+ * See {@link org.tribuo.transform} for a more detailed discussion of densify.
  */
 public final class TransformerMap implements Provenancable<TransformerMapProvenance>, Serializable {
     

--- a/Core/src/main/java/org/tribuo/transform/package-info.java
+++ b/Core/src/main/java/org/tribuo/transform/package-info.java
@@ -19,8 +19,8 @@
  * <p>
  * This package is the necessary infrastructure for transformations. The workflow is first to build a
  * {@link org.tribuo.transform.TransformationMap} which represents the
- * {@link org.tribuo.transform.Transformation}s and the order that they should be applied to each
- * {@link org.tribuo.Feature}. This can be applied to a Dataset to produce a
+ * {@link org.tribuo.transform.Transformation}s and the order that they should be applied to the specified
+ * {@link org.tribuo.Feature}s. This can be applied to a Dataset to produce a
  * {@link org.tribuo.transform.TransformerMap} which contains a fitted set of
  * {@link org.tribuo.transform.Transformer}s which can be used to apply the transformation to any
  * other Dataset (e.g., to apply the same transformation to training and test sets), or to be used at prediction
@@ -31,7 +31,7 @@
  * {@link org.tribuo.transform.TransformedModel} which automatically transforms it's input data at
  * prediction time.
  * <p>
- * Transformations don't produces new {@link org.tribuo.Feature} entries - they only modify the values of existing ones.
+ * Transformations don't produces new {@link org.tribuo.Feature}s - they only modify the values of existing ones.
  * When doing so they can be instructed to treat Features that are absent due to sparsity as zero or as
  * not existing at all. Independently, we can explicitly add zero-valued Features by densifying the dataset
  * before the transformation is fit or before it is applied. Once they exist these Features can be altered by
@@ -40,13 +40,14 @@
  * <p>
  * The transformation fitting methods have two parameters which alter their behaviour: {@code includeImplicitZeroFeatures}
  * and {@code densify}. {@code includeImplicitZeroFeatures} controls if the transformation incorporates the implicit zero
- * valued features (i.e., the ones not present in the example) when building the transformation statistics. This is
+ * valued features (i.e., the ones not present in the example but are present in the dataset's
+ * {@link org.tribuo.FeatureMap}) when building the transformation statistics. This is
  * important when working with {@link org.tribuo.transform.transformations.IDFTransformation} as it allows correct
  * computation of the inverse document frequency, but can be detrimental to features which are one-hot encodings of
  * categoricals (as they have many more implicit zeros). {@code densify} controls if the example or dataset should have
  * it's implicit zero valued features converted into explicit zero valued features (i.e., it makes a sparse example into
- * a dense one which contains an explicit value for every feature) before the transformation is applied, and
- * transformations are only applied to feature values which are present.
+ * a dense one which contains an explicit value for every feature known to the dataset) before the transformation is
+ * applied, and transformations are only applied to feature values which are present.
  * <p>
  * These parameters interact to form 4 possibilities:
  * <ul>

--- a/Core/src/main/java/org/tribuo/transform/package-info.java
+++ b/Core/src/main/java/org/tribuo/transform/package-info.java
@@ -31,6 +31,13 @@
  * {@link org.tribuo.transform.TransformedModel} which automatically transforms it's input data at
  * prediction time.
  * <p>
+ * Transformations don't produces new {@link org.tribuo.Feature} entries - they only modify the values of existing ones.
+ * When doing so they can be instructed to treat Features that are absent due to sparsity as zero or as
+ * not existing at all. Independently, we can explicitly add zero-valued Features by densifying the dataset
+ * before the transformation is fit or before it is applied. Once they exist these Features can be altered by
+ * {@link org.tribuo.transform.Transformer}s and are visible to {@link org.tribuo.transform.Transformation}s which are
+ * being fit.
+ * <p>
  * The transformation fitting methods have two parameters which alter their behaviour: {@code includeImplicitZeroFeatures}
  * and {@code densify}. {@code includeImplicitZeroFeatures} controls if the transformation incorporates the implicit zero
  * valued features (i.e., the ones not present in the example) when building the transformation statistics. This is
@@ -53,5 +60,8 @@
  *     three combinations, but could be used to move the minimum value, or when zero is not appropriate for a missing
  *     value and needs to be transformed.</li>
  * </ul>
+ * One further option is to call {@link org.tribuo.MutableDataset#densify} before passing the data to
+ * {@link org.tribuo.transform.TransformTrainer#train}, which is equivalent to setting {@code includeImplicitZeroFeatures}
+ * to true and {@code densify} to true.
  */
 package org.tribuo.transform;

--- a/Core/src/main/java/org/tribuo/transform/package-info.java
+++ b/Core/src/main/java/org/tribuo/transform/package-info.java
@@ -42,7 +42,7 @@
  * and {@code densify}. {@code includeImplicitZeroFeatures} controls if the transformation incorporates the implicit zero
  * valued features (i.e., the ones not present in the example but are present in the dataset's
  * {@link org.tribuo.FeatureMap}) when building the transformation statistics. This is
- * important when working with {@link org.tribuo.transform.transformations.IDFTransformation} as it allows correct
+ * important when working with, e.g. {@link org.tribuo.transform.transformations.IDFTransformation} as it allows correct
  * computation of the inverse document frequency, but can be detrimental to features which are one-hot encodings of
  * categoricals (as they have many more implicit zeros). {@code densify} controls if the example or dataset should have
  * it's implicit zero valued features converted into explicit zero valued features (i.e., it makes a sparse example into

--- a/Core/src/main/java/org/tribuo/transform/package-info.java
+++ b/Core/src/main/java/org/tribuo/transform/package-info.java
@@ -30,5 +30,28 @@
  * TransformationMap and an inner {@link org.tribuo.Trainer} and produces a
  * {@link org.tribuo.transform.TransformedModel} which automatically transforms it's input data at
  * prediction time.
+ * <p>
+ * The transformation fitting methods have two parameters which alter their behaviour: {@code includeImplicitZeroFeatures}
+ * and {@code densify}. {@code includeImplicitZeroFeatures} controls if the transformation incorporates the implicit zero
+ * valued features (i.e., the ones not present in the example) when building the transformation statistics. This is
+ * important when working with {@link org.tribuo.transform.transformations.IDFTransformation} as it allows correct
+ * computation of the inverse document frequency, but can be detrimental to features which are one-hot encodings of
+ * categoricals (as they have many more implicit zeros). {@code densify} controls if the example or dataset should have
+ * it's implicit zero valued features converted into explicit zero valued features (i.e., it makes a sparse example into
+ * a dense one which contains an explicit value for every feature) before the transformation is applied, and
+ * transformations are only applied to feature values which are present.
+ * <p>
+ * These parameters interact to form 4 possibilities:
+ * <ul>
+ *     <li>Both false: transformations are only fit on explicit feature values, and only applied to explicit feature values</li>
+ *     <li>Both true: transformations include explicit features and implicit zeros, and implicit zeros are converted into explicit zeros and transformed</li>
+ *     <li>{@code includeImplicitZeroFeatures} is true, {@code densify} is false: the implicit zeroes are used to fit
+ *     the transformation, but not modified when the transformation is applied. This is most useful when working with
+ *     text data where you want to compute IDF style statistics</li>
+ *     <li>{@code includeImplicitZeroFeatures} is false, {@code densify} is true: the implicit zeros are not used to
+ *     fit the transformation, but are converted to explicit zeros and transformed. This is less useful than the other
+ *     three combinations, but could be used to move the minimum value, or when zero is not appropriate for a missing
+ *     value and needs to be transformed.</li>
+ * </ul>
  */
 package org.tribuo.transform;

--- a/Core/src/main/java/org/tribuo/transform/package-info.java
+++ b/Core/src/main/java/org/tribuo/transform/package-info.java
@@ -31,7 +31,7 @@
  * {@link org.tribuo.transform.TransformedModel} which automatically transforms it's input data at
  * prediction time.
  * <p>
- * Transformations don't produces new {@link org.tribuo.Feature}s - they only modify the values of existing ones.
+ * Transformations don't produce new {@link org.tribuo.Feature}s - they only modify the values of existing ones.
  * When doing so they can be instructed to treat Features that are absent due to sparsity as zero or as
  * not existing at all. Independently, we can explicitly add zero-valued Features by densifying the dataset
  * before the transformation is fit or before it is applied. Once they exist these Features can be altered by

--- a/Core/src/main/java/org/tribuo/transform/package-info.java
+++ b/Core/src/main/java/org/tribuo/transform/package-info.java
@@ -45,7 +45,7 @@
  * important when working with, e.g. {@link org.tribuo.transform.transformations.IDFTransformation} as it allows correct
  * computation of the inverse document frequency, but can be detrimental to features which are one-hot encodings of
  * categoricals (as they have many more implicit zeros). {@code densify} controls if the example or dataset should have
- * it's implicit zero valued features converted into explicit zero valued features (i.e., it makes a sparse example into
+ * its implicit zero valued features converted into explicit zero valued features (i.e., it makes a sparse example into
  * a dense one which contains an explicit value for every feature known to the dataset) before the transformation is
  * applied, and transformations are only applied to feature values which are present.
  * <p>

--- a/Core/src/main/java/org/tribuo/transform/package-info.java
+++ b/Core/src/main/java/org/tribuo/transform/package-info.java
@@ -63,6 +63,8 @@
  * </ul>
  * One further option is to call {@link org.tribuo.MutableDataset#densify} before passing the data to
  * {@link org.tribuo.transform.TransformTrainer#train}, which is equivalent to setting {@code includeImplicitZeroFeatures}
- * to true and {@code densify} to true.
+ * to true and {@code densify} to true. To sum up, in the context of transformations {@code includeImplicitZeroFeatures}
+ * determines whether (implicit) zero-values features are <i>measured</i> and {@code densify} determines whether
+ * they can be <i>altered</i>. 
  */
 package org.tribuo.transform;

--- a/Core/src/main/java/org/tribuo/transform/transformations/BinningTransformation.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/BinningTransformation.java
@@ -243,6 +243,7 @@ public final class BinningTransformation implements Transformation {
         }
 
         @Override
+        @Deprecated
         public void observeSparse() {
             observeValue(0.0);
         }
@@ -327,6 +328,7 @@ public final class BinningTransformation implements Transformation {
         }
 
         @Override
+        @Deprecated
         public void observeSparse() {
             observeValue(0.0);
         }
@@ -387,6 +389,7 @@ public final class BinningTransformation implements Transformation {
         }
 
         @Override
+        @Deprecated
         public void observeSparse() {
             observeValue(0.0);
         }

--- a/Core/src/main/java/org/tribuo/transform/transformations/IDFTransformation.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/IDFTransformation.java
@@ -2,7 +2,6 @@ package org.tribuo.transform.transformations;
 
 import com.oracle.labs.mlrg.olcut.provenance.Provenance;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import org.tribuo.transform.TransformStatistics;
 import org.tribuo.transform.Transformation;
@@ -24,7 +23,7 @@ public class IDFTransformation implements Transformation {
 
     @Override
     public TransformationProvenance getProvenance() {
-        if(provenance == null) {
+        if (provenance == null) {
             provenance = new IDFTransformationProvenance();
         }
         return provenance;
@@ -54,6 +53,7 @@ public class IDFTransformation implements Transformation {
 
         @Override
         public void observeSparse() {
+            sparseObservances++;
         }
 
         @Override
@@ -69,7 +69,8 @@ public class IDFTransformation implements Transformation {
     }
     
     private static class IDFTransformer implements Transformer {
-        
+        private static final long serialVersionUID = 1L;
+
         private double df;
         
         private double N;
@@ -87,10 +88,11 @@ public class IDFTransformation implements Transformation {
     }
     
     public final static class IDFTransformationProvenance implements TransformationProvenance {
+        private static final long serialVersionUID = 1L;
 
         @Override
         public Map<String, Provenance> getConfiguredParameters() {
-            return Collections.unmodifiableMap(new HashMap<>());
+            return Collections.emptyMap();
         }
 
         @Override

--- a/Core/src/main/java/org/tribuo/transform/transformations/IDFTransformation.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/IDFTransformation.java
@@ -52,6 +52,7 @@ public class IDFTransformation implements Transformation {
         }
 
         @Override
+        @Deprecated
         public void observeSparse() {
             sparseObservances++;
         }
@@ -86,9 +87,17 @@ public class IDFTransformation implements Transformation {
         }
         
     }
-    
+
+    /**
+     * Provenance for {@link IDFTransformation}.
+     */
     public final static class IDFTransformationProvenance implements TransformationProvenance {
         private static final long serialVersionUID = 1L;
+
+        IDFTransformationProvenance() { }
+
+        // IDFTransformation has no state to record.
+        public IDFTransformationProvenance(Map<String,Provenance> map) { }
 
         @Override
         public Map<String, Provenance> getConfiguredParameters() {

--- a/Core/src/main/java/org/tribuo/transform/transformations/LinearScalingTransformation.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/LinearScalingTransformation.java
@@ -161,10 +161,15 @@ public final class LinearScalingTransformation implements Transformation {
         }
 
         @Override
-        public void observeSparse() { }
+        public void observeSparse() {
+            observeValue(0.0);
+        }
 
         @Override
-        public void observeSparse(int count) { }
+        public void observeSparse(int count) {
+            // This just tracks max and min, so seeing many 0.0 is the same as one 0.0.
+            observeValue(0.0);
+        }
 
         @Override
         public Transformer generateTransformer() {

--- a/Core/src/main/java/org/tribuo/transform/transformations/LinearScalingTransformation.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/LinearScalingTransformation.java
@@ -161,6 +161,7 @@ public final class LinearScalingTransformation implements Transformation {
         }
 
         @Override
+        @Deprecated
         public void observeSparse() {
             observeValue(0.0);
         }

--- a/Core/src/main/java/org/tribuo/transform/transformations/MeanStdDevTransformation.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/MeanStdDevTransformation.java
@@ -162,6 +162,7 @@ public final class MeanStdDevTransformation implements Transformation {
         }
 
         @Override
+        @Deprecated
         public void observeSparse() {
             observeValue(0.0);
         }

--- a/Core/src/main/java/org/tribuo/transform/transformations/SimpleTransform.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/SimpleTransform.java
@@ -250,6 +250,7 @@ public final class SimpleTransform implements Transformer, Transformation, Trans
      * No-op on this TransformStatistics.
      */
     @Override
+    @Deprecated
     public void observeSparse() { }
 
     /**

--- a/Core/src/test/java/org/tribuo/transform/TransformationMapTest.java
+++ b/Core/src/test/java/org/tribuo/transform/TransformationMapTest.java
@@ -185,7 +185,7 @@ public class TransformationMapTest {
         MutableDataset<MockOutput> dataset = generateSparseDataset();
         TransformationMap t = new TransformationMap(Collections.singletonList(new CountTransformation()),new HashMap<>());
 
-        TransformerMap tMap = dataset.createTransformers(t);
+        TransformerMap tMap = dataset.createTransformers(t,true);
 
         for (Map.Entry<String,List<Transformer>> e : tMap.entrySet()) {
             CountTransformer countTransformer = (CountTransformer) e.getValue().get(0);

--- a/Core/src/test/java/org/tribuo/transform/TransformationMapTest.java
+++ b/Core/src/test/java/org/tribuo/transform/TransformationMapTest.java
@@ -254,6 +254,7 @@ public class TransformationMapTest {
         }
 
         @Override
+        @Deprecated
         public void observeSparse() {
             sparseCount++;
         }

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DoubleFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DoubleFieldProcessor.java
@@ -29,7 +29,8 @@ import java.util.logging.Logger;
 /**
  * Processes a column that contains a real value. The name of the feature
  * will be the name given for the column and the value will be the value in the 
- * column.
+ * column. This processor returns all doubles that can be parsed by {@link Double#parseDouble(String)}
+ * including zeros, and so will emit zero valued features.
  * <p>
  * Returns an empty list if the value failed to parse or was empty.
  */
@@ -62,13 +63,9 @@ public class DoubleFieldProcessor implements FieldProcessor {
     public List<ColumnarFeature> process(String value) {
         try {
             double parsedValue = Double.parseDouble(value);
-            if (parsedValue == 0.0) {
-                return Collections.emptyList();
-            } else {
-                return Collections.singletonList(new ColumnarFeature(fieldName, "value", Double.parseDouble(value)));
-            }
+            return Collections.singletonList(new ColumnarFeature(fieldName, "value", parsedValue));
         } catch (NumberFormatException ex) {
-            if(!value.trim().isEmpty()){
+            if (!value.trim().isEmpty()) {
                 logger.warning(String.format("Non-double value %s in %s", value, fieldName));
             }
             return Collections.emptyList();


### PR DESCRIPTION
### Description
This PR adds implementations of `observeSparse` to all the transformers (apart from `IDFTransformation` which already had it). As a consequence to preserve the 4.0 behaviour the transformation fitting methods grow a new argument which turns on or off the use of the `observeSparse` method. It also switches `DoubleFieldProcessor` over so that it always emits values if they are parsable doubles. Before it would elide zero values, but this makes it much harder to implement transformations which should touch every value because they are numerical (rather than categorical encoded as a double).

One downside of this implementation is that it's not possible to change the behaviour of `observeSparse` on a per feature basis (due to it being a tricky breaking API change), which makes it difficult to apply an IDFTransformation to text features while simultaneously transforming features which should ignore the implicit zeros. If this behaviour is required then two `TransformationMap`s can be applied in sequence to a `Dataset`. We'll note this in the release notes for 4.1.

### Motivation
The observeSparse change is so the transformers actually have the documented behaviour, and then that rippled into adding new overloads for the transformation fitting methods. The `DoubleFieldProcessor` change is because it's tricky to correctly transform numerical data without it.