### PR TITLE
Adds a field processor which operates on dates

### DIFF
--- a/Data/src/main/java/org/tribuo/data/columnar/FieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/FieldProcessor.java
@@ -41,9 +41,13 @@ public interface FieldProcessor extends Configurable, Provenancable<ConfiguredOb
          */
         BINARISED_CATEGORICAL,
         /**
-         * Categorical features with the values converted into doubles.
+         * Unordered categorical features with the values converted into doubles.
          */
         CATEGORICAL,
+        /**
+         * Ordered integral feature values (e.g. day of month) stored as doubles.
+         */
+        INTEGER,
         /**
          * Real valued features.
          */

--- a/Data/src/main/java/org/tribuo/data/columnar/extractors/DateExtractor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/extractors/DateExtractor.java
@@ -23,6 +23,7 @@ import com.oracle.labs.mlrg.olcut.provenance.impl.ConfiguredObjectProvenanceImpl
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -39,6 +40,12 @@ public class DateExtractor extends SimpleFieldExtractor<LocalDate> {
     private String dateFormat;
     private DateTimeFormatter formatter;
 
+    @Config(mandatory = false, description = "Sets the locale language.")
+    private String localeLanguage = null;
+
+    @Config(mandatory = false, description = "Sets the locale country.")
+    private String localeCountry = null;
+
     /**
      * for olcut
      */
@@ -46,13 +53,29 @@ public class DateExtractor extends SimpleFieldExtractor<LocalDate> {
 
     /**
      * Constructs a date extractor that emits a LocalDate by applying the supplied format to the specified field.
+     * <p>
+     * Uses the system locale for backwards compatibility with 4.0 and 4.1.
      * @param fieldName The field to read.
      * @param metadataName The metadata field to write.
      * @param dateFormat The date format (supplied to {@link DateTimeFormatter}.
      */
     public DateExtractor(String fieldName, String metadataName, String dateFormat) {
+        this(fieldName,metadataName,dateFormat,null,null);
+    }
+
+    /**
+     * Constructs a date extractor that emits a LocalDate by applying the supplied format to the specified field.
+     * @param fieldName The field to read.
+     * @param metadataName The metadata field to write to.
+     * @param dateFormat The date format (supplied to {@link DateTimeFormatter}.
+     * @param localeLanguage The locale language.
+     * @param localeCountry The locale country.
+     */
+    public DateExtractor(String fieldName, String metadataName, String dateFormat, String localeLanguage, String localeCountry) {
         super(fieldName, metadataName);
         this.dateFormat = dateFormat;
+        this.localeCountry = localeCountry;
+        this.localeLanguage = localeLanguage;
         postConfig();
     }
 
@@ -60,6 +83,8 @@ public class DateExtractor extends SimpleFieldExtractor<LocalDate> {
      * Constructs a date extractor that emits a LocalDate by applying the supplied format to the specified field.
      * <p>
      * Deprecated as it does not allow recovery of the formatter pattern for the provenance.
+     * <p>
+     * Uses the system locale for backwards compatibility with 4.0 and 4.1.
      * @param fieldName The field to read.
      * @param metadataName The metadata field to write.
      * @param formatter The date format (supplied to {@link DateTimeFormatter}.
@@ -77,8 +102,14 @@ public class DateExtractor extends SimpleFieldExtractor<LocalDate> {
     @Override
     public void postConfig() {
         super.postConfig();
+        Locale locale;
+        if ((localeLanguage == null) && (localeCountry == null)) {
+            locale = Locale.getDefault(Locale.Category.FORMAT);
+        } else {
+            locale = new Locale(localeLanguage,localeCountry);
+        }
         if (dateFormat != null) {
-            formatter = DateTimeFormatter.ofPattern(dateFormat);
+            formatter = DateTimeFormatter.ofPattern(dateFormat,locale);
         } else {
             formatter = DateTimeFormatter.BASIC_ISO_DATE;
         }
@@ -102,7 +133,13 @@ public class DateExtractor extends SimpleFieldExtractor<LocalDate> {
 
     @Override
     public String toString() {
-        return "DateExtractor(fieldName=" + fieldName + ", metadataName=" + metadataName + ", dateFormat=" + formatter.toString() + ")";
+        return "DateExtractor(" +
+                "fieldName='" + fieldName + '\'' +
+                ", metadataName='" + metadataName + '\'' +
+                ", dateFormat=" + formatter +
+                ", localeLanguage='" + localeLanguage + '\'' +
+                ", localeCountry='" + localeCountry + '\'' +
+                ')';
     }
 
     @Override

--- a/Data/src/main/java/org/tribuo/data/columnar/extractors/DateExtractor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/extractors/DateExtractor.java
@@ -17,6 +17,7 @@
 package org.tribuo.data.columnar.extractors;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import com.oracle.labs.mlrg.olcut.provenance.ConfiguredObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.impl.ConfiguredObjectProvenanceImpl;
 
@@ -105,11 +106,19 @@ public class DateExtractor extends SimpleFieldExtractor<LocalDate> {
         Locale locale;
         if ((localeLanguage == null) && (localeCountry == null)) {
             locale = Locale.getDefault(Locale.Category.FORMAT);
+        } else if (localeLanguage == null) {
+            throw new PropertyException("","localeLanguage","Must supply both localeLanguage and localeCountry when setting the locale.");
+        } else if (localeCountry == null) {
+            throw new PropertyException("","localeCountry","Must supply both localeLanguage and localeCountry when setting the locale.");
         } else {
             locale = new Locale(localeLanguage,localeCountry);
         }
         if (dateFormat != null) {
-            formatter = DateTimeFormatter.ofPattern(dateFormat,locale);
+            try {
+                formatter = DateTimeFormatter.ofPattern(dateFormat,locale);
+            } catch (IllegalArgumentException e) {
+                throw new PropertyException(e,"","dateFormat","dateFormat could not be parsed by DateTimeFormatter");
+            }
         } else {
             formatter = DateTimeFormatter.BASIC_ISO_DATE;
         }

--- a/Data/src/main/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractor.java
@@ -24,6 +24,7 @@ import com.oracle.labs.mlrg.olcut.provenance.impl.ConfiguredObjectProvenanceImpl
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,6 +43,12 @@ public class OffsetDateTimeExtractor extends SimpleFieldExtractor<OffsetDateTime
     private String dateTimeFormat;
     private DateTimeFormatter formatter;
 
+    @Config(mandatory = false, description = "The locale language.")
+    private String localeLanguage = null;
+
+    @Config(mandatory = false, description = "The locale country.")
+    private String localeCountry = null;
+
     /**
      * for olcut
      */
@@ -49,13 +56,29 @@ public class OffsetDateTimeExtractor extends SimpleFieldExtractor<OffsetDateTime
 
     /**
      * Constructs a date time extractor that emits an OffsetDateTime by applying the supplied format to the specified field.
+     * <p>
+     * Uses the system locale for backwards compatibility with 4.0 and 4.1.
      * @param fieldName The field to read.
      * @param metadataName The metadata field to write.
      * @param dateTimeFormat The date/time format (supplied to {@link DateTimeFormatter}.
      */
     public OffsetDateTimeExtractor(String fieldName, String metadataName, String dateTimeFormat) {
+        this(fieldName,metadataName,dateTimeFormat,null,null);
+    }
+
+    /**
+     * Constructs a date time extractor that emits an OffsetDateTime by applying the supplied format to the specified field.
+     * @param fieldName The field to read.
+     * @param metadataName The metadata field to write to.
+     * @param dateTimeFormat The date format (supplied to {@link DateTimeFormatter}.
+     * @param localeLanguage The locale language.
+     * @param localeCountry The locale country.
+     */
+    public OffsetDateTimeExtractor(String fieldName, String metadataName, String dateTimeFormat, String localeLanguage, String localeCountry) {
         super(fieldName, metadataName);
         this.dateTimeFormat = dateTimeFormat;
+        this.localeCountry = localeCountry;
+        this.localeLanguage = localeLanguage;
         postConfig();
     }
 
@@ -65,8 +88,14 @@ public class OffsetDateTimeExtractor extends SimpleFieldExtractor<OffsetDateTime
     @Override
     public void postConfig() {
         super.postConfig();
+        Locale locale;
+        if ((localeLanguage == null) && (localeCountry == null)) {
+            locale = Locale.getDefault(Locale.Category.FORMAT);
+        } else {
+            locale = new Locale(localeLanguage,localeCountry);
+        }
         if (dateTimeFormat != null) {
-            formatter = DateTimeFormatter.ofPattern(dateTimeFormat);
+            formatter = DateTimeFormatter.ofPattern(dateTimeFormat,locale);
         } else {
             throw new PropertyException("","dateTimeFormat", "Invalid Date/Time format string supplied");
         }
@@ -90,7 +119,13 @@ public class OffsetDateTimeExtractor extends SimpleFieldExtractor<OffsetDateTime
 
     @Override
     public String toString() {
-        return "OffsetDateTimeExtractor(fieldName=" + fieldName + ", metadataName=" + metadataName + ", dateTimeFormat=" + dateTimeFormat + ")";
+        return "OffsetDateTimeExtractor(" +
+                "fieldName='" + fieldName + '\'' +
+                ", metadataName='" + metadataName + '\'' +
+                ", dateTimeFormat='" + dateTimeFormat + '\'' +
+                ", localeLanguage='" + localeLanguage + '\'' +
+                ", localeCountry='" + localeCountry + '\'' +
+                ')';
     }
 
     @Override

--- a/Data/src/main/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractor.java
@@ -91,11 +91,19 @@ public class OffsetDateTimeExtractor extends SimpleFieldExtractor<OffsetDateTime
         Locale locale;
         if ((localeLanguage == null) && (localeCountry == null)) {
             locale = Locale.getDefault(Locale.Category.FORMAT);
+        } else if (localeLanguage == null) {
+            throw new PropertyException("","localeLanguage","Must supply both localeLanguage and localeCountry when setting the locale.");
+        } else if (localeCountry == null) {
+            throw new PropertyException("","localeCountry","Must supply both localeLanguage and localeCountry when setting the locale.");
         } else {
             locale = new Locale(localeLanguage,localeCountry);
         }
         if (dateTimeFormat != null) {
-            formatter = DateTimeFormatter.ofPattern(dateTimeFormat,locale);
+            try {
+                formatter = DateTimeFormatter.ofPattern(dateTimeFormat,locale);
+            } catch (IllegalArgumentException e) {
+                throw new PropertyException(e,"","dateTimeFormat","dateTimeFormat could not be parsed by DateTimeFormatter");
+            }
         } else {
             throw new PropertyException("","dateTimeFormat", "Invalid Date/Time format string supplied");
         }

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
@@ -17,6 +17,7 @@
 package org.tribuo.data.columnar.processors.field;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import com.oracle.labs.mlrg.olcut.provenance.ConfiguredObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.impl.ConfiguredObjectProvenanceImpl;
 import org.tribuo.data.columnar.ColumnarFeature;
@@ -179,8 +180,12 @@ public final class DateFieldProcessor implements FieldProcessor {
      */
     @Override
     public void postConfig() {
-        Locale locale = new Locale(localeLanguage,localeCountry);
-        formatter = DateTimeFormatter.ofPattern(dateFormat,locale);
+        Locale locale = new Locale(localeLanguage, localeCountry);
+        try {
+            formatter = DateTimeFormatter.ofPattern(dateFormat, locale);
+        } catch (IllegalArgumentException e) {
+            throw new PropertyException(e,"","dateFormat","dateFormat could not be parsed by DateTimeFormatter");
+        }
     }
 
     @Override

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
@@ -208,7 +208,7 @@ public final class DateFieldProcessor implements FieldProcessor {
 
     @Override
     public GeneratedFeatureType getFeatureType() {
-        return GeneratedFeatureType.REAL;
+        return GeneratedFeatureType.INTEGER;
     }
 
     @Override

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
@@ -217,6 +217,18 @@ public final class DateFieldProcessor implements FieldProcessor {
     }
 
     @Override
+    public String toString() {
+        return "DateFieldProcessor(" +
+                "fieldName='" + fieldName + '\'' +
+                ", featureTypes=" + featureTypes +
+                ", dateFormat='" + dateFormat + '\'' +
+                ", formatter=" + formatter +
+                ", localeLanguage='" + localeLanguage + '\'' +
+                ", localeCountry='" + localeCountry + '\'' +
+                ')';
+    }
+
+    @Override
     public ConfiguredObjectProvenance getProvenance() {
         return new ConfiguredObjectProvenanceImpl(this,"FieldProcessor");
     }

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.data.columnar.processors.field;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.provenance.ConfiguredObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.impl.ConfiguredObjectProvenanceImpl;
+import org.tribuo.data.columnar.ColumnarFeature;
+import org.tribuo.data.columnar.FieldProcessor;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.ToIntFunction;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Processes a column that contains a date value. The features are named
+ * based on the column name and the feature type extracted.
+ * <p>
+ * This class uses {@link LocalDate}
+ * <p>
+ * Returns an empty list if the date failed to parse or was empty.
+ */
+public final class DateFieldProcessor implements FieldProcessor {
+
+    private static final Logger logger = Logger.getLogger(DateFieldProcessor.class.getName());
+
+    /**
+     * The types of date features which can be extracted.
+     */
+    public enum DateFeatureType {
+        /**
+         * The day of the week in ISO 8601.
+         */
+        DAY_OF_WEEK((LocalDate l) -> l.getDayOfWeek().getValue()),
+        /**
+         * The week of the year in ISO 8601.
+         */
+        WEEK_OF_YEAR((LocalDate l) -> l.get(WeekFields.ISO.weekOfWeekBasedYear())),
+        /**
+         * The day of the year.
+         */
+        DAY_OF_YEAR(LocalDate::getDayOfYear),
+        /**
+         * The day.
+         */
+        DAY(LocalDate::getDayOfMonth),
+        /**
+         * The month.
+         */
+        MONTH(LocalDate::getMonthValue),
+        /**
+         * The year.
+         */
+        YEAR(LocalDate::getYear);
+
+        private final ToIntFunction<LocalDate> extractionFunction;
+
+        private DateFeatureType(ToIntFunction<LocalDate> func) {
+            this.extractionFunction = func;
+        }
+
+        public int extract(LocalDate date) {
+            return extractionFunction.applyAsInt(date);
+        }
+    }
+
+    @Config(mandatory = true, description = "The field name to read.")
+    private String fieldName;
+
+    @Config(mandatory = true, description = "The date features to extract.")
+    private EnumSet<DateFeatureType> featureTypes;
+
+    @Config(mandatory = true, description = "The expected date format.")
+    private String dateFormat;
+    private DateTimeFormatter formatter;
+
+    @Config(mandatory = false, description = "Sets the locale language.")
+    private String localeLanguage = "en";
+
+    @Config(mandatory = false, description = "Sets the locale country.")
+    private String localeCountry = "US";
+
+    /**
+     * For olcut.
+     */
+    private DateFieldProcessor() {}
+
+    /**
+     * Constructs a field processor which parses a date from the specified field name using the supplied
+     * format string then extracts date features according to the supplied {@link EnumSet}.
+     * <p>
+     * Defaults to {@link Locale#US}.
+     * <p>
+     * Throws {@link IllegalArgumentException} if the date format is invalid.
+     * @param fieldName The field name to read.
+     * @param featureTypes The features to extract.
+     * @param dateFormat The date format to use.
+     */
+    public DateFieldProcessor(String fieldName, EnumSet<DateFeatureType> featureTypes, String dateFormat) {
+        this(fieldName,featureTypes,dateFormat,"en","US");
+    }
+
+
+    /**
+     * Constructs a field processor which parses a date from the specified field name using the supplied
+     * format string then extracts date features according to the supplied {@link EnumSet}.
+     * <p>
+     * Throws {@link IllegalArgumentException} if the date format is invalid.
+     * @param fieldName The field name to read.
+     * @param featureTypes The features to extract.
+     * @param dateFormat The date format to use.
+     * @param localeLanguage The Locale language.
+     * @param localeCountry The Locale country.
+     */
+    public DateFieldProcessor(String fieldName, EnumSet<DateFeatureType> featureTypes, String dateFormat,
+                              String localeLanguage, String localeCountry) {
+        this.fieldName = fieldName;
+        this.featureTypes = EnumSet.copyOf(featureTypes);
+        this.dateFormat = dateFormat;
+        this.localeLanguage = localeLanguage;
+        this.localeCountry = localeCountry;
+        postConfig();
+    }
+
+    /**
+     * Used by the OLCUT configuration system, and should not be called by external code.
+     */
+    @Override
+    public void postConfig() {
+        Locale locale = new Locale(localeLanguage,localeCountry);
+        formatter = DateTimeFormatter.ofPattern(dateFormat,locale);
+    }
+
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    @Override
+    public List<ColumnarFeature> process(String value) {
+        try {
+            LocalDate date = LocalDate.parse(value, formatter);
+            List<ColumnarFeature> features = new ArrayList<>(featureTypes.size());
+            for (DateFeatureType f : featureTypes) {
+                int featureValue = f.extract(date);
+                ColumnarFeature feature = new ColumnarFeature(fieldName,f.toString(),featureValue);
+                features.add(feature);
+            }
+            return features;
+        } catch (DateTimeParseException e) {
+            logger.log(Level.WARNING, e.getParsedString());
+            logger.log(Level.WARNING, String.format("Unable to parse date %s with formatter %s", value, formatter.toString()));
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public GeneratedFeatureType getFeatureType() {
+        return GeneratedFeatureType.REAL;
+    }
+
+    @Override
+    public FieldProcessor copy(String newFieldName) {
+        return new DateFieldProcessor(newFieldName,featureTypes,dateFormat);
+    }
+
+    @Override
+    public ConfiguredObjectProvenance getProvenance() {
+        return new ConfiguredObjectProvenanceImpl(this,"FieldProcessor");
+    }
+}

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DateFieldProcessor.java
@@ -25,6 +25,7 @@ import org.tribuo.data.columnar.FieldProcessor;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.IsoFields;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,9 +61,37 @@ public final class DateFieldProcessor implements FieldProcessor {
          */
         WEEK_OF_YEAR((LocalDate l) -> l.get(WeekFields.ISO.weekOfWeekBasedYear())),
         /**
+         * The week of the month, as defined by ISO 8601 semantics for week of the year.
+         */
+        WEEK_OF_MONTH((LocalDate l) -> l.get(WeekFields.ISO.weekOfMonth())),
+        /**
          * The day of the year.
          */
         DAY_OF_YEAR(LocalDate::getDayOfYear),
+        /**
+         * The parity of the day of the year.
+         */
+        EVEN_OR_ODD_DAY((LocalDate l) -> l.getDayOfYear() % 2),
+        /**
+         * The parity of the week of the year as defined by ISO 8601.
+         */
+        EVEN_OR_ODD_WEEK((LocalDate l) -> l.get(WeekFields.ISO.weekOfWeekBasedYear()) % 2),
+        /**
+         * The parity of the month.
+         */
+        EVEN_OR_ODD_MONTH((LocalDate l) -> l.getMonthValue() % 2),
+        /**
+         * The parity of the year.
+         */
+        EVEN_OR_ODD_YEAR((LocalDate l) -> l.getYear() % 2),
+        /**
+         * The calendar quarter of the year.
+         */
+        CALENDAR_QUARTER((LocalDate l) -> l.get(IsoFields.QUARTER_OF_YEAR)),
+        /**
+         * The day of the quarter.
+         */
+        DAY_OF_QUARTER((LocalDate l) -> l.get(IsoFields.DAY_OF_QUARTER)),
         /**
          * The day.
          */

--- a/Data/src/test/java/org/tribuo/data/columnar/extractors/DateExtractorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/extractors/DateExtractorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.data.columnar.extractors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class DateExtractorTest {
+
+    @BeforeAll
+    public static void setup() {
+        // Turn off the logger during the tests
+        Logger logger = Logger.getLogger(DateExtractor.class.getName());
+        logger.setLevel(Level.OFF);
+    }
+
+    @Test
+    public void testInvalidBehaviour() {
+        String notADateFormatString = "not-a-date-format-string";
+        try {
+            DateExtractor extractor = new DateExtractor("test","date", notADateFormatString);
+            fail("Should have thrown on failing to parse the date format string");
+        } catch (IllegalArgumentException e) {
+            // pass
+        }
+
+        String isoFormat = "uuuu-MM-dd";
+        DateExtractor extractor = new DateExtractor("test", "date", isoFormat);
+
+        Optional<LocalDate> extractedMetadata = extractor.extractField("definitely-not-a-date");
+        assertFalse(extractedMetadata.isPresent());
+    }
+
+    @Test
+    public void testValidBehaviour() {
+        String isoFormat = "uuuu-MM-dd";
+        DateTimeFormatter isoFormatter = DateTimeFormatter.ofPattern(isoFormat, Locale.US);
+        String isoInput = "1994-01-26";
+        DateExtractor isoExtractor = new DateExtractor("test-iso", "date-iso", isoFormat);
+        LocalDate isoDate = LocalDate.parse(isoInput, isoFormatter);
+        Optional<LocalDate> isoExtracted = isoExtractor.extractField(isoInput);
+        assertTrue(isoExtracted.isPresent());
+        assertEquals(isoDate,isoExtracted.get());
+
+        String usFormat = "MM-dd-uuuu";
+        DateTimeFormatter usFormatter = DateTimeFormatter.ofPattern(usFormat, Locale.US);
+        String usInput = "09-08-1966";
+        DateExtractor usExtractor = new DateExtractor("test-us", "date-us", usFormat);
+        LocalDate usDate = LocalDate.parse(usInput, usFormatter);
+        Optional<LocalDate> usExtracted = usExtractor.extractField(usInput);
+        assertTrue(usExtracted.isPresent());
+        assertEquals(usDate,usExtracted.get());
+
+        String ukFormat = "dd-MM-uuuu";
+        DateTimeFormatter ukFormatter = DateTimeFormatter.ofPattern(ukFormat, Locale.US);
+        String ukInput = "23-11-1963";
+        DateExtractor ukProc = new DateExtractor("test-uk", "date-uk", ukFormat);
+        LocalDate ukDate = LocalDate.parse(ukInput, ukFormatter);
+        Optional<LocalDate> ukExtracted = ukProc.extractField(ukInput);
+        assertTrue(ukExtracted.isPresent());
+        assertEquals(ukDate,ukExtracted.get());
+    }
+
+}

--- a/Data/src/test/java/org/tribuo/data/columnar/extractors/DateExtractorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/extractors/DateExtractorTest.java
@@ -16,6 +16,7 @@
 
 package org.tribuo.data.columnar.extractors;
 
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +47,7 @@ public class DateExtractorTest {
         try {
             DateExtractor extractor = new DateExtractor("test","date", notADateFormatString);
             fail("Should have thrown on failing to parse the date format string");
-        } catch (IllegalArgumentException e) {
+        } catch (PropertyException e) {
             // pass
         }
 

--- a/Data/src/test/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractorTest.java
@@ -16,6 +16,7 @@
 
 package org.tribuo.data.columnar.extractors;
 
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -46,7 +47,7 @@ public class OffsetDateTimeExtractorTest {
         try {
             OffsetDateTimeExtractor extractor = new OffsetDateTimeExtractor("test","date", notADateFormatString);
             fail("Should have thrown on failing to parse the date format string");
-        } catch (IllegalArgumentException e) {
+        } catch (PropertyException e) {
             // pass
         }
 

--- a/Data/src/test/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/extractors/OffsetDateTimeExtractorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.data.columnar.extractors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class OffsetDateTimeExtractorTest {
+
+    @BeforeAll
+    public static void setup() {
+        // Turn off the logger during the tests
+        Logger logger = Logger.getLogger(OffsetDateTimeExtractor.class.getName());
+        logger.setLevel(Level.OFF);
+    }
+
+    @Test
+    public void testInvalidBehaviour() {
+        String notADateFormatString = "not-a-date-format-string";
+        try {
+            OffsetDateTimeExtractor extractor = new OffsetDateTimeExtractor("test","date", notADateFormatString);
+            fail("Should have thrown on failing to parse the date format string");
+        } catch (IllegalArgumentException e) {
+            // pass
+        }
+
+        String isoFormat = "uuuu-MM-dd";
+        OffsetDateTimeExtractor extractor = new OffsetDateTimeExtractor("test", "date", isoFormat);
+
+        Optional<OffsetDateTime> extractedMetadata = extractor.extractField("definitely-not-a-date");
+        assertFalse(extractedMetadata.isPresent());
+    }
+
+    @Test
+    public void testValidBehaviour() {
+        String isoFormat = "uuuu-MM-dd HH:mmx";
+        DateTimeFormatter isoFormatter = DateTimeFormatter.ofPattern(isoFormat, Locale.US);
+        String isoInput = "1994-01-26 20:00+05";
+        OffsetDateTimeExtractor isoExtractor = new OffsetDateTimeExtractor("test-iso", "date-iso", isoFormat);
+        OffsetDateTime isoDate = OffsetDateTime.parse(isoInput, isoFormatter);
+        Optional<OffsetDateTime> isoExtracted = isoExtractor.extractField(isoInput);
+        assertTrue(isoExtracted.isPresent());
+        assertEquals(isoDate,isoExtracted.get());
+
+        String usFormat = "MM-dd-uuuu HH:mmx";
+        DateTimeFormatter usFormatter = DateTimeFormatter.ofPattern(usFormat, Locale.US);
+        String usInput = "09-08-1966 20:30+05";
+        OffsetDateTimeExtractor usExtractor = new OffsetDateTimeExtractor("test-us", "date-us", usFormat);
+        OffsetDateTime usDate = OffsetDateTime.parse(usInput, usFormatter);
+        Optional<OffsetDateTime> usExtracted = usExtractor.extractField(usInput);
+        assertTrue(usExtracted.isPresent());
+        assertEquals(usDate,usExtracted.get());
+
+        String ukFormat = "dd-MM-uuuu HH:mmx";
+        DateTimeFormatter ukFormatter = DateTimeFormatter.ofPattern(ukFormat, Locale.US);
+        String ukInput = "23-11-1963 17:16+00";
+        OffsetDateTimeExtractor ukProc = new OffsetDateTimeExtractor("test-uk", "date-uk", ukFormat);
+        OffsetDateTime ukDate = OffsetDateTime.parse(ukInput, ukFormatter);
+        Optional<OffsetDateTime> ukExtracted = ukProc.extractField(ukInput);
+        assertTrue(ukExtracted.isPresent());
+        assertEquals(ukDate,ukExtracted.get());
+    }
+
+}

--- a/Data/src/test/java/org/tribuo/data/columnar/processors/field/DateFieldProcessorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/processors/field/DateFieldProcessorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.data.columnar.processors.field;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.tribuo.data.columnar.ColumnarFeature;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.WeekFields;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class DateFieldProcessorTest {
+
+    @BeforeAll
+    public static void setup() {
+        // Turn off the logger during the tests
+        Logger logger = Logger.getLogger(DateFieldProcessor.class.getName());
+        logger.setLevel(Level.OFF);
+    }
+
+    @Test
+    public void testInvalidBehaviour() {
+        String notADateFormatString = "not-a-date-format-string";
+        try {
+            DateFieldProcessor proc = new DateFieldProcessor("test",
+                    EnumSet.of(DateFieldProcessor.DateFeatureType.DAY),
+                    notADateFormatString);
+            fail("Should have thrown on failing to parse the date format string");
+        } catch (IllegalArgumentException e) {
+            // pass
+        }
+
+        String isoFormat = "uuuu-MM-dd";
+        DateFieldProcessor proc = new DateFieldProcessor("test",
+                EnumSet.of(DateFieldProcessor.DateFeatureType.DAY),
+                isoFormat);
+
+        List<ColumnarFeature> extractedFeatures = proc.process("definitely-not-a-date");
+        assertTrue(extractedFeatures.isEmpty());
+    }
+
+    @Test
+    public void testValidBehaviour() {
+        String isoFormat = "uuuu-MM-dd";
+        DateTimeFormatter isoFormatter = DateTimeFormatter.ofPattern(isoFormat, Locale.US);
+        String isoInput = "1994-01-26";
+        DateFieldProcessor isoProc = new DateFieldProcessor("test-iso",
+                EnumSet.allOf(DateFieldProcessor.DateFeatureType.class), isoFormat);
+        LocalDate isoDate = LocalDate.parse(isoInput, isoFormatter);
+        List<ColumnarFeature> isoFeatures = isoProc.process(isoInput);
+        assertEquals(6, isoFeatures.size());
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "DAY", isoDate.getDayOfMonth())));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "DAY", 26)));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "DAY_OF_WEEK", isoDate.getDayOfWeek().getValue())));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "DAY_OF_WEEK", DayOfWeek.WEDNESDAY.getValue())));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "DAY_OF_YEAR", isoDate.getDayOfYear())));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "DAY_OF_YEAR", 26)));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "WEEK_OF_YEAR", isoDate.get(WeekFields.ISO.weekOfWeekBasedYear()))));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "MONTH", isoDate.getMonthValue())));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "MONTH", Month.JANUARY.getValue())));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "YEAR", isoDate.getYear())));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "YEAR", 1994)));
+
+        String usFormat = "MM-dd-uuuu";
+        DateTimeFormatter usFormatter = DateTimeFormatter.ofPattern(usFormat, Locale.US);
+        String usInput = "09-08-1966";
+        DateFieldProcessor usProc = new DateFieldProcessor("test-us",
+                EnumSet.allOf(DateFieldProcessor.DateFeatureType.class), usFormat);
+        LocalDate usDate = LocalDate.parse(usInput, usFormatter);
+        List<ColumnarFeature> usFeatures = usProc.process(usInput);
+        assertEquals(6, usFeatures.size());
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "DAY", usDate.getDayOfMonth())));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "DAY", 8)));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "DAY_OF_WEEK", usDate.getDayOfWeek().getValue())));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "DAY_OF_WEEK", DayOfWeek.THURSDAY.getValue())));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "DAY_OF_YEAR", usDate.getDayOfYear())));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "DAY_OF_YEAR", 251)));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "WEEK_OF_YEAR", usDate.get(WeekFields.ISO.weekOfWeekBasedYear()))));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "MONTH", usDate.getMonthValue())));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "MONTH", Month.SEPTEMBER.getValue())));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "YEAR", usDate.getYear())));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "YEAR", 1966)));
+
+
+        String ukFormat = "dd-MM-uuuu";
+        DateTimeFormatter ukFormatter = DateTimeFormatter.ofPattern(ukFormat, Locale.US);
+        String ukInput = "23-11-1963";
+        DateFieldProcessor ukProc = new DateFieldProcessor("test-uk",
+                EnumSet.allOf(DateFieldProcessor.DateFeatureType.class), ukFormat);
+        LocalDate ukDate = LocalDate.parse(ukInput, ukFormatter);
+        List<ColumnarFeature> ukFeatures = ukProc.process(ukInput);
+        assertEquals(6, ukFeatures.size());
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "DAY", ukDate.getDayOfMonth())));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "DAY", 23)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "DAY_OF_WEEK", ukDate.getDayOfWeek().getValue())));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "DAY_OF_WEEK", DayOfWeek.SATURDAY.getValue())));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "DAY_OF_YEAR", ukDate.getDayOfYear())));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "DAY_OF_YEAR", 327)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "WEEK_OF_YEAR", ukDate.get(WeekFields.ISO.weekOfWeekBasedYear()))));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "MONTH", ukDate.getMonthValue())));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "MONTH", Month.NOVEMBER.getValue())));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "YEAR", ukDate.getYear())));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "YEAR", 1963)));
+        ukProc = new DateFieldProcessor("test-uk",
+                EnumSet.of(DateFieldProcessor.DateFeatureType.DAY,
+                        DateFieldProcessor.DateFeatureType.MONTH,
+                        DateFieldProcessor.DateFeatureType.YEAR),
+                ukFormat);
+        ukFeatures = ukProc.process(ukInput);
+        assertEquals(3, ukFeatures.size());
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "DAY", 23)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "MONTH", Month.NOVEMBER.getValue())));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "YEAR", 1963)));
+    }
+
+}

