### PR TITLE
Adds a ConfigurableDataSource data generator for Clustering

### DIFF
--- a/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/example/GaussianAnomalyDataSource.java
+++ b/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/example/GaussianAnomalyDataSource.java
@@ -104,7 +104,6 @@ public final class GaussianAnomalyDataSource implements ConfigurableDataSource<E
      * @param numSamples        The size of the output dataset.
      * @param fractionAnomalous The fraction of anomalies in the generated data.
      * @param seed              The rng seed to use.
-     * @return Examples drawn from a gaussian.
      */
     public GaussianAnomalyDataSource(int numSamples, float fractionAnomalous, long seed) {
         this.numSamples = numSamples;
@@ -127,7 +126,6 @@ public final class GaussianAnomalyDataSource implements ConfigurableDataSource<E
      * @param anomalousVariances The variances of the anomalous event features.
      * @param fractionAnomalous  The fraction of anomalies to generate.
      * @param seed               The rng seed to use.
-     * @return Examples drawn from a gaussian.
      */
     public GaussianAnomalyDataSource(int numSamples, double[] expectedMeans, double[] expectedVariances,
                                      double[] anomalousMeans, double[] anomalousVariances,
@@ -171,6 +169,14 @@ public final class GaussianAnomalyDataSource implements ConfigurableDataSource<E
                     "of anomalous features as expected features. anomalousMeans.length = " + anomalousMeans.length +
                     ", expectedMeans.length = " + expectedMeans.length);
 
+        }
+        for (int i = 0; i < anomalousVariances.length; i++) {
+            if (anomalousVariances[i] < 1e-10) {
+                throw new PropertyException("","anomalousVariances", "Variances must be positive, found " + Arrays.toString(anomalousVariances));
+            }
+            if (expectedVariances[i] < 1e-10) {
+                throw new PropertyException("","expectedVariances", "Variances must be positive, found " + Arrays.toString(expectedVariances));
+            }
         }
         String[] featureNames = Arrays.copyOf(allFeatureNames, expectedMeans.length);
         // We use java.util.Random here because SplittableRandom doesn't have nextGaussian yet.

