### PR TITLE
Adding the RNG to AbstractSGDTrainer.createParameters()

### DIFF
--- a/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractLinearSGDTrainer.java
+++ b/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractLinearSGDTrainer.java
@@ -20,6 +20,7 @@ import org.tribuo.Output;
 import org.tribuo.math.LinearParameters;
 import org.tribuo.math.StochasticGradientOptimiser;
 
+import java.util.SplittableRandom;
 import java.util.logging.Logger;
 
 /**
@@ -70,9 +71,10 @@ public abstract class AbstractLinearSGDTrainer<T extends Output<T>,U> extends Ab
      * a single weight matrix.
      * @param numFeatures The number of input features.
      * @param numOutputs The number of output dimensions.
+     * @param localRNG The RNG to use for parameter initialisation.
      * @return The trainable parameters.
      */
-    protected LinearParameters createParameters(int numFeatures, int numOutputs) {
+    protected LinearParameters createParameters(int numFeatures, int numOutputs, SplittableRandom localRNG) {
         return new LinearParameters(numFeatures+1,numOutputs);
     }
 

--- a/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractSGDTrainer.java
+++ b/Common/SGD/src/main/java/org/tribuo/common/sgd/AbstractSGDTrainer.java
@@ -171,7 +171,7 @@ public abstract class AbstractSGDTrainer<T extends Output<T>,U,V extends Model<T
         logger.info(String.format("Training SGD model with %d examples", n));
         logger.info("Outputs - " + outputIDInfo.toReadableString());
 
-        X parameters = createParameters(featureIDMap.size(),outputIDInfo.size());
+        X parameters = createParameters(featureIDMap.size(), outputIDInfo.size(), localRNG);
 
         localOptimiser.initialise(parameters);
         double loss = 0.0;
@@ -279,9 +279,10 @@ public abstract class AbstractSGDTrainer<T extends Output<T>,U,V extends Model<T
      * Constructs the trainable parameters object.
      * @param numFeatures The number of input features.
      * @param numOutputs The number of output dimensions.
+     * @param localRNG The RNG to use for parameter initialisation.
      * @return The trainable parameters.
      */
-    protected abstract X createParameters(int numFeatures, int numOutputs);
+    protected abstract X createParameters(int numFeatures, int numOutputs, SplittableRandom localRNG);
 
     @Override
     public TrainerProvenance getProvenance() {


### PR DESCRIPTION
### Description
The parameter creation hook in `AbstractSGDTrainer` now accepts a RNG to allow for random initialisations of the logistic regression and future trainers which depend on `AbstractSGDTrainer`.

### Motivation
Tribuo's linear sgd models use a fixed initialisation, but we're considering making it random. Some of the other SGD models we're investigating for the next release will need random initialisations for symmetry breaking, and so they need access to the localRNG produced for that call to train. The RNG state is already tracked in the trainer provenance so this change is very small.