--- a/Data/src/test/java/org/tribuo/data/columnar/processors/field/DateFieldProcessorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/processors/field/DateFieldProcessorTest.java
@@ -16,6 +16,7 @@
 
 package org.tribuo.data.columnar.processors.field;
 
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.tribuo.data.columnar.ColumnarFeature;
@@ -52,7 +53,7 @@ public class DateFieldProcessorTest {
                     EnumSet.of(DateFieldProcessor.DateFeatureType.DAY),
                     notADateFormatString);
             fail("Should have thrown on failing to parse the date format string");
-        } catch (IllegalArgumentException e) {
+        } catch (PropertyException e) {
             // pass
         }
 

--- a/Data/src/test/java/org/tribuo/data/columnar/processors/field/DateFieldProcessorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/processors/field/DateFieldProcessorTest.java
@@ -74,7 +74,7 @@ public class DateFieldProcessorTest {
                 EnumSet.allOf(DateFieldProcessor.DateFeatureType.class), isoFormat);
         LocalDate isoDate = LocalDate.parse(isoInput, isoFormatter);
         List<ColumnarFeature> isoFeatures = isoProc.process(isoInput);
-        assertEquals(6, isoFeatures.size());
+        assertEquals(DateFieldProcessor.DateFeatureType.values().length, isoFeatures.size());
         assertTrue(isoFeatures.contains(
                 new ColumnarFeature("test-iso", "DAY", isoDate.getDayOfMonth())));
         assertTrue(isoFeatures.contains(
@@ -89,6 +89,20 @@ public class DateFieldProcessorTest {
                 new ColumnarFeature("test-iso", "DAY_OF_YEAR", 26)));
         assertTrue(isoFeatures.contains(
                 new ColumnarFeature("test-iso", "WEEK_OF_YEAR", isoDate.get(WeekFields.ISO.weekOfWeekBasedYear()))));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "WEEK_OF_MONTH", 4)));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "EVEN_OR_ODD_DAY", 0)));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "EVEN_OR_ODD_WEEK", 0)));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "EVEN_OR_ODD_MONTH", 1)));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "EVEN_OR_ODD_YEAR", 0)));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "CALENDAR_QUARTER", 1)));
