### PR TITLE
CSVLoader refactor

### DIFF
--- a/Data/src/main/java/org/tribuo/data/columnar/ColumnarFeature.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/ColumnarFeature.java
@@ -42,6 +42,21 @@ public class ColumnarFeature extends Feature {
     private final String columnEntry;
 
     /**
+     * Constructs a {@code ColumnarFeature} from the field name. The column entry is blank.
+     * <p>
+     * This produces a ColumnarFeature which is identical to a Feature.
+     * @param fieldName The field name.
+     * @param value The feature value.
+     */
+    public ColumnarFeature(String fieldName, double value) {
+        super(fieldName,value);
+        this.fieldName = fieldName;
+        this.columnEntry = "";
+        this.firstFieldName = "";
+        this.secondFieldName = "";
+    }
+
+    /**
      * Constructs a {@code ColumnarFeature} from the field name, column entry and value.
      * @param fieldName The field name.
      * @param columnEntry The name of the extracted value from the field.
@@ -71,7 +86,7 @@ public class ColumnarFeature extends Feature {
     }
 
     /**
-     * Generates a feature name based on the field name.
+     * Generates a feature name based on the field name and the name.
      * <p>
      * Uses {@link ColumnarFeature#JOINER} to join the strings.
      * @param fieldName The field name.

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DoubleFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DoubleFieldProcessor.java
@@ -67,7 +67,7 @@ public class DoubleFieldProcessor implements FieldProcessor {
      * Constructs a field processor which extracts a single double valued feature from the specified field name.
      * <p>
      * Generates features named "&lt;fieldName&gt;@value" where &lt;fieldName&gt; is the argument to this constructor if
-     * {@code onlyFieldName} is false and "&lt;fieldName&gt;" otherwise.
+     * {@code onlyFieldName} is false, otherwise generates features named "&lt;fieldName&gt;".
      * Does not throw an exception if the value failed to parse.
      * @param fieldName The field name to read.
      * @param onlyFieldName Only use the field name as the feature name.

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DoubleFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DoubleFieldProcessor.java
@@ -80,7 +80,7 @@ public class DoubleFieldProcessor implements FieldProcessor {
      * Constructs a field processor which extracts a single double valued feature from the specified field name.
      * <p>
      * Generates features named "&lt;fieldName&gt;@value" where &lt;fieldName&gt; is the argument to this constructor if
-     * {@code onlyFieldName} is false and "&lt;fieldName&gt;" otherwise.
+     * {@code onlyFieldName} is false, otherwise generates features named "&lt;fieldName&gt;".
      * @param fieldName The field name to read.
      * @param onlyFieldName Only use the field name as the feature name.
      * @param throwOnInvalid Throw NumberFormatException if the value failed to parse.

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/field/DoubleFieldProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/field/DoubleFieldProcessor.java
@@ -55,7 +55,8 @@ public class DoubleFieldProcessor implements FieldProcessor {
     /**
      * Constructs a field processor which extracts a single double valued feature from the specified field name.
      * <p>
-     * Generates features named "fieldName@value", and does not throw an exception if the value failed to parse.
+     * Generates features named "&lt;fieldName&gt;@value" where &lt;fieldName&gt; is the argument to this constructor,
+     * and does not throw an exception if the value failed to parse.
      * @param fieldName The field name to read.
      */
     public DoubleFieldProcessor(String fieldName) {
@@ -65,7 +66,9 @@ public class DoubleFieldProcessor implements FieldProcessor {
     /**
      * Constructs a field processor which extracts a single double valued feature from the specified field name.
      * <p>
-     * Generates features named "fieldName@value", and does not throw an exception if the value failed to parse.
+     * Generates features named "&lt;fieldName&gt;@value" where &lt;fieldName&gt; is the argument to this constructor if
+     * {@code onlyFieldName} is false and "&lt;fieldName&gt;" otherwise.
+     * Does not throw an exception if the value failed to parse.
      * @param fieldName The field name to read.
      * @param onlyFieldName Only use the field name as the feature name.
      */
@@ -75,6 +78,9 @@ public class DoubleFieldProcessor implements FieldProcessor {
 
     /**
      * Constructs a field processor which extracts a single double valued feature from the specified field name.
+     * <p>
+     * Generates features named "&lt;fieldName&gt;@value" where &lt;fieldName&gt; is the argument to this constructor if
+     * {@code onlyFieldName} is false and "&lt;fieldName&gt;" otherwise.
      * @param fieldName The field name to read.
      * @param onlyFieldName Only use the field name as the feature name.
      * @param throwOnInvalid Throw NumberFormatException if the value failed to parse.

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/response/BinaryResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/response/BinaryResponseProcessor.java
@@ -192,6 +192,7 @@ public class BinaryResponseProcessor<T extends Output<T>> implements ResponsePro
         this.fieldName = fieldName;
     }
 
+    @Deprecated
     @Override
     public Optional<T> process(String value) {
         return process(Collections.singletonList(value));

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/response/EmptyResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/response/EmptyResponseProcessor.java
@@ -63,6 +63,7 @@ public final class EmptyResponseProcessor<T extends Output<T>> implements Respon
         return outputFactory;
     }
 
+    @Deprecated
     @Override
     public String getFieldName() {
         return FIELD_NAME;
@@ -81,11 +82,17 @@ public final class EmptyResponseProcessor<T extends Output<T>> implements Respon
      * @param value The value to process.
      * @return {@link Optional#empty}.
      */
+    @Deprecated
     @Override
     public Optional<T> process(String value) {
         return Optional.empty();
     }
 
+    /**
+     * This method always returns {@link Optional#empty}.
+     * @param values The values to process.
+     * @return {@link Optional#empty}.
+     */
     @Override
     public Optional<T> process(List<String> values) {
         return Optional.empty();

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/response/FieldResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/response/FieldResponseProcessor.java
@@ -54,6 +54,9 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
     @Config(description = "Whether to display field names as part of the generated label, defaults to false")
     private boolean displayField = false;
 
+    @Config(description = "Uppercase the value before converting to output.")
+    private boolean uppercase = true;
+
     @ConfigurableName
     private String configName;
 
@@ -93,6 +96,7 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
     /**
      * Constructs a response processor which passes the field value through the
      * output factory.
+     * Uppercases the value before generating the output.
      * @param fieldName The field to read.
      * @param defaultValue The default value to extract if it's not found.
      * @param outputFactory The output factory to use.
@@ -104,6 +108,7 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
     /**
      * Constructs a response processor which passes the field value through the
      * output factory.
+     * Uppercases the value before generating the output.
      * @param fieldNames The fields to read.
      * @param defaultValue The default value to extract if it's not found.
      * @param outputFactory The output factory to use.
@@ -115,6 +120,7 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
     /**
      * Constructs a response processor which passes the field value through the
      * output factory. fieldNames and defaultValues must be the same length.
+     * Uppercases the value before generating the output.
      * @param fieldNames The field to read.
      * @param defaultValues The default value to extract if it's not found.
      * @param outputFactory The output factory to use.
@@ -126,12 +132,26 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
     /**
      * Constructs a response processor which passes the field value through the
      * output factory. fieldNames and defaultValues must be the same length.
+     * Uppercases the value before generating the output.
      * @param fieldNames The field to read.
      * @param defaultValues The default value to extract if it's not found.
      * @param outputFactory The output factory to use.
      * @param displayField whether to include field names in the generated labels.
      */
     public FieldResponseProcessor(List<String> fieldNames, List<String> defaultValues, OutputFactory<T> outputFactory, boolean displayField) {
+        this(fieldNames,defaultValues,outputFactory,displayField,true);
+    }
+
+    /**
+     * Constructs a response processor which passes the field value through the
+     * output factory. fieldNames and defaultValues must be the same length.
+     * @param fieldNames The field to read.
+     * @param defaultValues The default value to extract if it's not found.
+     * @param outputFactory The output factory to use.
+     * @param displayField Whether to include field names in the generated output.
+     * @param uppercase Whether to uppercase the value before generating the output.
+     */
+    public FieldResponseProcessor(List<String> fieldNames, List<String> defaultValues, OutputFactory<T> outputFactory, boolean displayField, boolean uppercase) {
         if(fieldNames.size() != defaultValues.size()) {
             throw new IllegalArgumentException("fieldNames and defaultValues must be the same length");
         }
@@ -139,6 +159,7 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
         this.defaultValues = defaultValues;
         this.outputFactory = outputFactory;
         this.displayField = displayField;
+        this.uppercase = uppercase;
     }
 
     @Deprecated
@@ -158,6 +179,7 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
         return fieldNames.get(0);
     }
 
+    @Deprecated
     @Override
     public Optional<T> process(String value) {
         return process(Collections.singletonList(value));
@@ -174,7 +196,13 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
             if (displayField) {
                 prefix = fieldNames.get(i) + "=";
             }
-            String val = values.get(i).toUpperCase().trim();
+            String val;
+            if (uppercase) {
+                val = values.get(i).toUpperCase().trim();
+            }
+            else {
+                val = values.get(i).trim();
+            }
             val = val.isEmpty() ? defaultValues.get(i) : val;
             responses.add(prefix + val);
         }
@@ -188,7 +216,7 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
 
     @Override
     public String toString() {
-        return "FieldResponseProcessor(fieldNames="+ fieldNames.toString() +")";
+        return "FieldResponseProcessor(fieldNames="+ fieldNames.toString() + ",displayField="+displayField+",uppercase="+uppercase+")";
     }
 
     @Override

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/response/FieldResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/response/FieldResponseProcessor.java
@@ -199,8 +199,7 @@ public class FieldResponseProcessor<T extends Output<T>> implements ResponseProc
             String val;
             if (uppercase) {
                 val = values.get(i).toUpperCase().trim();
-            }
-            else {
+            } else {
                 val = values.get(i).trim();
             }
             val = val.isEmpty() ? defaultValues.get(i) : val;

--- a/Data/src/main/java/org/tribuo/data/columnar/processors/response/QuartileResponseProcessor.java
+++ b/Data/src/main/java/org/tribuo/data/columnar/processors/response/QuartileResponseProcessor.java
@@ -147,6 +147,7 @@ public class QuartileResponseProcessor<T extends Output<T>> implements ResponseP
         return fieldNames.get(0);
     }
 
+    @Deprecated
     @Override
     public Optional<T> process(String value) {
         if(value == null) {

--- a/Data/src/main/java/org/tribuo/data/csv/CSVLoader.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVLoader.java
@@ -136,6 +136,9 @@ public class CSVLoader<T extends Output<T>> {
 
     /**
      * Loads a DataSource from the specified csv file then wraps it in a dataset.
+     * <p>
+     * The {@code responseNames} set is traversed in iteration order to emit outputs,
+     * and should be an ordered set to ensure reproducibility.
      *
      * @param csvPath       The path to load.
      * @param responseNames The names of the response variables.
@@ -148,6 +151,9 @@ public class CSVLoader<T extends Output<T>> {
 
     /**
      * Loads a DataSource from the specified csv file then wraps it in a dataset.
+     * <p>
+     * The {@code responseNames} set is traversed in iteration order to emit outputs,
+     * and should be an ordered set to ensure reproducibility.
      *
      * @param csvPath       The path to load.
      * @param responseNames The names of the response variables.
@@ -211,6 +217,9 @@ public class CSVLoader<T extends Output<T>> {
 
     /**
      * Loads a DataSource from the specified csv path.
+     * <p>
+     * The {@code responseNames} set is traversed in iteration order to emit outputs,
+     * and should be an ordered set to ensure reproducibility.
      *
      * @param csvPath       The csv to load from.
      * @param responseNames The names of the response variables.
@@ -223,6 +232,9 @@ public class CSVLoader<T extends Output<T>> {
 
     /**
      * Loads a DataSource from the specified csv path.
+     * <p>
+     * The {@code responseNames} set is traversed in iteration order to emit outputs,
+     * and should be an ordered set to ensure reproducibility.
      *
      * @param csvPath       The csv to load from.
      * @param responseNames The names of the response variables.
@@ -235,6 +247,9 @@ public class CSVLoader<T extends Output<T>> {
 
     /**
      * Loads a DataSource from the specified csv path.
+     * <p>
+     * The {@code responseNames} set is traversed in iteration order to emit outputs,
+     * and should be an ordered set to ensure reproducibility.
      *
      * @param csvPath       The csv to load from.
      * @param responseNames The names of the response variables.
@@ -248,6 +263,9 @@ public class CSVLoader<T extends Output<T>> {
 
     /**
      * Loads a DataSource from the specified csv path.
+     * <p>
+     * The {@code responseNames} set is traversed in iteration order to emit outputs,
+     * and should be an ordered set to ensure reproducibility.
      *
      * @param csvPath       The csv to load from.
      * @param responseNames The names of the response variables.
@@ -296,7 +314,7 @@ public class CSVLoader<T extends Output<T>> {
                 fieldProcessors.put(field,new DoubleFieldProcessor(field,true,true));
             }
         }
-        boolean includeFieldName = responseNames.size() > 1 ? true : false;
+        boolean includeFieldName = responseNames.size() > 1;
         ResponseProcessor<T> responseProcessor = new FieldResponseProcessor<>(new ArrayList<>(responseNames),Collections.nCopies(responseNames.size(),""),outputFactory,includeFieldName,false);
         RowProcessor<T> rowProcessor = new RowProcessor<>(responseProcessor,fieldProcessors);
 

--- a/Data/src/test/java/org/tribuo/data/columnar/MockResponseProcessor.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/MockResponseProcessor.java
@@ -46,6 +46,7 @@ public class MockResponseProcessor implements ResponseProcessor<MockOutput> {
         return new MockOutputFactory();
     }
 
+    @Deprecated
     @Override
     public String getFieldName() {
         return fieldName;
@@ -57,6 +58,7 @@ public class MockResponseProcessor implements ResponseProcessor<MockOutput> {
         this.fieldName = fieldName;
     }
 
+    @Deprecated
     @Override
     public Optional<MockOutput> process(String value) {
         return Optional.of(new MockOutput(value));

--- a/Data/src/test/java/org/tribuo/data/columnar/processors/response/EmptyResponseProcessorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/processors/response/EmptyResponseProcessorTest.java
@@ -7,6 +7,7 @@ import org.tribuo.test.MockOutputFactory;
 
 public class EmptyResponseProcessorTest {
 
+    @SuppressWarnings("deprecation") // due to setFieldName test
     @Test
     public void basicTest() {
         MockOutputFactory outputFactory = new MockOutputFactory();

--- a/Data/src/test/java/org/tribuo/data/csv/CSVLoaderTest.java
+++ b/Data/src/test/java/org/tribuo/data/csv/CSVLoaderTest.java
@@ -30,9 +30,11 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -94,8 +96,8 @@ public class CSVLoaderTest {
         // because CSVIterator does not skip the first line in this case.
         // TODO do we want this behavior?
         String[] header = new String[]{"A","B","C","D","RESPONSE"};
-        assertThrows(NumberFormatException.class, () -> loader.loadDataSource(path, "RESPONSE", header));
-        assertThrows(NumberFormatException.class, () -> loader.loadDataSource(path, Collections.singleton("RESPONSE"), header));
+        assertThrows(NumberFormatException.class, () -> loader.load(Paths.get(path.toURI()), "RESPONSE", header));
+        assertThrows(NumberFormatException.class, () -> loader.load(Paths.get(path.toURI()), Collections.singleton("RESPONSE"), header));
         //
         // Test behavior when CSV file does not have a header row and the user instead supplies the header.
         URL noheader = CSVLoader.class.getResource("/org/tribuo/data/csv/test-noheader.csv");
@@ -103,7 +105,7 @@ public class CSVLoaderTest {
         checkDataTestCsv(loader.loadDataSource(noheader, Collections.singleton("RESPONSE"), header));
     }
 
-    private void checkDataTestCsv(DataSource<MockOutput> source) throws IOException {
+    private void checkDataTestCsv(DataSource<MockOutput> source) {
         MutableDataset<MockOutput> data = new MutableDataset<>(source);
         assertEquals(6, data.size());
         assertEquals("monkey", data.getExample(0).getOutput().label);
@@ -120,7 +122,7 @@ public class CSVLoaderTest {
         //
         // Missing feature column "A"
         assertThrows(IllegalArgumentException.class,
-                () -> loader.loadDataSource(path, Collections.singleton("RESPONSE"), new String[]{"B","C","D","RESPONSE"}));
+                () -> loader.load(Paths.get(path.toURI()), Collections.singleton("RESPONSE"), new String[]{"B","C","D","RESPONSE"}));
         //
         // Missing "RESPONSE" column
         assertThrows(IllegalArgumentException.class,
@@ -185,7 +187,7 @@ public class CSVLoaderTest {
     @Test
     public void testLoadMultiOutputAsSingleOutput() throws IOException {
         URL path = CSVLoader.class.getResource("/org/tribuo/data/csv/test-multioutput.csv");
-        Set<String> responses = new HashSet<>(Arrays.asList("R1", "R2"));
+        Set<String> responses = new LinkedHashSet<>(Arrays.asList("R1", "R2"));
         CSVLoader<MockOutput> loader = new CSVLoader<>(new MockOutputFactory());
         DataSource<MockOutput> source = loader.loadDataSource(path, responses);
         MutableDataset<MockOutput> data = new MutableDataset<>(source);


### PR DESCRIPTION
### Description
This change rebases `CSVLoader` on top of `CSVDataSource`, instead of reading the CSVs itself and processing the examples into a `ListDataSource`. 

There are currently two breaking changes both of which are sufficiently minor that we're ok with introducing them in a minor release. 

- All the `CSVLoader.loadDataSource` overloads now return `DataSource<T>` rather than `ListDataSource<T>` and the source they return is an instance of `CSVDataSource<T>`. This is unavoidable unless we want to read the `CSVDataSource` directly into a `ListDataSource` on construction, which might cause provenance issues.
- `CSVLoader.loadDataSource` is now lazy, like `CSVDataSource` itself. Previously it used to read the whole csv file and buffer the examples in memory, triggering any parsing exceptions during the call. Now the file is read as it's iterated, so the parsing exceptions are triggered on loading into a dataset, and the examples are not cached. We could modify `CSVDataSource` to have a cache flag which recovered the original behaviour.

This work caused a few changes in `DoubleFieldProcessor` and `FieldResponseProcessor` to allow them to behave in the same way as the old `CSVLoader` parsing code. All these options are off by default, so the current behaviour is preserved. I also went through and tagged all the method overrides where the super class method was marked deprecated in PR #150 which removes all the compile time deprecation warnings.

There is one further behaviour change, which is multi-output responses are generated in a different order. This seems to be because the set iteration order is not fixed, and so could have broken the test at any time in the old code. The test was fixed by using a `LinkedHashSet`, and we probably should specify in the docs that this should be used to ensure consistent iteration order.

### Motivation
CSVLoader currently emits `ListDataSource` with a special provenance class. This isn't configurable, and so that means it needs to be special cased in the reproducibility system, which seems unnecessary. After this change the CSVLoader will emit a CSVDataSourceProvenance which can be used to reconstruct the data without user intervention or special casing.
