### PR TITLE
Upgrading XGBoost to 1.4.1

### DIFF
--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Maven
-        run: mvn -DskipXGBoostTests=true -B package --file pom.xml
+        run: mvn -B package --file pom.xml

--- a/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostClassificationTrainer.java
+++ b/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/XGBoostClassificationTrainer.java
@@ -59,9 +59,12 @@ import java.util.logging.Logger;
  * Annals of statistics, 2001.
  * </pre>
  * <p>
- * Note: XGBoost requires a native library, on macOS this library requires libomp (which can be installed via homebrew),
- * on Windows this native library must be compiled into a jar as it's not contained in the official XGBoost binary
- * on Maven Central.
+ * N.B.: XGBoost4J wraps the native C implementation of xgboost that links to various C libraries, including libgomp
+ * and glibc (on Linux). If you're running on Alpine, which does not natively use glibc, you'll need to install glibc
+ * into the container.
+ * On the macOS binary on Maven Central is compiled without
+ * OpenMP support, meaning that XGBoost is single threaded on macOS. You can recompile the macOS binary with
+ * OpenMP support after installing libomp from homebrew if necessary.
  */
 public final class XGBoostClassificationTrainer extends XGBoostTrainer<Label> {
 

--- a/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/package-info.java
+++ b/Classification/XGBoost/src/main/java/org/tribuo/classification/xgboost/package-info.java
@@ -17,8 +17,11 @@
 /**
  * Provides an interface to XGBoost for classification problems.
  * <p>
- * Note: XGBoost requires a native library, on macOS this library requires libomp (which can be installed via homebrew),
- * on Windows this native library must be compiled into a jar as it's not contained in the official XGBoost binary
- * on Maven Central.
+ * N.B.: XGBoost4J wraps the native C implementation of xgboost that links to various C libraries, including libgomp
+ * and glibc (on Linux). If you're running on Alpine, which does not natively use glibc, you'll need to install glibc
+ * into the container.
+ * On the macOS binary on Maven Central is compiled without
+ * OpenMP support, meaning that XGBoost is single threaded on macOS. You can recompile the macOS binary with
+ * OpenMP support after installing libomp from homebrew if necessary.
  */
 package org.tribuo.classification.xgboost;

--- a/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostExternalModel.java
+++ b/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostExternalModel.java
@@ -76,9 +76,12 @@ import java.util.logging.Logger;
  * Annals of statistics, 2001.
  * </pre>
  * <p>
- * Note: XGBoost requires a native library, on macOS this library requires libomp (which can be installed via homebrew),
- * on Windows this native library must be compiled into a jar as it's not contained in the official XGBoost binary
- * on Maven Central.
+ * N.B.: XGBoost4J wraps the native C implementation of xgboost that links to various C libraries, including libgomp
+ * and glibc (on Linux). If you're running on Alpine, which does not natively use glibc, you'll need to install glibc
+ * into the container.
+ * On the macOS binary on Maven Central is compiled without
+ * OpenMP support, meaning that XGBoost is single threaded on macOS. You can recompile the macOS binary with
+ * OpenMP support after installing libomp from homebrew if necessary.
  */
 public final class XGBoostExternalModel<T extends Output<T>> extends ExternalModel<T,DMatrix,float[][]> {
     private static final long serialVersionUID = 1L;

--- a/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostTrainer.java
+++ b/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostTrainer.java
@@ -61,10 +61,12 @@ import java.util.logging.Logger;
  * "Greedy Function Approximation: a Gradient Boosting Machine"
  * Annals of statistics, 2001.
  * </pre>
- * N.B.: This uses a native C implementation of xgboost that links to various C libraries, including libgomp
- * and glibc. If you're running on Alpine, which does not natively use glibc, you'll need to install glibc
- * into the container. On Windows this binary is not available in the Maven Central release, you'll need
- * to compile it from source.
+ * N.B.: XGBoost4J wraps the native C implementation of xgboost that links to various C libraries, including libgomp
+ * and glibc (on Linux). If you're running on Alpine, which does not natively use glibc, you'll need to install glibc
+ * into the container.
+ * On the macOS binary on Maven Central is compiled without
+ * OpenMP support, meaning that XGBoost is single threaded on macOS. You can recompile the macOS binary with
+ * OpenMP support after installing libomp from homebrew if necessary.
  */
 public abstract class XGBoostTrainer<T extends Output<T>> implements Trainer<T>, WeightedExamples {
     /* Alpine install command

--- a/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/package-info.java
+++ b/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/package-info.java
@@ -18,8 +18,11 @@
  * Provides abstract classes for interfacing with XGBoost abstracting away all the {@link org.tribuo.Output}
  * dependent parts.
  * <p>
- * Note: XGBoost requires a native library, on macOS this library requires libomp (which can be installed via homebrew),
- * on Windows this native library must be compiled into a jar as it's not contained in the official XGBoost binary
- * on Maven Central.
+ * N.B.: XGBoost4J wraps the native C implementation of xgboost that links to various C libraries, including libgomp
+ * and glibc (on Linux). If you're running on Alpine, which does not natively use glibc, you'll need to install glibc
+ * into the container.
+ * On the macOS binary on Maven Central is compiled without
+ * OpenMP support, meaning that XGBoost is single threaded on macOS. You can recompile the macOS binary with
+ * OpenMP support after installing libomp from homebrew if necessary.
  */
 package org.tribuo.common.xgboost;

--- a/Regression/XGBoost/src/main/java/org/tribuo/regression/xgboost/XGBoostRegressionTrainer.java
+++ b/Regression/XGBoost/src/main/java/org/tribuo/regression/xgboost/XGBoostRegressionTrainer.java
@@ -61,9 +61,12 @@ import java.util.logging.Logger;
  * Annals of statistics, 2001.
  * </pre>
  * <p>
- * Note: XGBoost requires a native library, on macOS this library requires libomp (which can be installed via homebrew),
- * on Windows this native library must be compiled into a jar as it's not contained in the official XGBoost binary
- * on Maven Central.
+ * N.B.: XGBoost4J wraps the native C implementation of xgboost that links to various C libraries, including libgomp
+ * and glibc (on Linux). If you're running on Alpine, which does not natively use glibc, you'll need to install glibc
+ * into the container.
+ * On the macOS binary on Maven Central is compiled without
+ * OpenMP support, meaning that XGBoost is single threaded on macOS. You can recompile the macOS binary with
+ * OpenMP support after installing libomp from homebrew if necessary.
  */
 public final class XGBoostRegressionTrainer extends XGBoostTrainer<Regressor> {
 

--- a/Regression/XGBoost/src/main/java/org/tribuo/regression/xgboost/package-info.java
+++ b/Regression/XGBoost/src/main/java/org/tribuo/regression/xgboost/package-info.java
@@ -17,8 +17,11 @@
 /**
  * Provides an interface to XGBoost for regression problems.
  * <p>
- * Note: XGBoost requires a native library, on macOS this library requires libomp (which can be installed via homebrew),
- * on Windows this native library must be compiled into a jar as it's not contained in the official XGBoost binary
- * on Maven Central.
+ * N.B.: XGBoost4J wraps the native C implementation of xgboost that links to various C libraries, including libgomp
+ * and glibc (on Linux). If you're running on Alpine, which does not natively use glibc, you'll need to install glibc
+ * into the container.
+ * On the macOS binary on Maven Central is compiled without
+ * OpenMP support, meaning that XGBoost is single threaded on macOS. You can recompile the macOS binary with
+ * OpenMP support after installing libomp from homebrew if necessary.
  */
 package org.tribuo.regression.xgboost;

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <libsvm.version>3.24</libsvm.version>
         <onnxruntime.version>1.7.0</onnxruntime.version>
         <tensorflow.version>1.14.0</tensorflow.version>
-        <xgboost.version>1.3.1</xgboost.version>
+        <xgboost.version>1.4.1</xgboost.version>
 
         <!-- 3rd party other dependencies -->
         <junit.version>5.7.1</junit.version>
@@ -57,9 +57,7 @@
         <commonsmath.version>3.6.1</commonsmath.version>
 
         <!-- Other properties -->
-        <!-- used by CI on Windows as the
-             XGBoost 1.0.0 binary on Maven Central doesn't
-             include Windows support -->
+        <!-- Turn off tests which rely on native code -->
         <skipXGBoostTests>false</skipXGBoostTests>
         <skipONNXTests>false</skipONNXTests>
     </properties>


### PR DESCRIPTION
### Description
Bumps the XGBoost version to 1.4.1. This version has a bunch of native library improvements, the JVM library loader changes I wrote, a small improvement to XGBoost.loadModel, and a Windows binary in the Maven Central release. Turns on the XGBoost CI tests on Windows. I'll tidy up the XGBoost related tutorial text in the `4.1-tutorials` branch rather than induce more conflicts.

### Motivation
The Windows binary now means that Tribuo's tutorials will run on Windows as well as macOS and Linux x86_64 platforms. 