+        assertTrue(isoFeatures.contains(
+                new ColumnarFeature("test-iso", "DAY_OF_QUARTER", 26)));
         assertTrue(isoFeatures.contains(
                 new ColumnarFeature("test-iso", "MONTH", isoDate.getMonthValue())));
         assertTrue(isoFeatures.contains(
@@ -105,7 +119,7 @@ public class DateFieldProcessorTest {
                 EnumSet.allOf(DateFieldProcessor.DateFeatureType.class), usFormat);
         LocalDate usDate = LocalDate.parse(usInput, usFormatter);
         List<ColumnarFeature> usFeatures = usProc.process(usInput);
-        assertEquals(6, usFeatures.size());
+        assertEquals(DateFieldProcessor.DateFeatureType.values().length, usFeatures.size());
         assertTrue(usFeatures.contains(
                 new ColumnarFeature("test-us", "DAY", usDate.getDayOfMonth())));
         assertTrue(usFeatures.contains(
@@ -120,6 +134,20 @@ public class DateFieldProcessorTest {
                 new ColumnarFeature("test-us", "DAY_OF_YEAR", 251)));
         assertTrue(usFeatures.contains(
                 new ColumnarFeature("test-us", "WEEK_OF_YEAR", usDate.get(WeekFields.ISO.weekOfWeekBasedYear()))));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "WEEK_OF_MONTH", 2)));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "EVEN_OR_ODD_DAY", 1)));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "EVEN_OR_ODD_WEEK", 0)));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "EVEN_OR_ODD_MONTH", 1)));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "EVEN_OR_ODD_YEAR", 0)));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "CALENDAR_QUARTER", 3)));