--- a/Clustering/Core/src/main/java/org/tribuo/clustering/example/GaussianClusterDataSource.java
+++ b/Clustering/Core/src/main/java/org/tribuo/clustering/example/GaussianClusterDataSource.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.clustering.example;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
+import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import com.oracle.labs.mlrg.olcut.provenance.impl.SkeletalConfiguredObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
+import org.apache.commons.math3.distribution.MultivariateNormalDistribution;
+import org.apache.commons.math3.random.JDKRandomGenerator;
+import org.tribuo.ConfigurableDataSource;
+import org.tribuo.Dataset;
+import org.tribuo.Example;
+import org.tribuo.MutableDataset;
+import org.tribuo.OutputFactory;
+import org.tribuo.Trainer;
+import org.tribuo.clustering.ClusterID;
+import org.tribuo.clustering.ClusteringFactory;
+import org.tribuo.impl.ArrayExample;
+import org.tribuo.provenance.ConfiguredDataSourceProvenance;
+import org.tribuo.provenance.DataSourceProvenance;
+import org.tribuo.util.Util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Generates a clustering dataset drawn from a mixture of 5 Gaussians.
+ * <p>
+ * The Gaussians can be at most 4 dimensional, resulting in 4 features.
+ * <p>
+ * By default the Gaussians are 2-dimensional with the following means and variances:
+ * <ul>
+ *     <li>Mean = (), variance = ()</li>
+ * </ul>
+ */
+public final class GaussianClusterDataSource implements ConfigurableDataSource<ClusterID> {
+
+    private static final ClusteringFactory factory = new ClusteringFactory();
+
+    private static final String[] allFeatureNames = new String[]{
+            "A", "B", "C", "D",
+    };
+
+    @Config(mandatory = true, description = "The number of samples to draw.")
+    private int numSamples;
+
+    @Config(description = "The probability of sampling from each Gaussian, must sum to 1.0.")
+    private double[] mixingPMF = new double[]{0.1, 0.35, 0.05, 0.25, 0.25};
+
+    @Config(description = "The mean of the first Gaussian.")
+    private double[] firstMean = new double[]{0.0, 0.0};
+
+    @Config(description = "A vector representing the first Gaussian's covariance matrix.")
+    private double[] firstVariance = new double[]{1.0, 0.0, 0.0, 1.0};
+
+    @Config(description = "The mean of the second Gaussian.")
+    private double[] secondMean = new double[]{5.0, 5.0};
+
+    @Config(description = "A vector representing the second Gaussian's covariance matrix.")
+    private double[] secondVariance = new double[]{1.0, 0.0, 0.0, 1.0};
+
+    @Config(description = "The mean of the third Gaussian.")
+    private double[] thirdMean = new double[]{2.5, 2.5};
+
+    @Config(description = "A vector representing the third Gaussian's covariance matrix.")
+    private double[] thirdVariance = new double[]{1.0, 0.5, 0.5, 1.0};
+
+    @Config(description = "The mean of the fourth Gaussian.")
+    private double[] fourthMean = new double[]{10.0, 0.0};
+
+    @Config(description = "A vector representing the fourth Gaussian's covariance matrix.")
+    private double[] fourthVariance = new double[]{0.1, 0.0, 0.0, 0.1};
+
+    @Config(description = "The mean of the fifth Gaussian.")
+    private double[] fifthMean = new double[]{-1.0, 0.0};
+
+    @Config(description = "A vector representing the fifth Gaussian's covariance matrix.")
+    private double[] fifthVariance = new double[]{1.0, 0.0, 0.0, 0.1};
+
+    @Config(description = "The RNG seed.")
+    private long seed = Trainer.DEFAULT_SEED;
+
+    private List<Example<ClusterID>> examples;
+
+    /**
+     * For OLCUT.
+     */
+    private GaussianClusterDataSource() {
+    }
+
+    /**
+     * Generates a clustering dataset drawn from a mixture of 5 Gaussians.
+     *
+     * @param numSamples The size of the output dataset.
+     * @param seed       The rng seed to use.
+     * @return Examples drawn from a mixture of Gaussians.
+     */
+    public GaussianClusterDataSource(int numSamples, long seed) {
+        this.numSamples = numSamples;
+        this.seed = seed;
+        postConfig();
+    }
+
+    /**
+     * Generates a clustering dataset drawn from a mixture of 5 Gaussians.
+     * <p>
+     * The Gaussians can be at most 4 dimensional, resulting in 4 features.
+     *
+     * @param numSamples     The size of the output dataset.
+     * @param mixingPMF      The probability of each cluster.
+     * @param firstMean      The mean of the first Gaussian.
+     * @param firstVariance  The variance of the first Gaussian, linearised from a row-major matrix.
+     * @param secondMean     The mean of the second Gaussian.
+     * @param secondVariance The variance of the second Gaussian, linearised from a row-major matrix.
+     * @param thirdMean      The mean of the third Gaussian.
+     * @param thirdVariance  The variance of the third Gaussian, linearised from a row-major matrix.
+     * @param fourthMean     The mean of the fourth Gaussian.
+     * @param fourthVariance The variance of the fourth Gaussian, linearised from a row-major matrix.
+     * @param fifthMean      The mean of the fifth Gaussian.
+     * @param fifthVariance  The variance of the fifth Gaussian, linearised from a row-major matrix.
+     * @param seed           The rng seed to use.
+     */
+    public GaussianClusterDataSource(int numSamples, double[] mixingPMF,
+                                     double[] firstMean, double[] firstVariance,
+                                     double[] secondMean, double[] secondVariance,
+                                     double[] thirdMean, double[] thirdVariance,
+                                     double[] fourthMean, double[] fourthVariance,
+                                     double[] fifthMean, double[] fifthVariance,
+                                     long seed) {
+        this.numSamples = numSamples;
+        this.mixingPMF = mixingPMF;
+        this.firstMean = firstMean;
+        this.firstVariance = firstVariance;
+        this.secondMean = secondMean;
+        this.secondVariance = secondVariance;
+        this.thirdMean = thirdMean;
+        this.thirdVariance = thirdVariance;
+        this.fourthMean = fourthMean;
+        this.fourthVariance = fourthVariance;
+        this.fifthMean = fifthMean;
+        this.fifthVariance = fifthVariance;
+        this.seed = seed;
+        postConfig();
+    }
+
+    /**
+     * Used by the OLCUT configuration system, and should not be called by external code.
+     */
+    @Override
+    public void postConfig() {
+        if (numSamples < 1) {
+            throw new PropertyException("", "numSamples", "numSamples must be positive, found " + numSamples);
+        }
+        if (mixingPMF.length != 5) {
+            throw new PropertyException("", "mixingPMF", "mixingPMF must have 5 elements, found " + mixingPMF.length);
+        }
+        if (Math.abs(Util.sum(mixingPMF) - 1.0) > 1e-10) {
+            throw new PropertyException("", "mixingPMF", "mixingPMF must sum to 1.0, found " + Util.sum(mixingPMF));
+        }
+        if ((firstMean.length > allFeatureNames.length) || (firstMean.length == 0)) {
+            throw new PropertyException("", "firstMean", "Must have 1-4 features, found " + firstMean.length);
+        }
+        int covarianceSize = firstMean.length * firstMean.length;
+        if (firstVariance.length != (covarianceSize)) {
+            throw new PropertyException("", "firstVariance", "Invalid first covariance matrix, expected " + covarianceSize + " elements, found " + firstVariance.length);
+        }
+        if (secondMean.length != firstMean.length) {
+            throw new PropertyException("", "secondMean", "All Gaussians must have the same number of dimensions, expected " + firstMean.length + ", found " + secondMean.length);
+        }
+        if (secondVariance.length != firstVariance.length) {
+            throw new PropertyException("", "secondVariance", "secondVariance is invalid, expected " + covarianceSize + ", found " + secondVariance.length);
+        }
+        if (thirdMean.length != firstMean.length) {
+            throw new PropertyException("", "thirdMean", "All Gaussians must have the same number of dimensions, expected " + firstMean.length + ", found " + thirdMean.length);
+        }
+        if (thirdVariance.length != firstVariance.length) {
+            throw new PropertyException("", "thirdVariance", "thirdVariance is invalid, expected " + covarianceSize + ", found " + thirdVariance.length);
+        }
+        if (fourthMean.length != firstMean.length) {
+            throw new PropertyException("", "fourthMean", "All Gaussians must have the same number of dimensions, expected " + firstMean.length + ", found " + fourthMean.length);
+        }
+        if (fourthVariance.length != firstVariance.length) {
+            throw new PropertyException("", "fourthVariance", "fourthVariance is invalid, expected " + covarianceSize + ", found " + fourthVariance.length);
+        }
+        if (fifthMean.length != firstMean.length) {
+            throw new PropertyException("", "fifthMean", "All Gaussians must have the same number of dimensions, expected " + firstMean.length + ", found " + fifthMean.length);
+        }
+        if (fifthVariance.length != firstVariance.length) {
+            throw new PropertyException("", "fifthVariance", "fifthVariance is invalid, expected " + covarianceSize + ", found " + fifthVariance.length);
+        }
+        double[] mixingCDF = Util.generateCDF(mixingPMF);
+        String[] featureNames = Arrays.copyOf(allFeatureNames, firstMean.length);
+        Random rng = new Random(seed);
+        MultivariateNormalDistribution first = new MultivariateNormalDistribution(new JDKRandomGenerator(rng.nextInt()),
+                firstMean, reshape(firstVariance)
+        );
+        MultivariateNormalDistribution second = new MultivariateNormalDistribution(new JDKRandomGenerator(rng.nextInt()),
+                secondMean, reshape(secondVariance)
+        );
+        MultivariateNormalDistribution third = new MultivariateNormalDistribution(new JDKRandomGenerator(rng.nextInt()),
+                thirdMean, reshape(thirdVariance)
+        );
+        MultivariateNormalDistribution fourth = new MultivariateNormalDistribution(new JDKRandomGenerator(rng.nextInt()),
+                fourthMean, reshape(fourthVariance)
+        );
+        MultivariateNormalDistribution fifth = new MultivariateNormalDistribution(new JDKRandomGenerator(rng.nextInt()),
+                fifthMean, reshape(fifthVariance)
+        );
+        MultivariateNormalDistribution[] Gaussians = new MultivariateNormalDistribution[]{first, second, third, fourth, fifth};
+        List<Example<ClusterID>> examples = new ArrayList<>(numSamples);
+        for (int i = 0; i < numSamples; i++) {
+            int centroid = Util.sampleFromCDF(mixingCDF, rng);
+            double[] sample = Gaussians[centroid].sample();
+            examples.add(new ArrayExample<>(new ClusterID(centroid), featureNames, sample));
+        }
+        this.examples = Collections.unmodifiableList(examples);
+    }
+
+    @Override
+    public OutputFactory<ClusterID> getOutputFactory() {
+        return factory;
+    }
+
+    @Override
+    public DataSourceProvenance getProvenance() {
+        return new GaussianClusterDataSourceProvenance(this);
+    }
+
+    @Override
+    public Iterator<Example<ClusterID>> iterator() {
+        return examples.iterator();
+    }
+
+    /**
+     * Reshapes the vector into a matrix.
+     *
+     * @param vector The vector.
+     * @return The matrix assuming the vector is linearised in row-major order.
+     */
+    private static double[][] reshape(double[] vector) {
+        int length = (int) Math.sqrt(vector.length);
+        if (length * length != vector.length) {
+            throw new IllegalArgumentException("The vector does not represent a square matrix, found " + vector.length + " elements, which is not square.");
+        }
+        double[][] matrix = new double[length][length];
+        for (int i = 0; i < vector.length; i++) {
+            matrix[i / length][i % length] = vector[i];
+        }
+        return matrix;
+    }
+
+    /**
+     * Generates a clustering dataset drawn from a mixture of 5 Gaussians.
+     * <p>
+     * The Gaussians can be at most 4 dimensional, resulting in 4 features.
+     *
+     * @param numSamples     The size of the output dataset.
+     * @param mixingPMF      The probability of each cluster.
+     * @param firstMean      The mean of the first Gaussian.
+     * @param firstVariance  The variance of the first Gaussian, linearised from a row-major matrix.
+     * @param secondMean     The mean of the second Gaussian.
+     * @param secondVariance The variance of the second Gaussian, linearised from a row-major matrix.
+     * @param thirdMean      The mean of the third Gaussian.
+     * @param thirdVariance  The variance of the third Gaussian, linearised from a row-major matrix.
+     * @param fourthMean     The mean of the fourth Gaussian.
+     * @param fourthVariance The variance of the fourth Gaussian, linearised from a row-major matrix.
+     * @param fifthMean      The mean of the fifth Gaussian.
+     * @param fifthVariance  The variance of the fifth Gaussian, linearised from a row-major matrix.
+     * @param seed           The rng seed to use.
+     * @return A dataset drawn from a mixture of Gaussians.
+     */
+    public static Dataset<ClusterID> generateDataset(int numSamples, double[] mixingPMF,
+                                                     double[] firstMean, double[] firstVariance,
+                                                     double[] secondMean, double[] secondVariance,
+                                                     double[] thirdMean, double[] thirdVariance,
+                                                     double[] fourthMean, double[] fourthVariance,
+                                                     double[] fifthMean, double[] fifthVariance,
+                                                     long seed) {
+        GaussianClusterDataSource source = new GaussianClusterDataSource(numSamples, mixingPMF,
+                firstMean, firstVariance, secondMean, secondVariance, thirdMean, thirdVariance, fourthMean, fourthVariance,
+                fifthMean, fifthVariance, seed);
+        return new MutableDataset<>(source);
+    }
+
+    /**
+     * Provenance for {@link GaussianClusterDataSource}.
+     */
+    public static final class GaussianClusterDataSourceProvenance extends SkeletalConfiguredObjectProvenance implements ConfiguredDataSourceProvenance {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Constructs a provenance from the host data source.
+         *
+         * @param host The host to read.
+         */
+        GaussianClusterDataSourceProvenance(GaussianClusterDataSource host) {
+            super(host, "DataSource");
+        }
+
+        /**
+         * Constructs a provenance from the marshalled form.
+         *
+         * @param map The map of field values.
+         */
+        public GaussianClusterDataSourceProvenance(Map<String, Provenance> map) {
+            this(extractProvenanceInfo(map));
+        }
+
+        private GaussianClusterDataSourceProvenance(ExtractedInfo info) {
+            super(info);
+        }
+
+        /**
+         * Extracts the relevant provenance information fields for this class.
+         *
+         * @param map The map to remove values from.
+         * @return The extracted information.
+         */
+        protected static ExtractedInfo extractProvenanceInfo(Map<String, Provenance> map) {
+            Map<String, Provenance> configuredParameters = new HashMap<>(map);
+            String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters, CLASS_NAME, StringProvenance.class, GaussianClusterDataSourceProvenance.class.getSimpleName()).getValue();
+            String hostTypeStringName = ObjectProvenance.checkAndExtractProvenance(configuredParameters, HOST_SHORT_NAME, StringProvenance.class, GaussianClusterDataSourceProvenance.class.getSimpleName()).getValue();
+
+            return new ExtractedInfo(className, hostTypeStringName, configuredParameters, Collections.emptyMap());
+        }
+    }
+}

