### PR TITLE
Upgrades OLCUT to 5.1.6

### DIFF
--- a/Core/src/main/java/org/tribuo/datasource/AggregateDataSource.java
+++ b/Core/src/main/java/org/tribuo/datasource/AggregateDataSource.java
@@ -27,7 +27,6 @@ import org.tribuo.Example;
 import org.tribuo.Output;
 import org.tribuo.OutputFactory;
 import org.tribuo.provenance.DataSourceProvenance;
-import org.tribuo.provenance.ModelProvenance;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -208,8 +207,9 @@ public class AggregateDataSource<T extends Output<T>> implements DataSource<T> {
         public AggregateDataSourceProvenance(Map<String,Provenance> map) {
             this.className = ObjectProvenance.checkAndExtractProvenance(map,CLASS_NAME, StringProvenance.class,AggregateDataSourceProvenance.class.getSimpleName());
             this.provenances = ObjectProvenance.checkAndExtractProvenance(map,SOURCES,ListProvenance.class,AggregateDataSourceProvenance.class.getSimpleName());
-            // TODO fix this when we upgrade OLCUT.
-            Optional<EnumProvenance> opt = ModelProvenance.maybeExtractProvenance(map,ORDER,EnumProvenance.class);
+
+            // Provenance added in Tribuo 4.1
+            Optional<EnumProvenance> opt = ObjectProvenance.maybeExtractProvenance(map,ORDER,EnumProvenance.class,AggregateDataSourceProvenance.class.getSimpleName());
             this.orderProvenance = opt.orElseGet(() -> new EnumProvenance<>(ORDER, IterationOrder.SEQUENTIAL));
         }
 

--- a/Core/src/main/java/org/tribuo/provenance/ModelProvenance.java
+++ b/Core/src/main/java/org/tribuo/provenance/ModelProvenance.java
@@ -157,37 +157,10 @@ public class ModelProvenance implements ObjectProvenance {
         this.instanceProvenance = (MapProvenance<?>) ObjectProvenance.checkAndExtractProvenance(map,INSTANCE_VALUES,MapProvenance.class, ModelProvenance.class.getSimpleName());
         this.versionString = ObjectProvenance.checkAndExtractProvenance(map,TRIBUO_VERSION_STRING,StringProvenance.class,ModelProvenance.class.getSimpleName()).getValue();
 
-        // TODO fix this when we upgrade OLCUT.
-        this.javaVersionString = maybeExtractProvenance(map,JAVA_VERSION_STRING,StringProvenance.class).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
-        this.osString = maybeExtractProvenance(map,OS_STRING,StringProvenance.class).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
-        this.archString = maybeExtractProvenance(map,ARCH_STRING,StringProvenance.class).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
-    }
-
-    /**
-     * Like {@link ObjectProvenance#checkAndExtractProvenance(Map, String, Class, String)} but doesn't
-     * throw if it fails to find the key, only if the value is of the wrong type.
-     *
-     * @deprecated Deprecated as it's in OLCUT.
-     * @param map The map to inspect.
-     * @param key The key to find.
-     * @param type The class of the value.
-     * @param <T> The type of the value.
-     * @return An optional containing the value if present.
-     * @throws ProvenanceException If the value is the wrong type.
-     */
-    @SuppressWarnings("unchecked") // Guarded by isInstance check
-    @Deprecated
-    public static <T extends Provenance> Optional<T> maybeExtractProvenance(Map<String,Provenance> map, String key, Class<T> type) throws ProvenanceException {
-        Provenance tmp = map.remove(key);
-        if (tmp != null) {
-            if (type.isInstance(tmp)) {
-                return Optional.of((T) tmp);
-            } else {
-                throw new ProvenanceException("Failed to cast " + key + " when constructing ModelProvenance, found " + tmp);
-            }
-        } else {
-            return Optional.empty();
-        }
+        // Provenances added in Tribuo 4.1
+        this.javaVersionString = ObjectProvenance.maybeExtractProvenance(map,JAVA_VERSION_STRING,StringProvenance.class,ModelProvenance.class.getSimpleName()).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
+        this.osString = ObjectProvenance.maybeExtractProvenance(map,OS_STRING,StringProvenance.class,ModelProvenance.class.getSimpleName()).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
+        this.archString = ObjectProvenance.maybeExtractProvenance(map,ARCH_STRING,StringProvenance.class,ModelProvenance.class.getSimpleName()).map(StringProvenance::getValue).orElse(UNKNOWN_VERSION);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- MLRG dependencies -->
-        <olcut.version>5.1.5</olcut.version>
+        <olcut.version>5.1.6</olcut.version>
 
         <!-- 3rd party backend dependencies -->
         <liblinear.version>2.43</liblinear.version>


### PR DESCRIPTION
### Description
Bumps OLCUT to 5.1.6 and migrates ModelProvenance.maybeExtractProvenance over to ObjectProvenance.maybeExtractProvenance.

### Motivation
Pulls in updated jline3 and jackson dependencies and a few OLCUT bug fixes.
