### PR TITLE
Adding an ARM maven profile which skips the native library tests

### DIFF
--- a/Regression/Core/src/main/java/org/tribuo/regression/MutableRegressionInfo.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/MutableRegressionInfo.java
@@ -39,7 +39,7 @@ public class MutableRegressionInfo extends RegressionInfo implements MutableOutp
 
     @Override
     public void observe(Regressor output) {
-        if (output == RegressionFactory.UNKNOWN_MULTIPLE_REGRESSOR) {
+        if (output == RegressionFactory.UNKNOWN_REGRESSOR) {
             unknownCount++;
         } else {
             if (overallCount != 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,15 @@
 
     <profiles>
         <profile>
+            <!-- Turn off ONNX, XGBoost and TF tests on ARM platforms as the binaries are not available -->
+            <id>arm</id>
+            <properties>
+                <skipXGBoostTests>true</skipXGBoostTests>
+                <skipONNXTests>true</skipONNXTests>
+                <skipTFTests>true</skipTFTests>
+            </properties>
+        </profile>
+        <profile>
             <id>src</id>
             <build>
                 <plugins>


### PR DESCRIPTION
### Description
XGBoost, ONNX and TF don't provide ARM binaries on Maven Central, so those tests need to be skipped on ARM platforms. This change makes it easier to do so.

It also removes a deprecation warning from `MutableRegressionInfo` which should have switched to using `UNKNOWN_REGRESSOR` when we added the deprecation notice to `UNKNOWN_MULTIPLE_REGRESSOR` in 4.1. Both fields refer to the same object, so there is no visible change.