### PR TITLE
Fixing an NPE in LIMEExplanation.getActiveFeatures()

### DIFF
--- a/Classification/Explanations/src/main/java/org/tribuo/classification/explanations/lime/LIMEExplanation.java
+++ b/Classification/Explanations/src/main/java/org/tribuo/classification/explanations/lime/LIMEExplanation.java
@@ -25,6 +25,7 @@ import org.tribuo.regression.Regressor;
 import org.tribuo.regression.evaluation.RegressionEvaluation;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * An {@link Explanation} using LIME.
@@ -56,7 +57,12 @@ public class LIMEExplanation implements Explanation<Regressor> {
 
     @Override
     public List<String> getActiveFeatures() {
-        return model.getActiveFeatures().get(prediction.getOutput().getLabel());
+        Map<String,List<String>> features = model.getActiveFeatures();
+        if (features.containsKey(Model.ALL_OUTPUTS)) {
+            return features.get(Model.ALL_OUTPUTS);
+        } else {
+            return features.get(prediction.getOutput().getLabel());
+        }
     }
 
     @Override

--- a/Classification/Explanations/src/test/java/org/tribuo/classification/explanations/lime/LIMEColumnarTest.java
+++ b/Classification/Explanations/src/test/java/org/tribuo/classification/explanations/lime/LIMEColumnarTest.java
@@ -52,6 +52,7 @@ import java.util.SplittableRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -204,6 +205,9 @@ public class LIMEColumnarTest {
         testExample.put("TextField","The full text field has more words in it than other fields.");
 
         Pair<LIMEExplanation, List<Example<Regressor>>> explanation = lime.explainWithSamples(testExample);
+
+        List<String> activeFeatures = explanation.getA().getActiveFeatures();
+        assertNotNull(activeFeatures);
 
         int[] aSampleCount = new int[3];
         int[] dSampleCount = new int[3];


### PR DESCRIPTION
### Description
SparseModels which only had a single feature set (rather than one per output dimension) caused an NPE in `LIMEExplanation.toString()` and other places which tried to use the output of `LIMEExplanation.getActiveFeatures()`.

### Motivation
LIME should work with any SparseTrainer, and the explanations should not throw NPE anywhere.

Noticed when looking at #156.
