### PR TITLE
feature/pretty-MultiLabelConfusionMatrix-toString

### DIFF
--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMetrics.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMetrics.java
@@ -60,7 +60,7 @@ public final class ConfusionMetrics {
         double support = cm.support(label);
         // handle div-by-zero
         if (support == 0d) {
-            logger.warning("No predictions: accuracy ill-defined");
+            logger.warning("No predictions for " + label + ": accuracy ill-defined");
             return Double.NaN;
         }
         return cm.tp(label) / cm.support(label);

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
@@ -28,6 +28,7 @@ import org.tribuo.multilabel.MultiLabelFactory;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * A {@link ConfusionMatrix} which accepts {@link MultiLabel}s.
@@ -158,15 +159,18 @@ public final class MultiLabelConfusionMatrix implements ConfusionMatrix<MultiLab
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
-        for (int i = 0; i < mcm.length; i++) {
-            DenseMatrix cm = mcm[i];
-            sb.append(cm.toString());
-            sb.append("\n");
-        }
-        sb.append("]");
-        return sb.toString();
+        return getDomain().getDomain().stream()
+            .map(multiLabel -> {
+                  final int tp = (int) tp(multiLabel);
+                  final int fn = (int) fn(multiLabel);
+                  final int fp = (int) fp(multiLabel);
+                  final int tn = (int) tn(multiLabel);
+                  return String.join("\n",
+                      multiLabel.toString(),
+                      String.format("    [tn: %,d fn: %,d]", tn, fn),
+                      String.format("    [fp: %,d tp: %,d]", fp, tp));
+                }
+            ).collect(Collectors.joining("\n"));
     }
 
     static ConfusionMatrixTuple tabulate(ImmutableOutputInfo<MultiLabel> domain, List<Prediction<MultiLabel>> predictions) {


### PR DESCRIPTION
### Description
Easier to read `MultiLabelConfusionMatrix.toString()`. (Subset of PR [#128] which includes other work.)

### Motivation

Such a feature would make analysis of `MultiLabel` models simpler: in particular `MultiLabelConfusionMatrix` `toString()` is hard to interpret. Compare

```
[DenseMatrix(dim1=2,dim2=2,values=
	row 0 [ 3.000000000000000, 0.000000000000000];
	row 1 [ 0.000000000000000, 1.000000000000000];
)
DenseMatrix(dim1=2,dim2=2,values=
	row 0 [ 0.000000000000000, 1.000000000000000];
	row 1 [ 1.000000000000000, 2.000000000000000];
)
DenseMatrix(dim1=2,dim2=2,values=
	row 0 [ 2.000000000000000, 1.000000000000000];
	row 1 [ 1.000000000000000, 0.000000000000000];
)
]
```

to

```
(LabelSet={a})
    [tn: 3 fn: 0]
    [fp: 0 tp: 1]
(LabelSet={b})
    [tn: 0 fn: 1]
    [fp: 1 tp: 2]
(LabelSet={c})
    [tn: 2 fn: 1]
    [fp: 1 tp: 0]
```

cc @Craigacp 