### PR TITLE
Allows configurable iteration order in AggregateDataSource, and adds a configurable version

### DIFF
--- a/Core/src/main/java/org/tribuo/datasource/AggregateConfigurableDataSource.java
+++ b/Core/src/main/java/org/tribuo/datasource/AggregateConfigurableDataSource.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.datasource;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import com.oracle.labs.mlrg.olcut.provenance.impl.SkeletalConfiguredObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
+import org.tribuo.ConfigurableDataSource;
+import org.tribuo.Example;
+import org.tribuo.Output;
+import org.tribuo.OutputFactory;
+import org.tribuo.datasource.AggregateDataSource.IterationOrder;
+import org.tribuo.provenance.DataSourceProvenance;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Aggregates multiple {@link ConfigurableDataSource}s, uses {@link AggregateDataSource.IterationOrder} to control the
+ * iteration order.
+ * <p>
+ * Identical to {@link AggregateDataSource} except it can be configured.
+ */
+public class AggregateConfigurableDataSource<T extends Output<T>> implements ConfigurableDataSource<T> {
+
+    @Config(mandatory = true, description = "The iteration order.")
+    private IterationOrder order;
+
+    @Config(mandatory = true, description = "The sources to aggregate.")
+    private List<ConfigurableDataSource<T>> sources;
+
+    /**
+     * Creates an aggregate data source which will iterate the provided
+     * sources in the order of the list (i.e., using {@link IterationOrder#SEQUENTIAL}.
+     * @param sources The sources to aggregate.
+     */
+    public AggregateConfigurableDataSource(List<ConfigurableDataSource<T>> sources) {
+        this(sources, IterationOrder.SEQUENTIAL);
+    }
+
+    /**
+     * Creates an aggregate data source using the supplied sources and iteration order.
+     * @param sources The sources to iterate.
+     * @param order The iteration order.
+     */
+    public AggregateConfigurableDataSource(List<ConfigurableDataSource<T>> sources, IterationOrder order) {
+        this.sources = Collections.unmodifiableList(new ArrayList<>(sources));
+        this.order = order;
+    }
+    
+    @Override
+    public String toString() {
+        return "AggregateConfigurableDataSource(sources="+sources.toString()+",order="+order+")";
+    }
+
+    @Override
+    public OutputFactory<T> getOutputFactory() {
+        return sources.get(0).getOutputFactory();
+    }
+
+    @Override
+    public Iterator<Example<T>> iterator() {
+        switch (order) {
+            case ROUNDROBIN:
+                return new AggregateDataSource.ADSRRIterator<>(sources);
+            case SEQUENTIAL:
+                return new AggregateDataSource.ADSSeqIterator<>(sources);
+            default:
+                throw new IllegalStateException("Unknown enum value " + order);
+        }
+    }
+
+    @Override
+    public DataSourceProvenance getProvenance() {
+        return new AggregateConfigurableDataSourceProvenance(this);
+    }
+
+    /**
+     * Provenance for the {@link AggregateConfigurableDataSource}.
+     */
+    public static class AggregateConfigurableDataSourceProvenance extends SkeletalConfiguredObjectProvenance implements DataSourceProvenance {
+        private static final long serialVersionUID = 1L;
+
+        <T extends Output<T>> AggregateConfigurableDataSourceProvenance(AggregateConfigurableDataSource<T> host) {
+            super(host, "DataSource");
+        }
+
+        /**
+         * Deserialization constructor.
+         * @param map The provenance to deserialize.
+         */
+        public AggregateConfigurableDataSourceProvenance(Map<String, Provenance> map) {
+            this(extractProvenanceInfo(map));
+        }
+
+        private AggregateConfigurableDataSourceProvenance(ExtractedInfo info) {
+            super(info);
+        }
+
+        protected static ExtractedInfo extractProvenanceInfo(Map<String, Provenance> map) {
+            Map<String, Provenance> configuredParameters = new HashMap<>(map);
+            String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters,CLASS_NAME, StringProvenance.class, AggregateConfigurableDataSourceProvenance.class.getSimpleName()).getValue();
+            String hostTypeStringName = ObjectProvenance.checkAndExtractProvenance(configuredParameters, HOST_SHORT_NAME, StringProvenance.class, AggregateConfigurableDataSourceProvenance.class.getSimpleName()).getValue();
+            return new ExtractedInfo(className, hostTypeStringName, configuredParameters, Collections.emptyMap());
+        }
+    }
+}