--- a/Clustering/Core/src/main/java/org/tribuo/clustering/example/package-info.java
+++ b/Clustering/Core/src/main/java/org/tribuo/clustering/example/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Provides a clustering data generator used for testing implementations.
+ * Provides clustering data generators used for demos and testing implementations.
  */
 package org.tribuo.clustering.example;

--- a/Clustering/KMeans/src/test/java/org/tribuo/clustering/kmeans/TestKMeans.java
+++ b/Clustering/KMeans/src/test/java/org/tribuo/clustering/kmeans/TestKMeans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,12 @@ package org.tribuo.clustering.kmeans;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.Dataset;
 import org.tribuo.Model;
+import org.tribuo.MutableDataset;
 import org.tribuo.clustering.ClusterID;
 import org.tribuo.clustering.evaluation.ClusteringEvaluation;
 import org.tribuo.clustering.evaluation.ClusteringEvaluator;
 import org.tribuo.clustering.example.ClusteringDataGenerator;
+import org.tribuo.clustering.example.GaussianClusterDataSource;
 import org.tribuo.clustering.kmeans.KMeansTrainer.Distance;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -64,7 +66,7 @@ public class TestKMeans {
     }
 
     public static void runEvaluation(KMeansTrainer trainer) {
-        Dataset<ClusterID> data = ClusteringDataGenerator.gaussianClusters(500, 1L);
+        Dataset<ClusterID> data = new MutableDataset<>(new GaussianClusterDataSource(500, 1L));
         Dataset<ClusterID> test = ClusteringDataGenerator.gaussianClusters(500, 2L);
         ClusteringEvaluator eval = new ClusteringEvaluator();
 

--- a/tutorials/clustering-tribuo-v4.ipynb
+++ b/tutorials/clustering-tribuo-v4.ipynb
@@ -32,7 +32,7 @@
     "import org.tribuo.util.Util;\n",
     "import org.tribuo.clustering.*;\n",
     "import org.tribuo.clustering.evaluation.*;\n",
-    "import org.tribuo.clustering.example.ClusteringDataGenerator;\n",
+    "import org.tribuo.clustering.example.GaussianClusterDataSource;\n",
     "import org.tribuo.clustering.kmeans.*;\n",
     "import org.tribuo.clustering.kmeans.KMeansTrainer.Distance;\n",
     "import org.tribuo.clustering.kmeans.KMeansTrainer.Initialisation;"
@@ -52,7 +52,7 @@
    "metadata": {},
    "source": [
     "## Dataset\n",
-    "Tribuo's clustering package comes with a simple data generator that emits data sampled from a mixture of 5 2-dimensional Gaussians (the centroids and variances are fixed). This generator gives the ground truth cluster IDs, so it can be used for demos like this. You can also use any of the standard data loaders to pull in clustering data.\n",
+    "Tribuo's clustering package comes with a simple data source that emits data sampled from a mixture of 5 2-dimensional Gaussians (the dimensionality of the Gaussians can be in the range 1 - 4, and the means & variances can also be set arbitrarily). This source sets the ground truth cluster IDs, so it can be used to measure clustering performance for demos like this. You can also use any of the standard data loaders to pull in clustering data.\n",
     "\n",
     "As it conforms to the standard `Trainer` and `Model` interface used for the rest of Tribuo, the training of a clustering algorithm doesn't produce cluster assignments that are visible, to recover the assignments we need to call `model.predict(trainData)`.\n",
     "\n",
@@ -65,15 +65,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "var data = ClusteringDataGenerator.gaussianClusters(500, 1L);\n",
-    "var test = ClusteringDataGenerator.gaussianClusters(500, 2L);"
+    "var data = new MutableDataset<>(new GaussianClusterDataSource(500, 1L));\n",
+    "var test = new MutableDataset<>(new GaussianClusterDataSource(500, 2L));"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The data generator uses the following Gaussians:\n",
+    "The defaults for the data source are:\n",
     "1. `N([ 0.0,0.0], [[1.0,0.0],[0.0,1.0]])`\n",
     "2. `N([ 5.0,5.0], [[1.0,0.0],[0.0,1.0]])`\n",
     "3. `N([ 2.5,2.5], [[1.0,0.5],[0.5,1.0]])`\n",
@@ -98,12 +98,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training with 5 clusters took (00:00:00:102)\n"
+      "Training with 5 clusters took (00:00:00:048)\n"
      ]
     }
    ],
    "source": [
-    "var trainer = new KMeansTrainer(5,10,Distance.EUCLIDEAN,1,1);\n",
+    "var trainer = new KMeansTrainer(5, /* centroids */\n",
+    "                                10, /* iterations */\n",
+    "                                Distance.EUCLIDEAN, /* distance function */\n",
+    "                                1, /* number of compute threads */\n",
+    "                                1 /* RNG seed */\n",
+    "                               );\n",
     "var startTime = System.currentTimeMillis();\n",
     "var model = trainer.train(data);\n",
     "var endTime = System.currentTimeMillis();\n",
@@ -155,7 +160,7 @@
     "|4|2|\n",
     "|5|4|\n",
     "\n",
-    "Though the first one is a bit far out as it's \"A\" feature should be -1.0 not -1.7, and there is a little wobble in the rest. Still it's pretty good considering K-Means assumes spherical gaussians and our data generator has a covariance matrix per gaussian."
+    "Though the first one is a bit far out as it's \"A\" feature should be -1.0 not -1.7, and there is a little wobble in the rest. Still it's pretty good considering K-Means assumes spherical Gaussians and our data generator has a covariance matrix per Gaussian."
    ]
   },
   {
@@ -175,7 +180,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training with 5 clusters took (00:00:00:074)\n"
+      "Training with 5 clusters took (00:00:00:023)\n"
      ]
     }
    ],