+        assertTrue(usFeatures.contains(
+                new ColumnarFeature("test-us", "DAY_OF_QUARTER", 70)));
         assertTrue(usFeatures.contains(
                 new ColumnarFeature("test-us", "MONTH", usDate.getMonthValue())));
         assertTrue(usFeatures.contains(
@@ -137,7 +165,7 @@ public class DateFieldProcessorTest {
                 EnumSet.allOf(DateFieldProcessor.DateFeatureType.class), ukFormat);
         LocalDate ukDate = LocalDate.parse(ukInput, ukFormatter);
         List<ColumnarFeature> ukFeatures = ukProc.process(ukInput);
-        assertEquals(6, ukFeatures.size());
+        assertEquals(DateFieldProcessor.DateFeatureType.values().length, ukFeatures.size());
         assertTrue(ukFeatures.contains(
                 new ColumnarFeature("test-uk", "DAY", ukDate.getDayOfMonth())));
         assertTrue(ukFeatures.contains(
@@ -152,6 +180,20 @@ public class DateFieldProcessorTest {
                 new ColumnarFeature("test-uk", "DAY_OF_YEAR", 327)));
         assertTrue(ukFeatures.contains(
                 new ColumnarFeature("test-uk", "WEEK_OF_YEAR", ukDate.get(WeekFields.ISO.weekOfWeekBasedYear()))));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "WEEK_OF_MONTH", 3)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "EVEN_OR_ODD_DAY", 1)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "EVEN_OR_ODD_WEEK", 1)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "EVEN_OR_ODD_MONTH", 1)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "EVEN_OR_ODD_YEAR", 1)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "CALENDAR_QUARTER", 4)));
+        assertTrue(ukFeatures.contains(
+                new ColumnarFeature("test-uk", "DAY_OF_QUARTER", 54)));
         assertTrue(ukFeatures.contains(
                 new ColumnarFeature("test-uk", "MONTH", ukDate.getMonthValue())));
         assertTrue(ukFeatures.contains(


### PR DESCRIPTION
### Description
Adds a `FieldProcessor` which parses a date value into a variety of features.

This also adds a new `GeneratedFeatureType` as date values produce integer features, along with adding locale generation to `DateExtractor` and `OffsetDateTimeExtractor`.

### Motivation
Tribuo needs a way of using dates as features as well as example metadata.