### PR TITLE
Adds a way to create an ensemble out of existing models

### DIFF
--- a/Classification/Core/src/test/java/org/tribuo/classification/ensemble/VotingCombinerTest.java
+++ b/Classification/Core/src/test/java/org/tribuo/classification/ensemble/VotingCombinerTest.java
@@ -30,6 +30,7 @@ import org.tribuo.datasource.ListDataSource;
 import org.tribuo.ensemble.WeightedEnsembleModel;
 import org.tribuo.impl.ArrayExample;
 import org.tribuo.provenance.SimpleDataSourceProvenance;
+import org.tribuo.test.Helpers;
 
 import java.lang.reflect.Array;
 import java.time.OffsetDateTime;
@@ -126,6 +127,8 @@ public class VotingCombinerTest {
         prediction = ensemble.predict(testExample);
         assertEquals(prediction.getOutput(),dishwasher);
         modelList.clear();
+
+        Helpers.testModelSerialization(ensemble,Label.class);
     }
 
     @Test

--- a/Classification/Core/src/test/java/org/tribuo/classification/ensemble/VotingCombinerTest.java
+++ b/Classification/Core/src/test/java/org/tribuo/classification/ensemble/VotingCombinerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.classification.ensemble;
+
+import org.junit.jupiter.api.Test;
+import org.tribuo.Dataset;
+import org.tribuo.Example;
+import org.tribuo.Model;
+import org.tribuo.MutableDataset;
+import org.tribuo.Prediction;
+import org.tribuo.Trainer;
+import org.tribuo.classification.Label;
+import org.tribuo.classification.LabelFactory;
+import org.tribuo.classification.baseline.DummyClassifierTrainer;
+import org.tribuo.datasource.ListDataSource;
+import org.tribuo.ensemble.WeightedEnsembleModel;
+import org.tribuo.impl.ArrayExample;
+import org.tribuo.provenance.SimpleDataSourceProvenance;
+
+import java.lang.reflect.Array;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class VotingCombinerTest {
+
+    private static final LabelFactory factory = new LabelFactory();
+
+    private static final VotingCombiner votingCombiner = new VotingCombiner();
+
+    private static final Label purple = new Label("PURPLE");
+    private static final Label monkey = new Label("MONKEY");
+    private static final Label dishwasher = new Label("DISHWASHER");
+    private static final Label pidgeon = new Label("PIDGEON");
+    private static final Label dryer = new Label("DRYER");
+
+    private static final Trainer<Label> purpleTrainer = DummyClassifierTrainer.createConstantTrainer(purple.getLabel());
+    private static final Trainer<Label> monkeyTrainer = DummyClassifierTrainer.createConstantTrainer(monkey.getLabel());
+    private static final Trainer<Label> dishwasherTrainer = DummyClassifierTrainer.createConstantTrainer(dishwasher.getLabel());
+    private static final Trainer<Label> pidgeonTrainer = DummyClassifierTrainer.createConstantTrainer(pidgeon.getLabel());
+    private static final Trainer<Label> dryerTrainer = DummyClassifierTrainer.createConstantTrainer(dryer.getLabel());
+
+    private static Dataset<Label> pmdDataset() {
+        String[] featureNames = new String[]{"X_0","X_1"};
+        double[] featureValues = new double[]{1.0,2.0};
+
+        List<Example<Label>> list = new ArrayList<>();
+
+        list.add(new ArrayExample<>(purple,featureNames,featureValues));
+        list.add(new ArrayExample<>(monkey,featureNames,featureValues));
+        list.add(new ArrayExample<>(dishwasher,featureNames,featureValues));
+
+        ListDataSource<Label> source = new ListDataSource<>(list,factory,new SimpleDataSourceProvenance("first-test", OffsetDateTime.now(),factory));
+        return new MutableDataset<>(source);
+    }
+
+    private static Dataset<Label> ppdDataset() {
+        String[] featureNames = new String[]{"X_0","X_1"};
+        double[] featureValues = new double[]{1.0,2.0};
+
+        List<Example<Label>> list = new ArrayList<>();
+
+        list.add(new ArrayExample<>(purple,featureNames,featureValues));
+        list.add(new ArrayExample<>(pidgeon,featureNames,featureValues));
+        list.add(new ArrayExample<>(dryer,featureNames,featureValues));
+
+        ListDataSource<Label> source = new ListDataSource<>(list,factory,new SimpleDataSourceProvenance("first-test", OffsetDateTime.now(),factory));
+        return new MutableDataset<>(source);
+    }
+
+    @Test
+    public void votingCombinerTest() {
+        Dataset<Label> pmd = pmdDataset();
+
+        Model<Label> purpleModel = purpleTrainer.train(pmd);
+        Model<Label> monkeyModel = monkeyTrainer.train(pmd);
+        Model<Label> dishwasherModel = dishwasherTrainer.train(pmd);
+
+        List<Model<Label>> modelList = new ArrayList<>();
+
+        Example<Label> testExample = new ArrayExample<>(purple,new String[]{"X_0","X_1","X_2"}, new double[]{1,2,3});
+
+        // Ties are broken with the first prediction
+        modelList.add(purpleModel);
+        modelList.add(monkeyModel);
+        modelList.add(dishwasherModel);
+        WeightedEnsembleModel<Label> ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("monkey",modelList,votingCombiner);
+        assertEquals(3,ensemble.getNumModels());
+        Prediction<Label> prediction = ensemble.predict(testExample);
+        assertEquals(prediction.getOutput(),ensemble.getOutputIDInfo().getOutput(0));
+        modelList.clear();
+
+        // Combiner predicts the majority vote
+        modelList.add(purpleModel);
+        modelList.add(purpleModel);
+        modelList.add(dishwasherModel);
+        ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("purple",modelList,votingCombiner);
+        assertEquals(3,ensemble.getNumModels());
+        prediction = ensemble.predict(testExample);
+        assertEquals(prediction.getOutput(),purple);
+        modelList.clear();
+
+        // Weights affect the vote
+        modelList.add(purpleModel);
+        modelList.add(monkeyModel);
+        modelList.add(dishwasherModel);
+        ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("dishwasher",modelList,votingCombiner,new float[]{1,1,3});
+        assertEquals(3,ensemble.getNumModels());
+        prediction = ensemble.predict(testExample);
+        assertEquals(prediction.getOutput(),dishwasher);
+        modelList.clear();
+    }
+
+    @Test
+    public void existingModelEnsembleTest() {
+        Dataset<Label> pmd = pmdDataset();
+        Dataset<Label> ppd = ppdDataset();
+
+        Model<Label> purpleModel = purpleTrainer.train(pmd);
+        Model<Label> monkeyModel = monkeyTrainer.train(pmd);
+        Model<Label> dishwasherModel = dishwasherTrainer.train(pmd);
+        Model<Label> pidgeonModel = pidgeonTrainer.train(ppd);
+
+        List<Model<Label>> modelList = new ArrayList<>();
+
+        // Empty list throws
+        assertThrows(IllegalArgumentException.class, () -> WeightedEnsembleModel.createEnsembleFromExistingModels("empty",modelList,votingCombiner));
+
+        // Less than 2 members throws
+        modelList.add(purpleModel);
+        assertThrows(IllegalArgumentException.class, () -> WeightedEnsembleModel.createEnsembleFromExistingModels("one-member",modelList,votingCombiner));
+        modelList.clear();
+
+        // Mismatch between models and weights throws
+        modelList.add(purpleModel);
+        modelList.add(monkeyModel);
+        assertThrows(IllegalArgumentException.class, () -> WeightedEnsembleModel.createEnsembleFromExistingModels("model-weight-mismatch",modelList,votingCombiner,new float[5]));
+        modelList.clear();
+
+        // Mismatch between model output dimensions throws
+        modelList.add(purpleModel);
+        modelList.add(pidgeonModel);
+        assertThrows(IllegalArgumentException.class, () -> WeightedEnsembleModel.createEnsembleFromExistingModels("output-mismatch",modelList,votingCombiner));
+        modelList.clear();
+
+        // Created an ensemble
+        modelList.add(purpleModel);
+        modelList.add(monkeyModel);
+        modelList.add(dishwasherModel);
+        WeightedEnsembleModel<Label> ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("valid",modelList,votingCombiner);
+        assertEquals(3,ensemble.getNumModels());
+    }
+
+}

