### PR TITLE
Refactoring AbstractLinearSGDModel and Trainer to extract SGD base classes

### DIFF
--- a/Classification/SGD/src/main/java/org/tribuo/classification/sgd/linear/LinearSGDModel.java
+++ b/Classification/SGD/src/main/java/org/tribuo/classification/sgd/linear/LinearSGDModel.java
@@ -47,7 +47,7 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Label> {
 
     private final VectorNormalizer normalizer;
 
-    // Unused as the weights now live in AbstractLinearSGDModel
+    // Unused as the weights now live in AbstractSGDModel
     // It remains for serialization compatibility with Tribuo 4.0
     @Deprecated
     private DenseMatrix weights = null;
@@ -65,24 +65,7 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Label> {
     LinearSGDModel(String name, ModelProvenance provenance,
                    ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<Label> outputIDInfo,
                    LinearParameters parameters, VectorNormalizer normalizer, boolean generatesProbabilities) {
-        super(name, provenance, featureIDMap, outputIDInfo, parameters.getWeightMatrix(), generatesProbabilities);
-        this.normalizer = normalizer;
-    }
-
-    /**
-     * Constructs a linear classification model trained via SGD.
-     * @param name The model name.
-     * @param provenance The model provenance.
-     * @param featureIDMap The feature domain.
-     * @param outputIDInfo The output domain.
-     * @param weights The model parameters (i.e., the weight matrix).
-     * @param normalizer The normalization function.
-     * @param generatesProbabilities Does this model generate probabilities?
-     */
-    private LinearSGDModel(String name, ModelProvenance provenance,
-                          ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<Label> outputIDInfo,
-                          DenseMatrix weights, VectorNormalizer normalizer, boolean generatesProbabilities) {
-        super(name, provenance, featureIDMap, outputIDInfo, weights, generatesProbabilities);
+        super(name, provenance, featureIDMap, outputIDInfo, parameters, generatesProbabilities);
         this.normalizer = normalizer;
     }
 
@@ -110,7 +93,7 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Label> {
 
     @Override
     protected LinearSGDModel copy(String newName, ModelProvenance newProvenance) {
-        return new LinearSGDModel(newName,newProvenance,featureIDMap,outputIDInfo,new DenseMatrix(baseWeights),normalizer,generatesProbabilities);
+        return new LinearSGDModel(newName,newProvenance,featureIDMap,outputIDInfo,(LinearParameters)modelParameters.copy(),normalizer,generatesProbabilities);
     }
 
     @Override
@@ -122,9 +105,10 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Label> {
         in.defaultReadObject();
 
         // Bounce old 4.0 style models into the new 4.1 style models
-        if (weights != null && baseWeights == null) {
-            baseWeights = weights;
+        if (weights != null && modelParameters == null) {
+            modelParameters = new LinearParameters(weights);
             weights = null;
+            addBias = true;
         }
     }
 }

--- a/Classification/SGD/src/test/java/org/tribuo/classification/sgd/linear/TestSGDLinear.java
+++ b/Classification/SGD/src/test/java/org/tribuo/classification/sgd/linear/TestSGDLinear.java
@@ -28,6 +28,8 @@ import org.tribuo.classification.evaluation.LabelEvaluation;
 import org.tribuo.classification.evaluation.LabelEvaluator;
 import org.tribuo.classification.example.LabelledDataGenerator;
 import org.tribuo.classification.sgd.objectives.Hinge;
+import org.tribuo.common.sgd.AbstractLinearSGDTrainer;
+import org.tribuo.common.sgd.AbstractSGDTrainer;
 import org.tribuo.dataset.DatasetView;
 import org.tribuo.math.optimisers.AdaGrad;
 import org.junit.jupiter.api.Assertions;
@@ -52,8 +54,11 @@ public class TestSGDLinear {
 
     @BeforeAll
     public static void setup() {
-        Logger logger = Logger.getLogger(LinearSGDTrainer.class.getName());
-        logger.setLevel(Level.WARNING);
+        Class<?>[] classes = new Class<?>[]{AbstractSGDTrainer.class, AbstractLinearSGDTrainer.class,LinearSGDTrainer.class};
+        for (Class c : classes) {
+            Logger logger = Logger.getLogger(c.getName());
+            logger.setLevel(Level.WARNING);
+        }
     }
 
     public static Model<Label> testSGDLinear(Pair<Dataset<Label>,Dataset<Label>> p) {

--- a/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractLinearSGDTrainer.java
+++ b/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractLinearSGDTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,36 +16,17 @@
 
 package org.tribuo.common.sgd;
 
-import com.oracle.labs.mlrg.olcut.config.Config;
-import com.oracle.labs.mlrg.olcut.provenance.Provenance;
-import com.oracle.labs.mlrg.olcut.util.Pair;
-import org.tribuo.Dataset;
-import org.tribuo.Example;
-import org.tribuo.ImmutableFeatureMap;
-import org.tribuo.ImmutableOutputInfo;
-import org.tribuo.Model;
 import org.tribuo.Output;
-import org.tribuo.Trainer;
-import org.tribuo.WeightedExamples;
 import org.tribuo.math.LinearParameters;
 import org.tribuo.math.StochasticGradientOptimiser;
-import org.tribuo.math.la.DenseVector;
-import org.tribuo.math.la.SGDVector;
-import org.tribuo.math.la.SparseVector;
-import org.tribuo.math.la.Tensor;
-import org.tribuo.math.optimisers.AdaGrad;
-import org.tribuo.provenance.ModelProvenance;
-import org.tribuo.provenance.TrainerProvenance;
-import org.tribuo.provenance.impl.TrainerProvenanceImpl;
 
-import java.time.OffsetDateTime;
-import java.util.Collections;
-import java.util.Map;
-import java.util.SplittableRandom;
 import java.util.logging.Logger;
 
 /**
  * A trainer for a linear model which uses SGD.
+ * <p>
+ * It's an {@link AbstractSGDTrainer} operating on {@link LinearParameters}, with
+ * the bias folded into the features.
  * <p>
  * See:
  * <pre>
@@ -54,30 +35,8 @@ import java.util.logging.Logger;
  * Proceedings of COMPSTAT, 2010.
  * </pre>
  */
-public abstract class AbstractLinearSGDTrainer<T extends Output<T>,U> implements Trainer<T>, WeightedExamples {
+public abstract class AbstractLinearSGDTrainer<T extends Output<T>,U> extends AbstractSGDTrainer<T,U,AbstractLinearSGDModel<T>,LinearParameters> {
     private static final Logger logger = Logger.getLogger(AbstractLinearSGDTrainer.class.getName());
-
-    @Config(description="The gradient optimiser to use.")
-    protected StochasticGradientOptimiser optimiser = new AdaGrad(1.0,0.1);
-
-    @Config(description="The number of gradient descent epochs.")
-    protected int epochs = 5;
-
-    @Config(description="Log values after this many updates.")
-    protected int loggingInterval = -1;
-
-    @Config(description="Minibatch size in SGD.")
-    protected int minibatchSize = 1;
-
-    @Config(description="Seed for the RNG used to shuffle elements.")
-    protected long seed = Trainer.DEFAULT_SEED;
-
-    @Config(description="Shuffle the data before each epoch. Only turn off for debugging.")
-    protected boolean shuffle = true;
-
-    protected SplittableRandom rng;
-
-    private int trainInvocationCounter;
 
     /**
      * Constructs an SGD trainer for a linear model.
@@ -88,236 +47,33 @@ public abstract class AbstractLinearSGDTrainer<T extends Output<T>,U> implements
      * @param seed A seed for the random number generator, used to shuffle the examples before each epoch.
      */
     protected AbstractLinearSGDTrainer(StochasticGradientOptimiser optimiser, int epochs, int loggingInterval, int minibatchSize, long seed) {
-        this.optimiser = optimiser;
-        this.epochs = epochs;
-        this.loggingInterval = loggingInterval;
-        this.minibatchSize = minibatchSize;
-        this.seed = seed;
-        postConfig();
-    }
-
-    /**
-     * Constructs an SGD trainer for a linear model.
-     * <p>
-     * Sets the minibatch size to 1.
-     * @param optimiser The gradient optimiser to use.
-     * @param epochs The number of epochs (complete passes through the training data).
-     * @param loggingInterval Log the loss after this many iterations. If -1 don't log anything.
-     * @param seed A seed for the random number generator, used to shuffle the examples before each epoch.
-     */
-    protected AbstractLinearSGDTrainer(StochasticGradientOptimiser optimiser, int epochs, int loggingInterval, long seed) {
-        this(optimiser,epochs,loggingInterval,1,seed);
-    }
-
-    /**
-     * Constructs an SGD trainer for a linear model.
-     * <p>
-     * Sets the minibatch size to 1 and the logging interval to 1000.
-     * @param optimiser The gradient optimiser to use.
-     * @param epochs The number of epochs (complete passes through the training data).
-     * @param seed A seed for the random number generator, used to shuffle the examples before each epoch.
-     */
-    protected AbstractLinearSGDTrainer(StochasticGradientOptimiser optimiser, int epochs, long seed) {
-        this(optimiser,epochs,1000,1,seed);
+        super(optimiser,epochs,loggingInterval,minibatchSize,seed,true);
     }
 
     /**
      * For olcut.
      */
-    protected AbstractLinearSGDTrainer() { }
-
-    /**
-     * Used by the OLCUT configuration system, and should not be called by external code.
-     */
-    @Override
-    public synchronized void postConfig() {
-        this.rng = new SplittableRandom(seed);
+    protected AbstractLinearSGDTrainer() {
+        super(true);
     }
 
     /**
-     * Turn on or off shuffling of examples.
-     * <p>
-     * This isn't exposed in the constructor as it defaults to on.
-     * This method should only be used for debugging.
-     * @param shuffle If true shuffle the examples, if false leave them in their current order.
+     * Returns the default model name.
+     * @return The default model name.
      */
-    public void setShuffle(boolean shuffle) {
-        this.shuffle = shuffle;
-    }
-
-    @Override
-    public AbstractLinearSGDModel<T> train(Dataset<T> examples) {
-        return train(examples, Collections.emptyMap());
-    }
-
-    @Override
-    public AbstractLinearSGDModel<T> train(Dataset<T> examples, Map<String, Provenance> runProvenance) {
-        if (examples.getOutputInfo().getUnknownCount() > 0) {
-            throw new IllegalArgumentException("The supplied Dataset contained unknown Outputs, and this Trainer is supervised.");
-        }
-        // Creates a new RNG, adds one to the invocation count, generates a local optimiser.
-        TrainerProvenance trainerProvenance;
-        SplittableRandom localRNG;
-        StochasticGradientOptimiser localOptimiser;
-        synchronized(this) {
-            localRNG = rng.split();
-            localOptimiser = optimiser.copy();
-            trainerProvenance = getProvenance();
-            trainInvocationCounter++;
-        }
-
-        SGDObjective<U> objective = getObjective();
-        ImmutableOutputInfo<T> outputIDInfo = examples.getOutputIDInfo();
-        ImmutableFeatureMap featureIDMap = examples.getFeatureIDMap();
-        int featureSpaceSize = featureIDMap.size();
-
-        SGDVector[] sgdFeatures = new SGDVector[examples.size()];
-        @SuppressWarnings("unchecked")
-        U[] sgdTargets = (U[]) new Object[examples.size()];
-        double[] weights = new double[examples.size()];
-        int n = 0;
-        for (Example<T> example : examples) {
-            weights[n] = example.getWeight();
-            if (example.size() == featureSpaceSize) {
-                sgdFeatures[n] = DenseVector.createDenseVector(example, featureIDMap, true);
-            } else {
-                sgdFeatures[n] = SparseVector.createSparseVector(example, featureIDMap, true);
-            }
-            sgdTargets[n] = getTarget(outputIDInfo,example.getOutput());
-            n++;
-        }
-        logger.info(String.format("Training linear SGD model with %d examples", n));
-        logger.info("Outputs - " + outputIDInfo.toReadableString());
-
-        // featureIDMap.size()+1 adds the bias feature.
-        LinearParameters linearParameters = new LinearParameters(featureIDMap.size()+1,outputIDInfo.size());
-
-        localOptimiser.initialise(linearParameters);
-        double loss = 0.0;
-        int iteration = 0;
-
-        for (int i = 0; i < epochs; i++) {
-            if (shuffle) {
-                shuffleInPlace(sgdFeatures, sgdTargets, weights, localRNG);
-            }
-            if (minibatchSize == 1) {
-                for (int j = 0; j < sgdFeatures.length; j++) {
-                    SGDVector pred = linearParameters.predict(sgdFeatures[j]);
-                    Pair<Double,SGDVector> output = objective.lossAndGradient(sgdTargets[j],pred);
-                    loss += output.getA()*weights[j];
-
-                    Tensor[] updates = localOptimiser.step(linearParameters.gradients(output,sgdFeatures[j]),weights[j]);
-                    linearParameters.update(updates);
-
-                    iteration++;
-                    if ((loggingInterval != -1) && (iteration % loggingInterval == 0)) {
-                        logger.info("At iteration " + iteration + ", average loss = " + loss/loggingInterval);
-                        loss = 0.0;
-                    }
-                }
-            } else {
-                Tensor[][] gradients = new Tensor[minibatchSize][];
-                for (int j = 0; j < sgdFeatures.length; j += minibatchSize) {
-                    double tempWeight = 0.0;
-                    int curSize = 0;
-                    for (int k = j; k < j+minibatchSize && k < sgdFeatures.length; k++) {
-                        SGDVector pred = linearParameters.predict(sgdFeatures[k]);
-                        Pair<Double,SGDVector> output = objective.lossAndGradient(sgdTargets[k],pred);
-                        loss += output.getA()*weights[k];
-                        tempWeight += weights[k];
-
-                        gradients[k-j] = linearParameters.gradients(output,sgdFeatures[k]);
-                        curSize++;
-                    }
-                    Tensor[] updates = linearParameters.merge(gradients,curSize);
-                    for (int k = 0; k < updates.length; k++) {
-                        updates[k].scaleInPlace(minibatchSize);
-                    }
-                    tempWeight /= minibatchSize;
-                    updates = localOptimiser.step(updates,tempWeight);
-                    linearParameters.update(updates);
-
-                    iteration++;
-                    if ((loggingInterval != -1) && (iteration % loggingInterval == 0)) {
-                        logger.info("At iteration " + iteration + ", average loss = " + loss/loggingInterval);
-                        loss = 0.0;
-                    }
-                }
-            }
-        }
-        localOptimiser.finalise();
-        ModelProvenance provenance = new ModelProvenance(getModelClassName(), OffsetDateTime.now(), examples.getProvenance(), trainerProvenance, runProvenance);
-        AbstractLinearSGDModel<T> model = createModel("linear-sgd-model",provenance,featureIDMap,outputIDInfo,linearParameters);
-        localOptimiser.reset();
-        return model;
-    }
-
-    @Override
-    public int getInvocationCount() {
-        return trainInvocationCounter;
+    protected String getName() {
+        return "linear-sgd-model";
     }
 
     /**
-     * Extracts the appropriate training time representation from the supplied output.
-     * @param outputInfo The output info to use.
-     * @param output The output to extract.
-     * @return The training time representation of the output.
+     * Constructs the trainable parameters object, in this case a {@link LinearParameters} containing
+     * a single weight matrix.
+     * @param numFeatures The number of input features.
+     * @param numOutputs The number of output dimensions.
+     * @return The trainable parameters.
      */
-    protected abstract U getTarget(ImmutableOutputInfo<T> outputInfo, T output);
-
-    /**
-     * Returns the objective used by this trainer.
-     * @return The SGDObjective used by this trainer.
-     */
-    protected abstract SGDObjective<U> getObjective();
-
-    /**
-     * Creates the appropriate model subclass for this subclass of AbstractLinearSGDTrainer.
-     * @param name The model name.
-     * @param provenance The model provenance.
-     * @param featureMap The feature map.
-     * @param outputInfo The output info.
-     * @param parameters The model parameters.
-     * @return A new instance of the appropriate subclass of {@link Model}.
-     */
-    protected abstract AbstractLinearSGDModel<T> createModel(String name, ModelProvenance provenance, ImmutableFeatureMap featureMap, ImmutableOutputInfo<T> outputInfo, LinearParameters parameters);
-
-    /**
-     * Returns the class name of the model that's produced by this trainer.
-     * @return The model class name;
-     */
-    protected abstract String getModelClassName();
-
-    @Override
-    public TrainerProvenance getProvenance() {
-        return new TrainerProvenanceImpl(this);
+    protected LinearParameters createParameters(int numFeatures, int numOutputs) {
+        return new LinearParameters(numFeatures+1,numOutputs);
     }
 
-    /**
-     * Shuffles the features, outputs and weights in place.
-     * @param features Feature array.
-     * @param labels Output array.
-     * @param weights Weight array.
-     * @param rng Random number generator.
-     * @param <T> The output type.
-     */
-    public static <T> void shuffleInPlace(SGDVector[] features, T[] labels, double[] weights, SplittableRandom rng) {
-        int size = features.length;
-        // Shuffle array
-        for (int i = size; i > 1; i--) {
-            int j = rng.nextInt(i);
-            //swap features
-            SGDVector tmpFeature = features[i-1];
-            features[i-1] = features[j];
-            features[j] = tmpFeature;
-            //swap labels
-            T tmpLabel = labels[i-1];
-            labels[i-1] = labels[j];
-            labels[j] = tmpLabel;
-            //swap weights
-            double tmpWeight = weights[i-1];
-            weights[i-1] = weights[j];
-            weights[j] = tmpWeight;
-        }
-    }
 }

--- a/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractSGDModel.java
+++ b/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractSGDModel.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.common.sgd;
+
+import org.tribuo.Example;
+import org.tribuo.ImmutableFeatureMap;
+import org.tribuo.ImmutableOutputInfo;
+import org.tribuo.Model;
+import org.tribuo.Output;
+import org.tribuo.math.FeedForwardParameters;
+import org.tribuo.math.la.DenseVector;
+import org.tribuo.math.la.SGDVector;
+import org.tribuo.math.la.SparseVector;
+import org.tribuo.provenance.ModelProvenance;
+
+public abstract class AbstractSGDModel<T extends Output<T>> extends Model<T> {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The weights for this model.
+     */
+    // Note this is not final to allow backwards compatibility for 4.0 models which need to rewrite the field on load.
+    protected FeedForwardParameters modelParameters;
+
+    // Defaults to true for backwards compatibility with 4.0 models, not final due to this defaulting.
+    protected boolean addBias = true;
+
+    /**
+     * Constructs a linear model trained via SGD.
+     * @param name The model name.
+     * @param provenance The model provenance.
+     * @param featureIDMap The feature domain.
+     * @param outputIDInfo The output domain.
+     * @param weights The model weights.
+     * @param generatesProbabilities Does this model generate probabilities?
+     */
+    protected AbstractSGDModel(String name, ModelProvenance provenance,
+                               ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<T> outputIDInfo,
+                               FeedForwardParameters weights, boolean generatesProbabilities, boolean addBias) {
+        super(name, provenance, featureIDMap, outputIDInfo, generatesProbabilities);
+        this.modelParameters = weights;
+        this.addBias = addBias;
+    }
+
+    /**
+     * Generates the dense vector prediction from the supplied example.
+     * @param example The example to use for prediction.
+     * @return The prediction and the number of features involved.
+     */
+    protected PredAndActive predictSingle(Example<T> example) {
+        SGDVector features;
+        if (example.size() == featureIDMap.size()) {
+            features = DenseVector.createDenseVector(example, featureIDMap, addBias);
+        } else {
+            features = SparseVector.createSparseVector(example, featureIDMap, addBias);
+        }
+        if (features.numActiveElements() == 1) {
+            throw new IllegalArgumentException("No features found in Example " + example.toString());
+        }
+        return new PredAndActive(modelParameters.predict(features),features.numActiveElements());
+    }
+
+    /**
+     * Returns a copy of the model parameters.
+     * @return A copy of the model parameters.
+     */
+    public FeedForwardParameters getModelParameters() {
+        return modelParameters.copy();
+    }
+
+    /**
+     * A nominal tuple used to capture the prediction and the number of active features used by the model.
+     */
+    protected static final class PredAndActive {
+        public final DenseVector prediction;
+        public final int numActiveFeatures;
+
+        PredAndActive(DenseVector prediction, int numActiveFeatures) {
+            this.prediction = prediction;
+            this.numActiveFeatures = numActiveFeatures;
+        }
+    }
+}

--- a/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractSGDTrainer.java
+++ b/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractSGDTrainer.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.common.sgd;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import com.oracle.labs.mlrg.olcut.util.Pair;
+import org.tribuo.Dataset;
+import org.tribuo.Example;
+import org.tribuo.ImmutableFeatureMap;
+import org.tribuo.ImmutableOutputInfo;
+import org.tribuo.Model;
+import org.tribuo.Output;
+import org.tribuo.Trainer;
+import org.tribuo.WeightedExamples;
+import org.tribuo.math.FeedForwardParameters;
+import org.tribuo.math.StochasticGradientOptimiser;
+import org.tribuo.math.la.DenseVector;
+import org.tribuo.math.la.SGDVector;
+import org.tribuo.math.la.SparseVector;
+import org.tribuo.math.la.Tensor;
+import org.tribuo.math.optimisers.AdaGrad;
+import org.tribuo.provenance.ModelProvenance;
+import org.tribuo.provenance.TrainerProvenance;
+import org.tribuo.provenance.impl.TrainerProvenanceImpl;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.SplittableRandom;
+import java.util.logging.Logger;
+
+/**
+ * A trainer for a model which uses SGD.
+ * <p>
+ * See:
+ * <pre>
+ * Bottou L.
+ * "Large-Scale Machine Learning with Stochastic Gradient Descent"
+ * Proceedings of COMPSTAT, 2010.
+ * </pre>
+ */
+public abstract class AbstractSGDTrainer<T extends Output<T>,U,V extends Model<T>,X extends FeedForwardParameters> implements Trainer<T>, WeightedExamples {
+    private static final Logger logger = Logger.getLogger(AbstractSGDTrainer.class.getName());
+
+    @Config(description="The gradient optimiser to use.")
+    protected StochasticGradientOptimiser optimiser = new AdaGrad(1.0,0.1);
+
+    @Config(description="The number of gradient descent epochs.")
+    protected int epochs = 5;
+
+    @Config(description="Log values after this many updates.")
+    protected int loggingInterval = -1;
+
+    @Config(description="Minibatch size in SGD.")
+    protected int minibatchSize = 1;
+
+    @Config(description="Seed for the RNG used to shuffle elements.")
+    protected long seed = Trainer.DEFAULT_SEED;
+
+    @Config(description="Shuffle the data before each epoch. Only turn off for debugging.")
+    protected boolean shuffle = true;
+
+    protected final boolean addBias;
+
+    protected SplittableRandom rng;
+
+    private int trainInvocationCounter;
+
+    /**
+     * Constructs an SGD trainer.
+     * @param optimiser The gradient optimiser to use.
+     * @param epochs The number of epochs (complete passes through the training data).
+     * @param loggingInterval Log the loss after this many iterations. If -1 don't log anything.
+     * @param minibatchSize The size of any minibatches.
+     * @param seed A seed for the random number generator, used to shuffle the examples before each epoch.
+     */
+    protected AbstractSGDTrainer(StochasticGradientOptimiser optimiser, int epochs, int loggingInterval, int minibatchSize, long seed, boolean addBias) {
+        this.optimiser = optimiser;
+        this.epochs = epochs;
+        this.loggingInterval = loggingInterval;
+        this.minibatchSize = minibatchSize;
+        this.seed = seed;
+        this.addBias = addBias;
+        postConfig();
+    }
+
+    /**
+     * Base constructor called by subclass no-args constructors used by OLCUT.
+     */
+    protected AbstractSGDTrainer(boolean addBias) {
+        this.addBias = addBias;
+    }
+
+    /**
+     * Used by the OLCUT configuration system, and should not be called by external code.
+     */
+    @Override
+    public synchronized void postConfig() {
+        this.rng = new SplittableRandom(seed);
+    }
+
+    /**
+     * Turn on or off shuffling of examples.
+     * <p>
+     * This isn't exposed in the constructor as it defaults to on.
+     * This method should only be used for debugging.
+     * @param shuffle If true shuffle the examples, if false leave them in their current order.
+     */
+    public void setShuffle(boolean shuffle) {
+        this.shuffle = shuffle;
+    }
+
+    @Override
+    public V train(Dataset<T> examples) {
+        return train(examples, Collections.emptyMap());
+    }
+
+    @Override
+    public V train(Dataset<T> examples, Map<String, Provenance> runProvenance) {
+        if (examples.getOutputInfo().getUnknownCount() > 0) {
+            throw new IllegalArgumentException("The supplied Dataset contained unknown Outputs, and this Trainer is supervised.");
+        }
+        // Creates a new RNG, adds one to the invocation count, generates a local optimiser.
+        TrainerProvenance trainerProvenance;
+        SplittableRandom localRNG;
+        StochasticGradientOptimiser localOptimiser;
+        synchronized(this) {
+            localRNG = rng.split();
+            localOptimiser = optimiser.copy();
+            trainerProvenance = getProvenance();
+            trainInvocationCounter++;
+        }
+
+        SGDObjective<U> objective = getObjective();
+        ImmutableOutputInfo<T> outputIDInfo = examples.getOutputIDInfo();
+        ImmutableFeatureMap featureIDMap = examples.getFeatureIDMap();
+        int featureSpaceSize = featureIDMap.size();
+
+        SGDVector[] sgdFeatures = new SGDVector[examples.size()];
+        @SuppressWarnings("unchecked")
+        U[] sgdTargets = (U[]) new Object[examples.size()];
+        double[] weights = new double[examples.size()];
+        int n = 0;
+        for (Example<T> example : examples) {
+            weights[n] = example.getWeight();
+            if (example.size() == featureSpaceSize) {
+                sgdFeatures[n] = DenseVector.createDenseVector(example, featureIDMap, addBias);
+            } else {
+                sgdFeatures[n] = SparseVector.createSparseVector(example, featureIDMap, addBias);
+            }
+            sgdTargets[n] = getTarget(outputIDInfo,example.getOutput());
+            n++;
+        }
+        logger.info(String.format("Training SGD model with %d examples", n));
+        logger.info("Outputs - " + outputIDInfo.toReadableString());
+
+        X parameters = createParameters(featureIDMap.size(),outputIDInfo.size());
+
+        localOptimiser.initialise(parameters);
+        double loss = 0.0;
+        int iteration = 0;
+
+        for (int i = 0; i < epochs; i++) {
+            if (shuffle) {
+                shuffleInPlace(sgdFeatures, sgdTargets, weights, localRNG);
+            }
+            if (minibatchSize == 1) {
+                for (int j = 0; j < sgdFeatures.length; j++) {
+                    SGDVector pred = parameters.predict(sgdFeatures[j]);
+                    Pair<Double,SGDVector> output = objective.lossAndGradient(sgdTargets[j],pred);
+                    loss += output.getA()*weights[j];
+
+                    Tensor[] updates = localOptimiser.step(parameters.gradients(output,sgdFeatures[j]),weights[j]);
+                    parameters.update(updates);
+
+                    iteration++;
+                    if ((loggingInterval != -1) && (iteration % loggingInterval == 0)) {
+                        logger.info("At iteration " + iteration + ", average loss = " + loss/loggingInterval);
+                        loss = 0.0;
+                    }
+                }
+            } else {
+                Tensor[][] gradients = new Tensor[minibatchSize][];
+                for (int j = 0; j < sgdFeatures.length; j += minibatchSize) {
+                    double tempWeight = 0.0;
+                    int curSize = 0;
+                    for (int k = j; k < j+minibatchSize && k < sgdFeatures.length; k++) {
+                        SGDVector pred = parameters.predict(sgdFeatures[k]);
+                        Pair<Double,SGDVector> output = objective.lossAndGradient(sgdTargets[k],pred);
+                        loss += output.getA()*weights[k];
+                        tempWeight += weights[k];
+
+                        gradients[k-j] = parameters.gradients(output,sgdFeatures[k]);
+                        curSize++;
+                    }
+                    Tensor[] updates = parameters.merge(gradients,curSize);
+                    for (int k = 0; k < updates.length; k++) {
+                        updates[k].scaleInPlace(minibatchSize);
+                    }
+                    tempWeight /= minibatchSize;
+                    updates = localOptimiser.step(updates,tempWeight);
+                    parameters.update(updates);
+
+                    iteration++;
+                    if ((loggingInterval != -1) && (iteration % loggingInterval == 0)) {
+                        logger.info("At iteration " + iteration + ", average loss = " + loss/loggingInterval);
+                        loss = 0.0;
+                    }
+                }
+            }
+        }
+        localOptimiser.finalise();
+        ModelProvenance provenance = new ModelProvenance(getModelClassName(), OffsetDateTime.now(), examples.getProvenance(), trainerProvenance, runProvenance);
+        V model = createModel(getName(),provenance,featureIDMap,outputIDInfo,parameters);
+        localOptimiser.reset();
+        return model;
+    }
+
+    @Override
+    public int getInvocationCount() {
+        return trainInvocationCounter;
+    }
+
+    /**
+     * Extracts the appropriate training time representation from the supplied output.
+     * @param outputInfo The output info to use.
+     * @param output The output to extract.
+     * @return The training time representation of the output.
+     */
+    protected abstract U getTarget(ImmutableOutputInfo<T> outputInfo, T output);
+
+    /**
+     * Returns the objective used by this trainer.
+     * @return The SGDObjective used by this trainer.
+     */
+    protected abstract SGDObjective<U> getObjective();
+
+    /**
+     * Creates the appropriate model subclass for this subclass of AbstractSGDTrainer.
+     * @param name The model name.
+     * @param provenance The model provenance.
+     * @param featureMap The feature map.
+     * @param outputInfo The output info.
+     * @param parameters The model parameters.
+     * @return A new instance of the appropriate subclass of {@link Model}.
+     */
+    protected abstract V createModel(String name, ModelProvenance provenance, ImmutableFeatureMap featureMap, ImmutableOutputInfo<T> outputInfo, X parameters);
+
+    /**
+     * Returns the class name of the model that's produced by this trainer.
+     * @return The model class name;
+     */
+    protected abstract String getModelClassName();
+
+    /**
+     * Returns the default model name.
+     * @return The default model name.
+     */
+    protected abstract String getName();
+
+    /**
+     * Constructs the trainable parameters object.
+     * @param numFeatures The number of input features.
+     * @param numOutputs The number of output dimensions.
+     * @return The trainable parameters.
+     */
+    protected abstract X createParameters(int numFeatures, int numOutputs);
+
+    @Override
+    public TrainerProvenance getProvenance() {
+        return new TrainerProvenanceImpl(this);
+    }
+
+    /**
+     * Shuffles the features, outputs and weights in place.
+     * @param features Feature array.
+     * @param labels Output array.
+     * @param weights Weight array.
+     * @param rng Random number generator.
+     * @param <T> The output type.
+     */
+    public static <T> void shuffleInPlace(SGDVector[] features, T[] labels, double[] weights, SplittableRandom rng) {
+        int size = features.length;
+        // Shuffle array
+        for (int i = size; i > 1; i--) {
+            int j = rng.nextInt(i);
+            //swap features
+            SGDVector tmpFeature = features[i-1];
+            features[i-1] = features[j];
+            features[j] = tmpFeature;
+            //swap labels
+            T tmpLabel = labels[i-1];
+            labels[i-1] = labels[j];
+            labels[j] = tmpLabel;
+            //swap weights
+            double tmpWeight = weights[i-1];
+            weights[i-1] = weights[j];
+            weights[j] = tmpWeight;
+        }
+    }
+}

--- a/Math/src/main/java/org/tribuo/math/FeedForwardParameters.java
+++ b/Math/src/main/java/org/tribuo/math/FeedForwardParameters.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.math;
+
+import com.oracle.labs.mlrg.olcut.util.Pair;
+import org.tribuo.math.la.DenseVector;
+import org.tribuo.math.la.SGDVector;
+import org.tribuo.math.la.Tensor;
+
+/**
+ * A Parameters for models which make a single prediction like logistic regressions and neural networks.
+ */
+public interface FeedForwardParameters extends Parameters {
+
+    /**
+     * Generates an un-normalized prediction by feeding the features through the parameters.
+     * @param example The features.
+     * @return The prediction.
+     */
+    public DenseVector predict(SGDVector example);
+
+    /**
+     * Generates the parameter gradients given the loss, output gradient and input
+     * features.
+     * @param score The loss and gradient.
+     * @param features The input features.
+     * @return The parameter gradient array.
+     */
+    public Tensor[] gradients(Pair<Double, SGDVector> score, SGDVector features);
+
+    /**
+     * Returns a copy of the parameters.
+     * @return A copy of the model parameters.
+     */
+    public FeedForwardParameters copy();
+
+}

--- a/Math/src/main/java/org/tribuo/math/Parameters.java
+++ b/Math/src/main/java/org/tribuo/math/Parameters.java
@@ -18,6 +18,8 @@ package org.tribuo.math;
 
 import org.tribuo.math.la.Tensor;
 
+import java.io.Serializable;
+
 /**
  * An interface to a {@link Tensor}[] array which accepts updates to the parameters.
  * <p>
@@ -25,8 +27,10 @@ import org.tribuo.math.la.Tensor;
  * <p>
  * Subclasses of this can add methods for calculating gradients for
  * their prediction task, or use an external objective class.
+ * <p>
+ * Implementations must be serializable.
  */
-public interface Parameters {
+public interface Parameters extends Serializable {
 
     /**
      * Generates an empty copy of the underlying {@link Tensor} array.

--- a/MultiLabel/Core/src/test/java/org/tribuo/multilabel/IndependentMultiLabelTest.java
+++ b/MultiLabel/Core/src/test/java/org/tribuo/multilabel/IndependentMultiLabelTest.java
@@ -22,6 +22,8 @@ import org.tribuo.Model;
 import org.tribuo.Prediction;
 import org.tribuo.classification.sgd.linear.LinearSGDTrainer;
 import org.tribuo.classification.sgd.linear.LogisticRegressionTrainer;
+import org.tribuo.common.sgd.AbstractLinearSGDTrainer;
+import org.tribuo.common.sgd.AbstractSGDTrainer;
 import org.tribuo.multilabel.baseline.IndependentMultiLabelTrainer;
 import org.tribuo.multilabel.example.MultiLabelDataGenerator;
 import org.junit.jupiter.api.Assertions;
@@ -43,8 +45,11 @@ public class IndependentMultiLabelTest {
 
     @BeforeAll
     public static void setup() {
-        Logger logger = Logger.getLogger(LinearSGDTrainer.class.getName());
-        logger.setLevel(Level.WARNING);
+        Class<?>[] classes = new Class<?>[]{AbstractSGDTrainer.class, AbstractLinearSGDTrainer.class,LinearSGDTrainer.class};
+        for (Class c : classes) {
+            Logger logger = Logger.getLogger(c.getName());
+            logger.setLevel(Level.WARNING);
+        }
     }
 
     @Test

--- a/MultiLabel/SGD/src/main/java/org/tribuo/multilabel/sgd/linear/LinearSGDModel.java
+++ b/MultiLabel/SGD/src/main/java/org/tribuo/multilabel/sgd/linear/LinearSGDModel.java
@@ -23,7 +23,6 @@ import org.tribuo.Prediction;
 import org.tribuo.classification.Label;
 import org.tribuo.common.sgd.AbstractLinearSGDModel;
 import org.tribuo.math.LinearParameters;
-import org.tribuo.math.la.DenseMatrix;
 import org.tribuo.math.la.DenseVector;
 import org.tribuo.math.util.VectorNormalizer;
 import org.tribuo.multilabel.MultiLabel;
@@ -50,18 +49,21 @@ public class LinearSGDModel extends AbstractLinearSGDModel<MultiLabel> {
     private final VectorNormalizer normalizer;
     private final double threshold;
 
+    /**
+     * Constructs a linear regression model trained via SGD.
+     * @param name The model name.
+     * @param provenance The model provenance.
+     * @param featureIDMap The feature domain.
+     * @param outputIDInfo The output domain.
+     * @param parameters The model parameters (i.e., the weight matrix).
+     * @param normalizer The output normalizer (usually sigmoid or no-op).
+     * @param generatesProbabilities Does this model produce probabilistic outputs.
+     * @param threshold The threshold for emitting a label.
+     */
     LinearSGDModel(String name, ModelProvenance provenance,
                    ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<MultiLabel> outputIDInfo,
                    LinearParameters parameters, VectorNormalizer normalizer, boolean generatesProbabilities, double threshold) {
-        super(name, provenance, featureIDMap, outputIDInfo, parameters.getWeightMatrix(), generatesProbabilities);
-        this.normalizer = normalizer;
-        this.threshold = threshold;
-    }
-
-    private LinearSGDModel(String name, ModelProvenance provenance,
-                          ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<MultiLabel> outputIDInfo,
-                          DenseMatrix weights, VectorNormalizer normalizer, boolean generatesProbabilities, double threshold) {
-        super(name, provenance, featureIDMap, outputIDInfo, weights, generatesProbabilities);
+        super(name, provenance, featureIDMap, outputIDInfo, parameters, generatesProbabilities);
         this.normalizer = normalizer;
         this.threshold = threshold;
     }
@@ -92,6 +94,6 @@ public class LinearSGDModel extends AbstractLinearSGDModel<MultiLabel> {
 
     @Override
     protected LinearSGDModel copy(String newName, ModelProvenance newProvenance) {
-        return new LinearSGDModel(newName,newProvenance,featureIDMap,outputIDInfo,new DenseMatrix(baseWeights),normalizer,generatesProbabilities,threshold);
+        return new LinearSGDModel(newName,newProvenance,featureIDMap,outputIDInfo,(LinearParameters)modelParameters.copy(),normalizer,generatesProbabilities,threshold);
     }
 }

--- a/MultiLabel/SGD/src/test/java/org/tribuo/multilabel/sgd/linear/TestSGDLinear.java
+++ b/MultiLabel/SGD/src/test/java/org/tribuo/multilabel/sgd/linear/TestSGDLinear.java
@@ -24,6 +24,8 @@ import org.tribuo.Dataset;
 import org.tribuo.Model;
 import org.tribuo.Prediction;
 import org.tribuo.Trainer;
+import org.tribuo.common.sgd.AbstractLinearSGDTrainer;
+import org.tribuo.common.sgd.AbstractSGDTrainer;
 import org.tribuo.math.optimisers.AdaGrad;
 import org.tribuo.multilabel.MultiLabel;
 import org.tribuo.multilabel.evaluation.MultiLabelEvaluation;
@@ -47,8 +49,11 @@ public class TestSGDLinear {
 
     @BeforeAll
     public static void setup() {
-        Logger logger = Logger.getLogger(org.tribuo.multilabel.sgd.linear.LinearSGDTrainer.class.getName());
-        logger.setLevel(Level.WARNING);
+        Class<?>[] classes = new Class<?>[]{AbstractSGDTrainer.class, AbstractLinearSGDTrainer.class,LinearSGDTrainer.class};
+        for (Class c : classes) {
+            Logger logger = Logger.getLogger(c.getName());
+            logger.setLevel(Level.WARNING);
+        }
     }
 
     @Test

--- a/Regression/SGD/src/main/java/org/tribuo/regression/sgd/linear/LinearSGDModel.java
+++ b/Regression/SGD/src/main/java/org/tribuo/regression/sgd/linear/LinearSGDModel.java
@@ -46,7 +46,7 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Regressor> {
 
     private final String[] dimensionNames;
 
-    // Unused as the weights now live in AbstractLinearSGDModel
+    // Unused as the weights now live in AbstractSGDModel
     // It remains for serialization compatibility with Tribuo 4.0
     @Deprecated
     private DenseMatrix weights = null;
@@ -54,6 +54,7 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Regressor> {
     /**
      * Constructs a linear regression model trained via SGD.
      * @param name The model name.
+     * @param dimensionNames The regression dimension names.
      * @param provenance The model provenance.
      * @param featureIDMap The feature domain.
      * @param outputIDInfo The output domain.
@@ -62,22 +63,7 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Regressor> {
     LinearSGDModel(String name, String[] dimensionNames, ModelProvenance provenance,
                           ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<Regressor> outputIDInfo,
                           LinearParameters parameters) {
-        super(name, provenance, featureIDMap, outputIDInfo, parameters.getWeightMatrix(), false);
-        this.dimensionNames = dimensionNames;
-    }
-
-    /**
-     * Constructs a linear regression model trained via SGD.
-     * @param name The model name.
-     * @param provenance The model provenance.
-     * @param featureIDMap The feature domain.
-     * @param outputIDInfo The output domain.
-     * @param weights The model parameters (i.e., the weight matrix).
-     */
-    private LinearSGDModel(String name, String[] dimensionNames, ModelProvenance provenance,
-                          ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<Regressor> outputIDInfo,
-                          DenseMatrix weights) {
-        super(name, provenance, featureIDMap, outputIDInfo, weights, false);
+        super(name, provenance, featureIDMap, outputIDInfo, parameters, false);
         this.dimensionNames = dimensionNames;
     }
 
@@ -89,7 +75,7 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Regressor> {
 
     @Override
     protected LinearSGDModel copy(String newName, ModelProvenance newProvenance) {
-        return new LinearSGDModel(newName,Arrays.copyOf(dimensionNames,dimensionNames.length),newProvenance,featureIDMap,outputIDInfo,getWeightsCopy());
+        return new LinearSGDModel(newName,Arrays.copyOf(dimensionNames,dimensionNames.length),newProvenance,featureIDMap,outputIDInfo,(LinearParameters)modelParameters.copy());
     }
 
     @Override
@@ -101,9 +87,10 @@ public class LinearSGDModel extends AbstractLinearSGDModel<Regressor> {
         in.defaultReadObject();
 
         // Bounce old 4.0 style models into the new 4.1 style models
-        if (weights != null && baseWeights == null) {
-            baseWeights = weights;
+        if (weights != null && modelParameters == null) {
+            modelParameters = new LinearParameters(weights);
             weights = null;
+            addBias = true;
         }
     }
 }

--- a/Regression/SGD/src/test/java/org/tribuo/regression/sgd/linear/TestSGDLinear.java
+++ b/Regression/SGD/src/test/java/org/tribuo/regression/sgd/linear/TestSGDLinear.java
@@ -23,6 +23,8 @@ import org.tribuo.Dataset;
 import org.tribuo.Model;
 import org.tribuo.Trainer;
 import org.tribuo.common.sgd.AbstractLinearSGDModel;
+import org.tribuo.common.sgd.AbstractLinearSGDTrainer;
+import org.tribuo.common.sgd.AbstractSGDTrainer;
 import org.tribuo.math.la.DenseMatrix;
 import org.tribuo.math.la.DenseVector;
 import org.tribuo.math.optimisers.AdaGrad;
@@ -55,8 +57,11 @@ public class TestSGDLinear {
 
     @BeforeAll
     public static void setup() {
-        Logger logger = Logger.getLogger(LinearSGDTrainer.class.getName());
-        logger.setLevel(Level.WARNING);
+        Class<?>[] classes = new Class<?>[]{AbstractSGDTrainer.class, AbstractLinearSGDTrainer.class,LinearSGDTrainer.class};
+        for (Class c : classes) {
+            Logger logger = Logger.getLogger(c.getName());
+            logger.setLevel(Level.WARNING);
+        }
     }
 
     public static Model<Regressor> testSGDLinear(Pair<Dataset<Regressor>,Dataset<Regressor>> p) {


### PR DESCRIPTION
### Description
This PR extracts out `AbstractSGDModel` and `AbstractSGDTrainer` from `AbstractLinearSGDModel` and `AbstractLinearSGDTrainer`, and introduces a `FeedForwardParameters` which has predict and gradient methods. They don't land on `Parameters` because that's used in the CRF as well, and sequences have a differently shaped input.

`AbstractSGDTrainer` has a lot of generic parameters, but those are all hidden from users and the concrete subclasses are still typed with just the output type like most of Tribuo. The code is tested by the existing tests, and can still deserialize Tribuo 4.0 models.

### Motivation
The recent introduction of AbstractLinearSGDModel/Trainer wasn't quite abstract enough. The SGD package could be used for things beyond linear models like factorization machines. This PR will make it straightforward to subclass `AbstractSGDTrainer` for a different model class so you don't have to reimplement the training loop.