@@ -224,7 +229,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see in this case that the K-Means++ initialisation has warped the centroids slightly, so the fit isn't quite as nice as the default initialisation, but that's why we have evaluation data and measure model fit. K-Means++ usually improves the fit of a K-Means clustering, but it might be too much for this toy dataset."
+    "We can see in this case that the K-Means++ initialisation has warped the centroids slightly, so the fit isn't quite as nice as the default initialisation, but that's why we have evaluation data and measure model fit. K-Means++ usually improves the fit of a K-Means clustering, but it might be too complicated for this simple toy dataset."
    ]
   },
   {
@@ -277,8 +282,8 @@
      "data": {
       "text/plain": [
        "Clustering Evaluation\n",
-       "Normalized MI = 0.8154291916732408\n",
-       "Adjusted MI = 0.8139169342020222"
+       "Normalized MI = 0.8154291916732409\n",
+       "Adjusted MI = 0.8139169342020223"
       ]
      },
      "execution_count": 10,
@@ -295,7 +300,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that as expected it's a pretty good correlation to the ground truth labels. K-Means (of the kind implemented in Tribuo) is similar to a gaussian mixture using spherical gaussians, and our data generator uses gaussians with full rank covariances, so it won't be perfect.\n",
+    "We see that as expected it's a pretty good correlation to the ground truth labels. K-Means (of the kind implemented in Tribuo) is similar to a Gaussian mixture using spherical Gaussians, and our data generator uses Gaussians with full rank covariances, so it won't be perfect.\n",
     "\n",
     "We can also check the K-Means++ model in the same way:"
    ]
