### PR TITLE
Bump OpenCSV to 5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <xgboost.version>1.3.1</xgboost.version>
 
         <!-- 3rd party other dependencies -->
-        <junit.version>5.6.2</junit.version>
-        <opencsv.version>5.2</opencsv.version>
+        <junit.version>5.7.1</junit.version>
+        <opencsv.version>5.4</opencsv.version>
         <commonsmath.version>3.6.1</commonsmath.version>
 
         <!-- Other properties -->
@@ -178,6 +178,11 @@
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.3.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -233,6 +238,11 @@
                         -Xlint:all
                     </compilerArgument>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
### Description
OpenCSV 5.2 has a dependency conflict with itself (it pulls in two versions of Apache Commons Lang 3). This bumps the dependency to 5.4 which doesn't have the issue, and also adds the Maven Enforcer plugin to fix #131.

### Motivation
Depending on multiple versions of the same library is likely to cause trouble when deploying Tribuo, even if it's transitively.