--- a/Core/src/main/java/org/tribuo/datasource/AggregateDataSource.java
+++ b/Core/src/main/java/org/tribuo/datasource/AggregateDataSource.java
@@ -85,7 +85,7 @@ public class AggregateDataSource<T extends Output<T>> implements DataSource<T> {
     
     @Override
     public String toString() {
-        return "AggregateDataSource(sources="+sources.toString()+")";
+        return "AggregateDataSource(sources="+sources.toString()+",order="+order+")";
     }
 
     @Override
@@ -110,7 +110,7 @@ public class AggregateDataSource<T extends Output<T>> implements DataSource<T> {
         return new AggregateDataSourceProvenance(this);
     }
 
-    private static class ADSRRIterator<T extends Output<T>> implements Iterator<Example<T>> {
+    static class ADSRRIterator<T extends Output<T>> implements Iterator<Example<T>> {
         private final Deque<Iterator<Example<T>>> queue;
 
         ADSRRIterator(List<? extends DataSource<T>> sources) {
@@ -146,7 +146,7 @@ public class AggregateDataSource<T extends Output<T>> implements DataSource<T> {
         }
     }
 
-    private static class ADSSeqIterator<T extends Output<T>> implements Iterator<Example<T>> {
+    static class ADSSeqIterator<T extends Output<T>> implements Iterator<Example<T>> {
         private final Iterator<? extends DataSource<T>> si;
         private Iterator<Example<T>> curr;
 

--- a/Core/src/main/java/org/tribuo/provenance/ModelProvenance.java
+++ b/Core/src/main/java/org/tribuo/provenance/ModelProvenance.java
@@ -156,6 +156,8 @@ public class ModelProvenance implements ObjectProvenance {
         this.time = ObjectProvenance.checkAndExtractProvenance(map,TRAINING_TIME,DateTimeProvenance.class, ModelProvenance.class.getSimpleName()).getValue();
         this.instanceProvenance = (MapProvenance<?>) ObjectProvenance.checkAndExtractProvenance(map,INSTANCE_VALUES,MapProvenance.class, ModelProvenance.class.getSimpleName());
         this.versionString = ObjectProvenance.checkAndExtractProvenance(map,TRIBUO_VERSION_STRING,StringProvenance.class,ModelProvenance.class.getSimpleName()).getValue();
+
+        // TODO fix this when we upgrade OLCUT.
         this.javaVersionString = maybeExtractProvenance(map,JAVA_VERSION_STRING,StringProvenance.class).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
         this.osString = maybeExtractProvenance(map,OS_STRING,StringProvenance.class).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
         this.archString = maybeExtractProvenance(map,ARCH_STRING,StringProvenance.class).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
@@ -164,6 +166,8 @@ public class ModelProvenance implements ObjectProvenance {
     /**
      * Like {@link ObjectProvenance#checkAndExtractProvenance(Map, String, Class, String)} but doesn't
      * throw if it fails to find the key, only if the value is of the wrong type.
+     *
+     * @deprecated Deprecated as it's in OLCUT.
      * @param map The map to inspect.
      * @param key The key to find.
      * @param type The class of the value.
@@ -172,7 +176,8 @@ public class ModelProvenance implements ObjectProvenance {
      * @throws ProvenanceException If the value is the wrong type.
      */
     @SuppressWarnings("unchecked") // Guarded by isInstance check
-    private static <T extends Provenance> Optional<T> maybeExtractProvenance(Map<String,Provenance> map, String key, Class<T> type) throws ProvenanceException {
+    @Deprecated
+    public static <T extends Provenance> Optional<T> maybeExtractProvenance(Map<String,Provenance> map, String key, Class<T> type) throws ProvenanceException {
         Provenance tmp = map.remove(key);
         if (tmp != null) {
             if (type.isInstance(tmp)) {

--- a/Core/src/test/java/org/tribuo/datasource/AggregateDataSourceTest.java
+++ b/Core/src/test/java/org/tribuo/datasource/AggregateDataSourceTest.java
@@ -18,21 +18,28 @@ package org.tribuo.datasource;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.tribuo.ConfigurableDataSource;
 import org.tribuo.DataSource;
 import org.tribuo.Example;
+import org.tribuo.Output;
+import org.tribuo.OutputFactory;
 import org.tribuo.impl.ArrayExample;
+import org.tribuo.provenance.DataSourceProvenance;
 import org.tribuo.provenance.SimpleDataSourceProvenance;
+import org.tribuo.test.Helpers;
 import org.tribuo.test.MockOutput;
 import org.tribuo.test.MockOutputFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
 public class AggregateDataSourceTest {
 
     @Test
-    public void testIterationOrder() {
+    public void testADSIterationOrder() {
         MockOutputFactory factory = new MockOutputFactory();
         String[] featureNames = new String[] {"X1","X2"};
         double[] featureValues = new double[] {1.0, 2.0};
@@ -66,11 +73,105 @@ public class AggregateDataSourceTest {
         String[] expectedSeq = new String[] {"A","B","C","D","E","F","G","H","I","J","K"};
         String[] actualSeq = StreamSupport.stream(adsSeq.spliterator(), false).map(Example::getOutput).map(MockOutput::toString).toArray(String[]::new);
         Assertions.assertArrayEquals(expectedSeq,actualSeq);
+        Helpers.testProvenanceMarshalling(adsSeq.getProvenance());
 
         AggregateDataSource<MockOutput> adsRR = new AggregateDataSource<>(sources, AggregateDataSource.IterationOrder.ROUNDROBIN);
         String[] expectedRR = new String[] {"A","F","H","B","G","I","C","J","D","K","E"};
         String[] actualRR = StreamSupport.stream(adsRR.spliterator(), false).map(Example::getOutput).map(MockOutput::toString).toArray(String[]::new);
         Assertions.assertArrayEquals(expectedRR,actualRR);
+        Helpers.testProvenanceMarshalling(adsRR.getProvenance());
+    }
+
+    @Test
+    public void testACDSIterationOrder() {
+        MockOutputFactory factory = new MockOutputFactory();
+        String[] featureNames = new String[] {"X1","X2"};
+        double[] featureValues = new double[] {1.0, 2.0};
+
+        List<Example<MockOutput>> first = new ArrayList<>();
+        first.add(new ArrayExample<>(new MockOutput("A"),featureNames,featureValues));
+        first.add(new ArrayExample<>(new MockOutput("B"),featureNames,featureValues));
+        first.add(new ArrayExample<>(new MockOutput("C"),featureNames,featureValues));
+        first.add(new ArrayExample<>(new MockOutput("D"),featureNames,featureValues));
+        first.add(new ArrayExample<>(new MockOutput("E"),featureNames,featureValues));
+        MockListConfigurableDataSource<MockOutput> firstSource = new MockListConfigurableDataSource<>(first,factory,new SimpleDataSourceProvenance("First",factory));
+
+        List<Example<MockOutput>> second = new ArrayList<>();
+        second.add(new ArrayExample<>(new MockOutput("F"),featureNames,featureValues));
+        second.add(new ArrayExample<>(new MockOutput("G"),featureNames,featureValues));
+        MockListConfigurableDataSource<MockOutput> secondSource = new MockListConfigurableDataSource<>(second,factory,new SimpleDataSourceProvenance("Second",factory));
+
+        List<Example<MockOutput>> third = new ArrayList<>();
+        third.add(new ArrayExample<>(new MockOutput("H"),featureNames,featureValues));
+        third.add(new ArrayExample<>(new MockOutput("I"),featureNames,featureValues));
+        third.add(new ArrayExample<>(new MockOutput("J"),featureNames,featureValues));
+        third.add(new ArrayExample<>(new MockOutput("K"),featureNames,featureValues));
+        MockListConfigurableDataSource<MockOutput> thirdSource = new MockListConfigurableDataSource<>(third,factory,new SimpleDataSourceProvenance("Third",factory));
+
+        List<ConfigurableDataSource<MockOutput>> sources = new ArrayList<>();
+        sources.add(firstSource);
+        sources.add(secondSource);
+        sources.add(thirdSource);
+
+        AggregateConfigurableDataSource<MockOutput> acdsSeq = new AggregateConfigurableDataSource<>(sources, AggregateDataSource.IterationOrder.SEQUENTIAL);
+        String[] expectedSeq = new String[] {"A","B","C","D","E","F","G","H","I","J","K"};
+        String[] actualSeq = StreamSupport.stream(acdsSeq.spliterator(), false).map(Example::getOutput).map(MockOutput::toString).toArray(String[]::new);
+        Assertions.assertArrayEquals(expectedSeq,actualSeq);
+        Helpers.testProvenanceMarshalling(acdsSeq.getProvenance());
+
+        AggregateConfigurableDataSource<MockOutput> acdsRR = new AggregateConfigurableDataSource<>(sources, AggregateDataSource.IterationOrder.ROUNDROBIN);
+        String[] expectedRR = new String[] {"A","F","H","B","G","I","C","J","D","K","E"};
+        String[] actualRR = StreamSupport.stream(acdsRR.spliterator(), false).map(Example::getOutput).map(MockOutput::toString).toArray(String[]::new);
+        Assertions.assertArrayEquals(expectedRR,actualRR);
+        Helpers.testProvenanceMarshalling(acdsRR.getProvenance());
+
+    }
+
+    /**
+     * This isn't actually configurable, it's used to test {@link AggregateConfigurableDataSource}.
+     * @param <T> The output type.
+     */
+    private static class MockListConfigurableDataSource<T extends Output<T>> implements ConfigurableDataSource<T> {
+
+        private final List<Example<T>> data;
+
+        private final OutputFactory<T> factory;
+
+        private final DataSourceProvenance provenance;
+
+        public MockListConfigurableDataSource(List<Example<T>> list, OutputFactory<T> factory, DataSourceProvenance provenance) {
+            this.data = Collections.unmodifiableList(new ArrayList<>(list));
+            this.factory = factory;
+            this.provenance = provenance;
+        }
+
+        /**
+         * Number of examples.
+         * @return The number of examples.
+         */
+        public int size() {
+            return data.size();
+        }
+
+        @Override
+        public OutputFactory<T> getOutputFactory() {
+            return factory;
+        }
+
+        @Override
+        public DataSourceProvenance getProvenance() {
+            return provenance;
+        }
+
+        @Override
+        public Iterator<Example<T>> iterator() {
+            return data.iterator();
+        }
+
+        @Override
+        public String toString() {
+            return provenance.toString();
+        }
     }
 
 }

--- a/Core/src/test/java/org/tribuo/datasource/AggregateDataSourceTest.java
+++ b/Core/src/test/java/org/tribuo/datasource/AggregateDataSourceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.datasource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.tribuo.DataSource;
+import org.tribuo.Example;
+import org.tribuo.impl.ArrayExample;
+import org.tribuo.provenance.SimpleDataSourceProvenance;
+import org.tribuo.test.MockOutput;
+import org.tribuo.test.MockOutputFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+public class AggregateDataSourceTest {
+
+    @Test
+    public void testIterationOrder() {
+        MockOutputFactory factory = new MockOutputFactory();
+        String[] featureNames = new String[] {"X1","X2"};
+        double[] featureValues = new double[] {1.0, 2.0};
+
+        List<Example<MockOutput>> first = new ArrayList<>();
+        first.add(new ArrayExample<>(new MockOutput("A"),featureNames,featureValues));
+        first.add(new ArrayExample<>(new MockOutput("B"),featureNames,featureValues));
+        first.add(new ArrayExample<>(new MockOutput("C"),featureNames,featureValues));
+        first.add(new ArrayExample<>(new MockOutput("D"),featureNames,featureValues));
+        first.add(new ArrayExample<>(new MockOutput("E"),featureNames,featureValues));
+        ListDataSource<MockOutput> firstSource = new ListDataSource<>(first,factory,new SimpleDataSourceProvenance("First",factory));
+
+        List<Example<MockOutput>> second = new ArrayList<>();
+        second.add(new ArrayExample<>(new MockOutput("F"),featureNames,featureValues));
+        second.add(new ArrayExample<>(new MockOutput("G"),featureNames,featureValues));
+        ListDataSource<MockOutput> secondSource = new ListDataSource<>(second,factory,new SimpleDataSourceProvenance("Second",factory));
+
+        List<Example<MockOutput>> third = new ArrayList<>();
+        third.add(new ArrayExample<>(new MockOutput("H"),featureNames,featureValues));
+        third.add(new ArrayExample<>(new MockOutput("I"),featureNames,featureValues));
+        third.add(new ArrayExample<>(new MockOutput("J"),featureNames,featureValues));
+        third.add(new ArrayExample<>(new MockOutput("K"),featureNames,featureValues));
+        ListDataSource<MockOutput> thirdSource = new ListDataSource<>(third,factory,new SimpleDataSourceProvenance("Third",factory));
+
+        List<DataSource<MockOutput>> sources = new ArrayList<>();
+        sources.add(firstSource);
+        sources.add(secondSource);
+        sources.add(thirdSource);
+
+        AggregateDataSource<MockOutput> adsSeq = new AggregateDataSource<>(sources, AggregateDataSource.IterationOrder.SEQUENTIAL);
+        String[] expectedSeq = new String[] {"A","B","C","D","E","F","G","H","I","J","K"};
+        String[] actualSeq = StreamSupport.stream(adsSeq.spliterator(), false).map(Example::getOutput).map(MockOutput::toString).toArray(String[]::new);
+        Assertions.assertArrayEquals(expectedSeq,actualSeq);
+
+        AggregateDataSource<MockOutput> adsRR = new AggregateDataSource<>(sources, AggregateDataSource.IterationOrder.ROUNDROBIN);
+        String[] expectedRR = new String[] {"A","F","H","B","G","I","C","J","D","K","E"};
+        String[] actualRR = StreamSupport.stream(adsRR.spliterator(), false).map(Example::getOutput).map(MockOutput::toString).toArray(String[]::new);
+        Assertions.assertArrayEquals(expectedRR,actualRR);
+    }
+
+}

--- a/Core/src/test/java/org/tribuo/test/Helpers.java
+++ b/Core/src/test/java/org/tribuo/test/Helpers.java
@@ -16,6 +16,7 @@
 
 package org.tribuo.test;
 
+import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.ProvenanceUtil;
 import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import org.junit.jupiter.api.Assertions;
@@ -75,11 +76,15 @@ public final class Helpers {
         return ex;
     }
 
+    public static void testProvenanceMarshalling(ObjectProvenance inputProvenance) {
+        List<ObjectMarshalledProvenance> provenanceList = ProvenanceUtil.marshalProvenance(inputProvenance);
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(provenanceList);
+        Assertions.assertEquals(unmarshalledProvenance,inputProvenance);
+    }
+
     public static <T extends Output<T>> void testModelSerialization(Model<T> model, Class<T> outputClazz) {
         // test provenance marshalling
-        List<ObjectMarshalledProvenance> provenanceList = ProvenanceUtil.marshalProvenance(model.getProvenance());
-        ModelProvenance provenance = (ModelProvenance) ProvenanceUtil.unmarshalProvenance(provenanceList);
-        Assertions.assertEquals(provenance,model.getProvenance());
+        testProvenanceMarshalling(model.getProvenance());
 
         // write to byte array
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
### Description
Adds an enum to `AggregateDataSource` that lets users pick the iteration order. The two options are sequential, which was the old behaviour, where each internal data source is exhausted in sequence, or round robin which draws an example from each data source in turn.

Adds `AggregateConfigurableDataSource` which is the same as `AggregateDataSource` but can be configured.

There's also a slight refactor in the test helpers to expose provenance marshalling checks.

### Motivation
Building data sources from multiple files is a pain, and `AggregateDataSource` had slightly misleading documentation. This fixes the docs and makes it easier to aggregate things as they can be all placed in one config file.

Partial fix for #123 until we have a bigger refactor of file based data sources.