@@ -347,12 +352,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training with 5 clusters on 4 threads took (00:00:00:062)\n"
+      "Training with 5 clusters on 4 threads took (00:00:00:035)\n"
      ]
     }
    ],
    "source": [
-    "var mtData = ClusteringDataGenerator.gaussianClusters(2000, 1L);\n",
+    "var mtData = new MutableDataset<>(new GaussianClusterDataSource(2000, 1L));\n",
     "var mtTrainer = new KMeansTrainer(5,10,Distance.EUCLIDEAN,4,1);\n",
     "var mtStartTime = System.currentTimeMillis();\n",
     "var mtModel = mtTrainer.train(mtData);\n",
@@ -376,7 +381,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training with 20 clusters on 4 threads took (00:00:00:080)\n"
+      "Training with 20 clusters on 4 threads took (00:00:00:027)\n"
      ]
     }
    ],
@@ -404,8 +409,8 @@
      "data": {
       "text/plain": [
        "Clustering Evaluation\n",
-       "Normalized MI = 0.8104463467727057\n",
-       "Adjusted MI = 0.8088941747451207"
+       "Normalized MI = 0.8104463467727059\n",
+       "Adjusted MI = 0.8088941747451209"
       ]
      },
      "execution_count": 14,
@@ -452,7 +457,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that the multi-threaded versions run in less time than the single threaded trainer, despite them using 4 times the training data. The 20 centroid model has a tighter fit of the test data, despite being overparameterised. This is common in clustering tasks where it's hard to balance the model fitting with complexity. We'll look at adding more performance metrics so users can diagnose such issues in future releases. "
+    "We see that the multi-threaded versions run in less time than the single threaded trainer, despite having 4 times the training data. The 20 centroid model has a tighter fit of the test data, though it is overparameterised. This is common in clustering tasks where it's hard to balance the model fitting with complexity. We'll look at adding more performance metrics so users can diagnose such issues in future releases. "
    ]
   },
   {
@@ -478,7 +483,7 @@
    "mimetype": "text/x-java-source",
    "name": "Java",
    "pygments_lexer": "java",
-   "version": "17-ea+22-1964"
+   "version": "17+0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Description
Adds a configurable data source for clustering demos and testing. Updated the clustering tutorial to use it.

The timing numbers are from my M1 Mac which is so fast that the multithreaded one takes roughly the same time as the single threaded one rather than being 3x faster (though it is running on 4x the data).

### Motivation
See #160 for the motivation.