### PR TITLE
Bumps the CI's latest JDK from Java 15 -> 16, tidies up the pom files

### DIFF
--- a/.github/workflows/maven-macos.yml
+++ b/.github/workflows/maven-macos.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 15 ]
+        java: [ 8, 11, 16 ]
     name: macOS OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 15 ]
+        java: [ 8, 11, 16 ]
     name: Ubuntu OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 15 ]
+        java: [ 8, 11, 16 ]
     name: Windows OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/AnomalyDetection/LibLinear/pom.xml
+++ b/AnomalyDetection/LibLinear/pom.xml
@@ -61,6 +61,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/AnomalyDetection/LibSVM/pom.xml
+++ b/AnomalyDetection/LibSVM/pom.xml
@@ -60,6 +60,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/AnomalyDetection/pom.xml
+++ b/AnomalyDetection/pom.xml
@@ -70,9 +70,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
-                    <show>public</show>
+                    <show>protected</show>
                     <failOnError>false</failOnError>
                     <linksource>true</linksource>
                     <nohelp>true</nohelp>
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -98,8 +98,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/Classification/DecisionTree/pom.xml
+++ b/Classification/DecisionTree/pom.xml
@@ -71,6 +71,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Classification/Experiments/pom.xml
+++ b/Classification/Experiments/pom.xml
@@ -75,6 +75,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Classification/Explanations/pom.xml
+++ b/Classification/Explanations/pom.xml
@@ -93,6 +93,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Classification/LibLinear/pom.xml
+++ b/Classification/LibLinear/pom.xml
@@ -61,6 +61,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Classification/LibSVM/pom.xml
+++ b/Classification/LibSVM/pom.xml
@@ -60,6 +60,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Classification/MultinomialNaiveBayes/pom.xml
+++ b/Classification/MultinomialNaiveBayes/pom.xml
@@ -62,6 +62,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Classification/SGD/pom.xml
+++ b/Classification/SGD/pom.xml
@@ -71,6 +71,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Classification/XGBoost/pom.xml
+++ b/Classification/XGBoost/pom.xml
@@ -66,6 +66,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Classification/pom.xml
+++ b/Classification/pom.xml
@@ -81,9 +81,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
-                    <show>public</show>
+                    <show>protected</show>
                     <failOnError>false</failOnError>
                     <linksource>true</linksource>
                     <nohelp>true</nohelp>
@@ -97,7 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -109,8 +109,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/Clustering/KMeans/pom.xml
+++ b/Clustering/KMeans/pom.xml
@@ -73,6 +73,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Clustering/pom.xml
+++ b/Clustering/pom.xml
@@ -69,9 +69,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
-                    <show>public</show>
+                    <show>protected</show>
                     <failOnError>false</failOnError>
                     <linksource>true</linksource>
                     <nohelp>true</nohelp>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -97,8 +97,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/Common/pom.xml
+++ b/Common/pom.xml
@@ -73,9 +73,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
-                    <show>public</show>
+                    <show>protected</show>
                     <failOnError>false</failOnError>
                     <linksource>true</linksource>
                     <nohelp>true</nohelp>
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -101,8 +101,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/Interop/Core/pom.xml
+++ b/Interop/Core/pom.xml
@@ -66,6 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/Interop/ONNX/pom.xml
+++ b/Interop/ONNX/pom.xml
@@ -92,6 +92,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Interop/Tensorflow/pom.xml
+++ b/Interop/Tensorflow/pom.xml
@@ -82,6 +82,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Interop/pom.xml
+++ b/Interop/pom.xml
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
                     <show>public</show>
                     <failOnError>false</failOnError>
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -98,8 +98,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/Json/pom.xml
+++ b/Json/pom.xml
@@ -71,6 +71,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/MultiLabel/SGD/pom.xml
+++ b/MultiLabel/SGD/pom.xml
@@ -71,6 +71,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/MultiLabel/pom.xml
+++ b/MultiLabel/pom.xml
@@ -69,9 +69,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
-                    <show>public</show>
+                    <show>protected</show>
                     <failOnError>false</failOnError>
                     <linksource>true</linksource>
                     <nohelp>true</nohelp>
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -97,8 +97,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/Regression/LibLinear/pom.xml
+++ b/Regression/LibLinear/pom.xml
@@ -65,6 +65,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Regression/LibSVM/pom.xml
+++ b/Regression/LibSVM/pom.xml
@@ -65,6 +65,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Regression/RegressionTree/pom.xml
+++ b/Regression/RegressionTree/pom.xml
@@ -71,6 +71,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Regression/SGD/pom.xml
+++ b/Regression/SGD/pom.xml
@@ -71,6 +71,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Regression/SLM/pom.xml
+++ b/Regression/SLM/pom.xml
@@ -71,6 +71,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Regression/XGBoost/pom.xml
+++ b/Regression/XGBoost/pom.xml
@@ -66,6 +66,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptorRefs>

--- a/Regression/pom.xml
+++ b/Regression/pom.xml
@@ -74,7 +74,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
                     <show>public</show>
                     <failOnError>false</failOnError>
@@ -90,7 +90,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -102,8 +102,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/Util/pom.xml
+++ b/Util/pom.xml
@@ -54,9 +54,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <configuration>
-                    <show>public</show>
+                    <show>protected</show>
                     <failOnError>false</failOnError>
                     <linksource>true</linksource>
                     <nohelp>true</nohelp>
@@ -70,7 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -82,8 +82,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -140,17 +140,18 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0-M5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
+                    <!-- Pinned to 2.7 due to a bug in symlink handling which is fixed in the upcoming 3.3.0 release -->
                     <version>2.7</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -159,8 +160,23 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -218,10 +234,6 @@
                     </compilerArgument>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
-            </plugin>
         </plugins>
     </build>
 
@@ -233,6 +245,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -253,6 +266,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
### Description
Sets the CI to use Java 8, 11 and 16 in line with our policy of LTS & latest releases. Tidies up the pom files, fixing plugin versions.

### Motivation
Java 16 has been out for two whole weeks now.