--- a/Core/src/main/java/org/tribuo/ensemble/EnsembleModel.java
+++ b/Core/src/main/java/org/tribuo/ensemble/EnsembleModel.java
@@ -44,8 +44,16 @@ public abstract class EnsembleModel<T extends Output<T>> extends Model<T> {
 
     protected final List<Model<T>> models;
 
-    public EnsembleModel(String name, EnsembleModelProvenance description, ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<T> outputIDInfo, List<Model<T>> newModels) {
-        super(name,description,featureIDMap,outputIDInfo,true);
+    /**
+     * Builds an EnsembleModel from the supplied model list.
+     * @param name The name of this ensemble.
+     * @param provenance The model provenance.
+     * @param featureIDMap The feature domain.
+     * @param outputIDInfo The output domain.
+     * @param newModels The ensemble members.
+     */
+    protected EnsembleModel(String name, EnsembleModelProvenance provenance, ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<T> outputIDInfo, List<Model<T>> newModels) {
+        super(name,provenance,featureIDMap,outputIDInfo,true);
         models = Collections.unmodifiableList(newModels);
     }
 
@@ -78,6 +86,13 @@ public abstract class EnsembleModel<T extends Output<T>> extends Model<T> {
         return copy(name,(EnsembleModelProvenance)newProvenance,new ArrayList<>(models));
     }
 
+    /**
+     * Copies this ensemble model.
+     * @param name The new name.
+     * @param newProvenance The new provenance.
+     * @param newModels The new models.
+     * @return A copy of the ensemble model.
+     */
     protected abstract EnsembleModel<T> copy(String name, EnsembleModelProvenance newProvenance, List<Model<T>> newModels);
 
     @Override

--- a/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
+++ b/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
@@ -49,7 +49,7 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
     protected final EnsembleCombiner<T> combiner;
 
     /**
-     * Constructs a weighted ensemble model.
+     * Constructs an ensemble model which uses uniform weights.
      * @param name The model name.
      * @param provenance The model provenance.
      * @param featureIDMap The feature domain.
@@ -138,7 +138,8 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
     /**
      * Creates an ensemble from existing models. The model outputs are combined using uniform weights.
      * <p>
-     * Uses the feature and output domain from the first model.
+     * Uses the feature and output domain from the first model as the ensemble model's domains.
+     * The individual ensemble members use the domains that they contain.
      * <p>
      * If the output domains don't cover the same dimensions then it throws {@link IllegalArgumentException}.
      * @param name The ensemble name.
@@ -154,7 +155,8 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
     /**
      * Creates an ensemble from existing models.
      * <p>
-     * Uses the feature and output domain from the first model.
+     * Uses the feature and output domain from the first model as the ensemble model's domains.
+     * The individual ensemble members use the domains that they contain.
      * <p>
      * If the output domains don't cover the same dimensions then it throws {@link IllegalArgumentException}.
      * If the weights aren't the same length as the models it throws {@link IllegalArgumentException}.

--- a/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
+++ b/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
@@ -152,7 +152,7 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
     }
 
     /**
-     * Creates an ensemble from existing models. The model outputs are combined using uniform weights.
+     * Creates an ensemble from existing models.
      * <p>
      * Uses the feature and output domain from the first model.
      * <p>

--- a/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
+++ b/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
@@ -49,6 +49,9 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
     protected final EnsembleCombiner<T> combiner;
 
     /**
+     * Unless you are implementing a {@link org.tribuo.Trainer} you should
+     * not use this constructor directly. Instead use {@link #createEnsembleFromExistingModels(String, List<Model<T>>, EnsembleCombiner<T>)}.
+     * <p>
      * Constructs an ensemble model which uses uniform weights.
      * @param name The model name.
      * @param provenance The model provenance.
@@ -64,7 +67,10 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
     }
 
     /**
-     * Constructs a weighted ensemble model.
+     * Unless you are implementing a {@link org.tribuo.Trainer} you should
+     * not use this constructor directly. Instead use {@link #createEnsembleFromExistingModels(String, List<Model<T>>, EnsembleCombiner<T>, float[])}.
+     * <p>
+     * Constructs an ensemble model which uses uniform weights.
      * @param name The model name.
      * @param provenance The model provenance.
      * @param featureIDMap The feature domain.

--- a/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
+++ b/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
@@ -16,6 +16,7 @@
 
 package org.tribuo.ensemble;
 
+import com.oracle.labs.mlrg.olcut.provenance.ListProvenance;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.Example;
 import org.tribuo.Excuse;
@@ -25,8 +26,10 @@ import org.tribuo.Model;
 import org.tribuo.Output;
 import org.tribuo.Prediction;
 import org.tribuo.provenance.EnsembleModelProvenance;
+import org.tribuo.provenance.impl.TimestampedTrainerProvenance;
 import org.tribuo.util.Util;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,16 +48,35 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
 
     protected final EnsembleCombiner<T> combiner;
 
-    public WeightedEnsembleModel(String name, EnsembleModelProvenance description, ImmutableFeatureMap featureIDMap,
+    /**
+     * Constructs a weighted ensemble model.
+     * @param name The model name.
+     * @param provenance The model provenance.
+     * @param featureIDMap The feature domain.
+     * @param outputIDInfo The output domain.
+     * @param newModels The list of ensemble members.
+     * @param combiner The combination function.
+     */
+    public WeightedEnsembleModel(String name, EnsembleModelProvenance provenance, ImmutableFeatureMap featureIDMap,
                                  ImmutableOutputInfo<T> outputIDInfo,
                                  List<Model<T>> newModels, EnsembleCombiner<T> combiner) {
-        this(name,description,featureIDMap,outputIDInfo,newModels, combiner, Util.generateUniformVector(newModels.size(), 1.0f/newModels.size()));
+        this(name,provenance,featureIDMap,outputIDInfo,newModels, combiner, Util.generateUniformVector(newModels.size(), 1.0f/newModels.size()));
     }
 
-    public WeightedEnsembleModel(String name, EnsembleModelProvenance description, ImmutableFeatureMap featureIDMap,
+    /**
+     * Constructs a weighted ensemble model.
+     * @param name The model name.
+     * @param provenance The model provenance.
+     * @param featureIDMap The feature domain.
+     * @param outputIDInfo The output domain.
+     * @param newModels The list of ensemble members.
+     * @param combiner The combination function.
+     * @param weights The model combination weights.
+     */
+    public WeightedEnsembleModel(String name, EnsembleModelProvenance provenance, ImmutableFeatureMap featureIDMap,
                           ImmutableOutputInfo<T> outputIDInfo,
                           List<Model<T>> newModels, EnsembleCombiner<T> combiner, float[] weights) {
-        super(name,description,featureIDMap,outputIDInfo,newModels);
+        super(name,provenance,featureIDMap,outputIDInfo,newModels);
         this.weights = Arrays.copyOf(weights,weights.length);
         this.combiner = combiner;
     }
@@ -111,5 +133,79 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
     @Override
     protected EnsembleModel<T> copy(String name, EnsembleModelProvenance newProvenance, List<Model<T>> newModels) {
         return new WeightedEnsembleModel<>(name,newProvenance,featureIDMap,outputIDInfo,newModels,combiner);
+    }
+
+    /**
+     * Creates an ensemble from existing models. The model outputs are combined using uniform weights.
+     * <p>
+     * Uses the feature and output domain from the first model.
+     * <p>
+     * If the output domains don't cover the same dimensions then it throws {@link IllegalArgumentException}.
+     * @param name The ensemble name.
+     * @param models The ensemble members.
+     * @param combiner The combination function.
+     * @param <T> The output type.
+     * @return A weighted ensemble model.
+     */
+    public static <T extends Output<T>> WeightedEnsembleModel<T> createEnsembleFromExistingModels(String name, List<Model<T>> models, EnsembleCombiner<T> combiner) {
+        return createEnsembleFromExistingModels(name,models,combiner,Util.generateUniformVector(models.size(), 1.0f/models.size()));
+    }
+
+    /**
+     * Creates an ensemble from existing models. The model outputs are combined using uniform weights.
+     * <p>
+     * Uses the feature and output domain from the first model.
+     * <p>
+     * If the output domains don't cover the same dimensions then it throws {@link IllegalArgumentException}.
+     * If the weights aren't the same length as the models it throws {@link IllegalArgumentException}.
+     * @param name The ensemble name.
+     * @param models The ensemble members.
+     * @param combiner The combination function.
+     * @param weights The model combination weights.
+     * @param <T> The output type.
+     * @return A weighted ensemble model.
+     */
+    public static <T extends Output<T>> WeightedEnsembleModel<T> createEnsembleFromExistingModels(String name, List<Model<T>> models, EnsembleCombiner<T> combiner, float[] weights) {
+        // Basic parameter validation
+        if (models.size() < 2) {
+            throw new IllegalArgumentException("Must supply at least 2 models, found " + models.size());
+        }
+        if (weights.length != models.size()) {
+            throw new IllegalArgumentException("Must supply one weight per model, models.size() = " + models.size() + ", weights.length = " + weights.length);
+        }
+
+        // Validate output domains
+        ImmutableOutputInfo<T> outputInfo = models.get(0).getOutputIDInfo();
+        List<Pair<Integer,T>> firstList = new ArrayList<>();
+        for (Pair<Integer,T> p : outputInfo) {
+            firstList.add(p);
+        }
+        List<Pair<Integer,T>> comparisonList = new ArrayList<>();
+        for (int i = 1; i < models.size(); i++) {
+            comparisonList.clear();
+            for (Pair<Integer,T> p : models.get(i).getOutputIDInfo()) {
+                comparisonList.add(p);
+            }
+            if (!firstList.equals(comparisonList)) {
+                throw new IllegalArgumentException("Model output domains are not equal.");
+            }
+        }
+
+        // Extract feature domain
+        ImmutableFeatureMap featureMap = models.get(0).getFeatureIDMap();
+
+        // Defensive copy the model list (the weights are copied in the constructor)
+        List<Model<T>> modelList = new ArrayList<>(models);
+
+        // Build EnsembleModelProvenance
+        TimestampedTrainerProvenance trainerProvenance = new TimestampedTrainerProvenance();
+        EnsembleModelProvenance provenance = new EnsembleModelProvenance(
+                WeightedEnsembleModel.class.getName(), OffsetDateTime.now(),
+                models.get(0).getProvenance().getDatasetProvenance(),
+                trainerProvenance,
+                ListProvenance.createListProvenance(models)
+                );
+
+        return new WeightedEnsembleModel<>("ensemble-from-existing-models",provenance,featureMap,outputInfo,modelList,combiner,weights);
     }
 }

--- a/Core/src/main/java/org/tribuo/provenance/impl/TimestampedTrainerProvenance.java
+++ b/Core/src/main/java/org/tribuo/provenance/impl/TimestampedTrainerProvenance.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.provenance.impl;
+
+import com.oracle.labs.mlrg.olcut.provenance.PrimitiveProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import com.oracle.labs.mlrg.olcut.provenance.ProvenanceException;
+import com.oracle.labs.mlrg.olcut.provenance.primitives.DateTimeProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
+import org.tribuo.Trainer;
+import org.tribuo.Tribuo;
+import org.tribuo.provenance.TrainerProvenance;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A TrainerProvenance with a timestamp, used when there was no trainer
+ * involved in model construction (e.g., creating an EnsembleModel from existing models).
+ */
+public final class TimestampedTrainerProvenance implements TrainerProvenance {
+    private static final long serialVersionUID = 1L;
+
+    public static final String CREATION_TIME = "creation-time";
+
+    private final DateTimeProvenance creationTime;
+    private final StringProvenance version;
+
+    /**
+     * Creates a TimestampedTrainerProvenance, tracking the creation time and Tribuo version.
+     */
+    public TimestampedTrainerProvenance() {
+        this.creationTime = new DateTimeProvenance(CREATION_TIME, OffsetDateTime.now());
+        this.version = new StringProvenance(TRIBUO_VERSION_STRING, Tribuo.VERSION);
+    }
+
+    /**
+     * Used for deserializing provenances from the marshalled form.
+     * @param map The provenance map.
+     */
+    public TimestampedTrainerProvenance(Map<String,Provenance> map) {
+        Provenance tmp = map.get(TRIBUO_VERSION_STRING);
+        if (tmp != null) {
+            if (StringProvenance.class.isInstance(tmp)) {
+                this.version = (StringProvenance) tmp;
+            } else {
+                throw new ProvenanceException("Failed to cast " + TRIBUO_VERSION_STRING + " when constructing TimestampedTrainerProvenance, found " + tmp);
+            }
+        } else {
+            throw new ProvenanceException("Failed to find " + TRIBUO_VERSION_STRING + " when constructing TimestampedTrainerProvenance");
+        }
+        tmp = map.get(CREATION_TIME);
+        if (tmp != null) {
+            if (DateTimeProvenance.class.isInstance(tmp)) {
+                this.creationTime = (DateTimeProvenance) tmp;
+            } else {
+                throw new ProvenanceException("Failed to cast " + CREATION_TIME + " when constructing TimestampedTrainerProvenance, found " + tmp);
+            }
+        } else {
+            throw new ProvenanceException("Failed to find " + CREATION_TIME + " when constructing TimestampedTrainerProvenance");
+        }
+    }
+
+    @Override
+    public Map<String, PrimitiveProvenance<?>> getInstanceValues() {
+        Map<String,PrimitiveProvenance<?>> provMap = new HashMap<>();
+        provMap.put(CREATION_TIME,creationTime);
+        provMap.put(TRIBUO_VERSION_STRING,version);
+        return provMap;
+    }
+
+    @Override
+    public Map<String, Provenance> getConfiguredParameters() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String getClassName() {
+        return Trainer.class.getName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TimestampedTrainerProvenance pairs = (TimestampedTrainerProvenance) o;
+        return creationTime.equals(pairs.creationTime) && version.equals(pairs.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(creationTime, version);
+    }
+
+    @Override
+    public String toString() {
+        return generateString("Trainer");
+    }
+}

--- a/Regression/Core/src/test/java/org/tribuo/regression/ensemble/AveragingCombinerTest.java
+++ b/Regression/Core/src/test/java/org/tribuo/regression/ensemble/AveragingCombinerTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.regression.ensemble;
+
+import org.junit.jupiter.api.Test;
+import org.tribuo.Dataset;
+import org.tribuo.Example;
+import org.tribuo.Model;
+import org.tribuo.MutableDataset;
+import org.tribuo.Prediction;
+import org.tribuo.Trainer;
+import org.tribuo.datasource.ListDataSource;
+import org.tribuo.ensemble.WeightedEnsembleModel;
+import org.tribuo.impl.ArrayExample;
+import org.tribuo.provenance.SimpleDataSourceProvenance;
+import org.tribuo.regression.RegressionFactory;
+import org.tribuo.regression.Regressor;
+import org.tribuo.regression.baseline.DummyRegressionTrainer;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AveragingCombinerTest {
+
+    private static final RegressionFactory factory = new RegressionFactory();
+
+    private static final AveragingCombiner averagingCombiner = new AveragingCombiner();
+
+    private static final String[] abc = new String[]{"a","b","c"};
+    private static final String[] xyz = new String[]{"x","y","z"};
+
+    private static final Trainer<Regressor> fiveTrainer = DummyRegressionTrainer.createConstantTrainer(5);
+    private static final Trainer<Regressor> threeTrainer = DummyRegressionTrainer.createConstantTrainer(3);
+    private static final Trainer<Regressor> oneTrainer = DummyRegressionTrainer.createConstantTrainer(1);
+
+    private static Dataset<Regressor> abcDataset() {
+        String[] featureNames = new String[]{"X_0","X_1"};
+        double[] featureValues = new double[]{1.0,2.0};
+
+        List<Example<Regressor>> list = new ArrayList<>();
+
+        list.add(new ArrayExample<>(new Regressor(abc,new double[]{1,2,3}),featureNames,featureValues));
+        list.add(new ArrayExample<>(new Regressor(abc,new double[]{4,5,6}),featureNames,featureValues));
+        list.add(new ArrayExample<>(new Regressor(abc,new double[]{-4,-5,-6}),featureNames,featureValues));
+
+        ListDataSource<Regressor> source = new ListDataSource<>(list,factory,new SimpleDataSourceProvenance("first-test", OffsetDateTime.now(),factory));
+        return new MutableDataset<>(source);
+    }
+
+    private static Dataset<Regressor> xyzDataset() {
+        String[] featureNames = new String[]{"X_0","X_1"};
+        double[] featureValues = new double[]{1.0,2.0};
+
+        List<Example<Regressor>> list = new ArrayList<>();
+
+        list.add(new ArrayExample<>(new Regressor(xyz,new double[]{3,2,1}),featureNames,featureValues));
+        list.add(new ArrayExample<>(new Regressor(xyz,new double[]{6,5,-4}),featureNames,featureValues));
+        list.add(new ArrayExample<>(new Regressor(xyz,new double[]{-6,-5,-4}),featureNames,featureValues));
+
+        ListDataSource<Regressor> source = new ListDataSource<>(list,factory,new SimpleDataSourceProvenance("first-test", OffsetDateTime.now(),factory));
+        return new MutableDataset<>(source);
+    }
+
+    @Test
+    public void averagingCombinerTest() {
+        Dataset<Regressor> abcDataset = abcDataset();
+
+        Model<Regressor> fiveModel = fiveTrainer.train(abcDataset);
+        Model<Regressor> threeModel = threeTrainer.train(abcDataset);
+        Model<Regressor> oneModel = oneTrainer.train(abcDataset);
+
+        List<Model<Regressor>> modelList = new ArrayList<>();
+
+        Example<Regressor> testExample = new ArrayExample<>(new Regressor(abc,new double[]{-1,-1,-1}),new String[]{"X_0","X_1","X_2"}, new double[]{1,2,3});
+
+        // Combiner predicts the average
+        modelList.add(fiveModel);
+        modelList.add(threeModel);
+        modelList.add(oneModel);
+        WeightedEnsembleModel<Regressor> ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("average",modelList, averagingCombiner);
+        assertEquals(3,ensemble.getNumModels());
+        Prediction<Regressor> prediction = ensemble.predict(testExample);
+        Regressor target = new Regressor(abc,new double[]{3,3,3});
+        assertArrayEquals(prediction.getOutput().getValues(),target.getValues());
+        modelList.clear();
+
+        // Weights affect the averaging
+        modelList.add(fiveModel);
+        modelList.add(threeModel);
+        modelList.add(oneModel);
+        ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("weighted",modelList, averagingCombiner,new float[]{3,1,1});
+        assertEquals(3,ensemble.getNumModels());
+        prediction = ensemble.predict(testExample);
+        target = new Regressor(abc,new double[]{3.8,3.8,3.8});
+        assertArrayEquals(prediction.getOutput().getValues(),target.getValues());
+        modelList.clear();
+    }
+
+    @Test
+    public void existingModelEnsembleTest() {
+        Dataset<Regressor> abcDataset = abcDataset();
+        Dataset<Regressor> xyzDataset = xyzDataset();
+
+        Model<Regressor> fiveModel = fiveTrainer.train(abcDataset);
+        Model<Regressor> oneModel = oneTrainer.train(abcDataset);
+        Model<Regressor> fiveXYZModel = fiveTrainer.train(xyzDataset);
+
+        List<Model<Regressor>> modelList = new ArrayList<>();
+
+        // Mismatch between model output dimensions throws
+        modelList.add(fiveModel);
+        modelList.add(fiveXYZModel);
+        assertThrows(IllegalArgumentException.class, () -> WeightedEnsembleModel.createEnsembleFromExistingModels("invalid-dimensions",modelList, averagingCombiner));
+        modelList.clear();
+
+        // Created an ensemble
+        modelList.add(fiveModel);
+        modelList.add(oneModel);
+        WeightedEnsembleModel<Regressor> ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("valid",modelList, averagingCombiner);
+        assertEquals(2,ensemble.getNumModels());
+    }
+
+}

--- a/Regression/Core/src/test/java/org/tribuo/regression/ensemble/AveragingCombinerTest.java
+++ b/Regression/Core/src/test/java/org/tribuo/regression/ensemble/AveragingCombinerTest.java
@@ -30,6 +30,7 @@ import org.tribuo.provenance.SimpleDataSourceProvenance;
 import org.tribuo.regression.RegressionFactory;
 import org.tribuo.regression.Regressor;
 import org.tribuo.regression.baseline.DummyRegressionTrainer;
+import org.tribuo.test.Helpers;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -114,6 +115,8 @@ public class AveragingCombinerTest {
         target = new Regressor(abc,new double[]{3.8,3.8,3.8});
         assertArrayEquals(prediction.getOutput().getValues(),target.getValues());
         modelList.clear();
+
+        Helpers.testModelSerialization(ensemble,Regressor.class);
     }
 
     @Test


### PR DESCRIPTION
### Description
This PR adds a method to `WeightedEnsembleModel` called `createEnsembleFromExistingModels` which builds an ensemble out of the supplied model list, ensemble combiner and optionally model combination weights. It adds a `TimestampTrainerProvenance` which is used as the `TrainerProvenance` for any ensembles created this way. Finally it adds a couple of tests for `VotingCombiner` and `AveragingCombiner` along with a few tests of the new behaviour.

The ensemble building mechanism validates that there are at least two models, that there are equal numbers of models and combination weights and that the output domains for all the supplied models are the same. We could consider adding a check that the feature domains are the same, or have some overlap, but it's plausible that text models trained using data subsampling have different views of the feature space and so I've left that check for future work.

### Motivation
It's currently hard in Tribuo to ensemble together models of different types (e.g. an ensemble of a linear model, a decision tree and a kernel SVM). This kind of arbitrary ensembling is occasionally very powerful, but difficult to express via Tribuo's trainer mechanism, so it's simpler to allow users to build custom ensembles from models they already have.

### Paper reference
Kuncheva, L. I. (2014). Combining pattern classifiers: methods and algorithms.
