### PR TITLE
Adds a tutorial on multi-label problems and a configurable data source generator for multi-label demos.

### DIFF
--- a/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/example/GaussianAnomalyDataSource.java
+++ b/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/example/GaussianAnomalyDataSource.java
@@ -251,7 +251,7 @@ public final class GaussianAnomalyDataSource implements ConfigurableDataSource<E
      * @param seed               The rng seed to use.
      * @return A dataset drawn from a gaussian.
      */
-    public static Dataset<Event> generateDataset(int numSamples, double[] expectedMeans, double[] expectedVariances,
+    public static MutableDataset<Event> generateDataset(int numSamples, double[] expectedMeans, double[] expectedVariances,
                                                  double[] anomalousMeans, double[] anomalousVariances,
                                                  float fractionAnomalous, long seed) {
         GaussianAnomalyDataSource source = new GaussianAnomalyDataSource(numSamples, expectedMeans, expectedVariances, anomalousMeans, anomalousVariances, fractionAnomalous, seed);

--- a/Clustering/Core/src/main/java/org/tribuo/clustering/example/GaussianClusterDataSource.java
+++ b/Clustering/Core/src/main/java/org/tribuo/clustering/example/GaussianClusterDataSource.java
@@ -316,7 +316,7 @@ public final class GaussianClusterDataSource implements ConfigurableDataSource<C
      * @param seed               The rng seed to use.
      * @return A dataset drawn from a mixture of Gaussians.
      */
-    public static Dataset<ClusterID> generateDataset(int numSamples, double[] mixingDistribution,
+    public static MutableDataset<ClusterID> generateDataset(int numSamples, double[] mixingDistribution,
                                                      double[] firstMean, double[] firstVariance,
                                                      double[] secondMean, double[] secondVariance,
                                                      double[] thirdMean, double[] thirdVariance,

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/example/MultiLabelGaussianDataSource.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/example/MultiLabelGaussianDataSource.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.multilabel.example;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
+import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import com.oracle.labs.mlrg.olcut.provenance.impl.SkeletalConfiguredObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
+import org.tribuo.ConfigurableDataSource;
+import org.tribuo.DataSource;
+import org.tribuo.Dataset;
+import org.tribuo.Example;
+import org.tribuo.MutableDataset;
+import org.tribuo.OutputFactory;
+import org.tribuo.Trainer;
+import org.tribuo.classification.Label;
+import org.tribuo.impl.ArrayExample;
+import org.tribuo.multilabel.MultiLabel;
+import org.tribuo.multilabel.MultiLabelFactory;
+import org.tribuo.provenance.ConfiguredDataSourceProvenance;
+import org.tribuo.provenance.DataSourceProvenance;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Generates a multi label output drawn from a series of functions.
+ * <p>
+ * The functions are:
+ * <ul>
+ *     <li>y_0 is positive if N(w_00*x_0 + w_01*x_1 + w_02*x_1*x_0 + w_03*x_1*x_1*x_1,variance) > threshold_0.</li>
+ *     <li>y_1 is positive if N(w_10*x_0 + w_11*x_1 + w_12*x_1*x_0 + w_13*x_1*x_1*x_1,variance) < threshold_1.</li>
+ *     <li>y_2 is positive if N(w_20*x_0 + w_21*x_2 + w_22*x_1*x_0 + w_23*x_1*x_2*x_2,variance) > threshold_2.</li>
+ * </ul>
+ * There are 4 features x_0, x_1, x_2, x_3. x_0 and x_1 are used by all three labels,
+ * x_2 is only used by y_2, and x_3 is irrelevant.
+ * <p>
+ * By default y_1 is the inverse of y_0, and y_2 shares the same weights w_0 and w_2.
+ * <ul>
+ *     <li>y_0 weights = [1.0,1.0,1.0,1.0]</li>
+ *     <li>y_1 weights = [1.0,1.0,1.0,1.0]</li>
+ *     <li>y_2 weights = [1.0,-3.0,1.0,3.0]</li>
+ *     <li>threshold = [0.0,0.0,2.0</li>
+ * </ul>
+ * <p>
+ * The features are drawn from a uniform distribution over the range.
+ */
+public final class MultiLabelGaussianDataSource implements ConfigurableDataSource<MultiLabel> {
+    @Config(mandatory = true, description = "The number of samples to draw.")
+    private int numSamples;
+
+    @Config(description = "The feature weights. Must be a 4 element array.")
+    private float[] yZeroWeights = new float[]{1.0f, 1.0f, 1.0f, 1.0f};
+
+    @Config(description = "The feature weights. Must be a 4 element array.")
+    private float[] yOneWeights = new float[]{1.0f, 1.0f, 1.0f, 1.0f};
+
+    @Config(description = "The feature weights. Must be a 4 element array.")
+    private float[] yTwoWeights = new float[]{1.0f, -3.0f, 1.0f, 3.0f};
+
+    @Config(description = "The threshold for each class.")
+    private float[] threshold = new float[]{0.0f, 0.0f, 2.0f};
+
+    @Config(description = "Negate the computed value before thresholding it.")
+    private boolean[] negate = new boolean[]{false, true, false};
+
+    @Config(description = "The variance of the noise gaussian.")
+    private float variance = 0.1f;
+
+    @Config(description = "The minimum values of the Xs.")
+    private float[] xMin = new float[]{-2.0f, -2.0f, -2.0f, -2.0f};
+
+    @Config(description = "The maximum values of the Xs.")
+    private float[] xMax = new float[]{2.0f, 2.0f, 2.0f, 2.0f};
+
+    @Config(description = "The RNG seed.")
+    private long seed = Trainer.DEFAULT_SEED;
+
+    private List<Example<MultiLabel>> examples;
+
+    private final MultiLabelFactory factory = new MultiLabelFactory();
+
+    private static final String[] FEATURE_NAMES = new String[]{"X_0", "X_1", "X_2", "X_3"};
+    private static final String[] LABEL_NAMES = new String[]{"Y_0", "Y_1", "Y_2"};
+
+    /**
+     * For OLCUT.
+     */
+    private MultiLabelGaussianDataSource() {}
+
+    /**
+     * Generates a multi-label output drawn from three gaussian functions.
+     * <ul>
+     *      <li>N(w_00*x_0 + w_01*x_1 + w_02*x_1*x_0 + w_03*x_1*x_1*x_1,variance)</li>
+     *      <li>N(w_10*x_0 + w_11*x_1 + w_12*x_1*x_0 + w_13*x_1*x_1*x_1,variance)</li>
+     *      <li>N(w_20*x_0 + w_21*x_2 + w_22*x_1*x_0 + w_23*x_1*x_2*x_2,variance)</li>
+     * </ul>
+     * <p>
+     * The features are drawn from a uniform distribution over the range.
+     *
+     * @param numSamples   The size of the output dataset.
+     * @param yZeroWeights The feature weights for label y_0.
+     * @param yOneWeights  The feature weights for label y_1.
+     * @param yTwoWeights  The feature weights for label y_2.
+     * @param threshold    The y threshold of each label.
+     * @param negate       Should the computed value be negated before thresholding?
+     * @param variance     The variance of the gaussian.
+     * @param xMin         The minimum feature values (inclusive).
+     * @param xMax         The maximum feature values (exclusive).
+     * @param seed         The rng seed to use.
+     */
+    public MultiLabelGaussianDataSource(int numSamples, float[] yZeroWeights, float[] yOneWeights, float[] yTwoWeights,
+                                        float[] threshold, boolean[] negate, float variance, float[] xMin, float[] xMax,
+                                        long seed) {
+        this.numSamples = numSamples;
+        this.yZeroWeights = yZeroWeights;
+        this.yOneWeights = yOneWeights;
+        this.yTwoWeights = yTwoWeights;
+        this.threshold = threshold;
+        this.negate = negate;
+        this.variance = variance;
+        this.xMin = xMin;
+        this.xMax = xMax;
+        this.seed = seed;
+        postConfig();
+    }
+
+    /**
+     * Used by the OLCUT configuration system, and should not be called by external code.
+     */
+    @Override
+    public void postConfig() {
+        // We use java.util.Random here because SplittableRandom doesn't have nextGaussian yet.
+        Random rng = new Random(seed);
+        if (yZeroWeights.length != 4) {
+            throw new PropertyException("", "yZeroWeights", "Must supply 4 yZeroWeights, found " + yZeroWeights.length);
+        }
+        if (yOneWeights.length != 4) {
+            throw new PropertyException("", "yOneWeights", "Must supply 4 yOneWeights, found " + yOneWeights.length);
+        }
+        if (yTwoWeights.length != 4) {
+            throw new PropertyException("", "yTwoWeights", "Must supply 4 yTwoWeights, found " + yTwoWeights.length);
+        }
+        if (threshold.length != 3) {
+            throw new PropertyException("", "threshold", "Must supply 3 values for threshold, found " + threshold.length);
+        }
+        if (negate.length != 3) {
+            throw new PropertyException("", "negate", "Must supply 3 values for negate, found " + negate.length);
+        }
+        if (xMin.length != 4) {
+            throw new PropertyException("", "xMin", "Must supply 4 feature minimums, found " + xMin.length);
+        }
+        if (xMax.length != 4) {
+            throw new PropertyException("", "xMax", "Must supply 4 feature maximums, found " + xMax.length);
+        }
+        float[] range = new float[4];
+        for (int i = 0; i < 4; i++) {
+            if (xMin[i] > xMax[i]) {
+                throw new PropertyException("", "xMin", "Feature minimums must be below the maximums, found min = " + Arrays.toString(xMin) + " and max = " + Arrays.toString(xMax));
+            } else {
+                range[i] = xMax[i] - xMin[i];
+            }
+        }
+        if (variance <= 0.0) {
+            throw new PropertyException("", "variance", "Variance must be positive, found variance = " + variance);
+        }
+        List<Example<MultiLabel>> examples = new ArrayList<>(numSamples);
+        for (int i = 0; i < numSamples; i++) {
+            double[] features = new double[4];
+            for (int j = 0; j < features.length; j++) {
+                features[j] = (rng.nextDouble() * range[j]) + xMin[j];
+            }
+            /*
+             * y_0 is positive if N(w_00*x_0 + w_01*x_1 + w_02*x_1*x_0 + w_03*x_1*x_1*x_1,variance) > threshold_0
+             * y_1 is positive if N(w_10*x_0 + w_11*x_1 + w_12*x_1*x_0 + w_13*x_1*x_1*x_1,variance) < threshold_1
+             * y_2 is positive if N(w_20*x_0 + w_21*x_2 + w_22*x_1*x_0 + w_23*x_1*x_2*x_2,variance) > threshold_2
+             */
+            double yZero = (rng.nextGaussian() * variance) + ((yZeroWeights[0] * features[0]) + (yZeroWeights[1] * features[1]) + (yZeroWeights[2] * features[0] * features[1]) + (yZeroWeights[3] * Math.pow(features[1], 3)));
+            double yOne = (rng.nextGaussian() * variance) + ((yOneWeights[0] * features[0]) + (yOneWeights[1] * features[1]) + (yOneWeights[2] * features[0] * features[1]) + (yOneWeights[3] * Math.pow(features[1], 3)));
+            double yTwo = (rng.nextGaussian() * variance) + ((yTwoWeights[0] * features[0]) + (yTwoWeights[1] * features[2]) + (yTwoWeights[2] * features[0] * features[1]) + (yTwoWeights[3] * features[1] * features[2] * features[2]));
+            if (negate[0]) {
+                yZero = -yZero;
+            }
+            if (negate[1]) {
+                yOne = -yOne;
+            }
+            if (negate[2]) {
+                yTwo = -yTwo;
+            }
+            Set<Label> labels = new HashSet<>();
+            if (yZero > threshold[0]) {
+                labels.add(new Label(LABEL_NAMES[0]));
+            }
+            if (yOne > threshold[1]) {
+                labels.add(new Label(LABEL_NAMES[1]));
+            }
+            if (yTwo > threshold[2]) {
+                labels.add(new Label(LABEL_NAMES[2]));
+            }
+            MultiLabel output = new MultiLabel(labels);
+            ArrayExample<MultiLabel> e = new ArrayExample<>(output, FEATURE_NAMES, features);
+            examples.add(e);
+        }
+        this.examples = Collections.unmodifiableList(examples);
+    }
+
+    @Override
+    public OutputFactory<MultiLabel> getOutputFactory() {
+        return factory;
+    }
+
+    @Override
+    public DataSourceProvenance getProvenance() {
+        return new MultiLabelGaussianDataSourceProvenance(this);
+    }
+
+    @Override
+    public Iterator<Example<MultiLabel>> iterator() {
+        return examples.iterator();
+    }
+
+    /**
+     * Generates a multi-label output drawn from three gaussian functions.
+     * <ul>
+     *      <li>N(w_00*x_0 + w_01*x_1 + w_02*x_1*x_0 + w_03*x_1*x_1*x_1,variance)</li>
+     *      <li>N(w_10*x_0 + w_11*x_1 + w_12*x_1*x_0 + w_13*x_1*x_1*x_1,variance)</li>
+     *      <li>N(w_20*x_0 + w_21*x_2 + w_22*x_1*x_0 + w_23*x_1*x_2*x_2,variance)</li>
+     * </ul>
+     * <p>
+     * The features are drawn from a uniform distribution over the range.
+     *
+     * @param numSamples   The size of the output dataset.
+     * @param yZeroWeights The feature weights for label y_0.
+     * @param yOneWeights  The feature weights for label y_1.
+     * @param yTwoWeights  The feature weights for label y_2.
+     * @param threshold    The y threshold of each label.
+     * @param negate       Should the computed value be negated before thresholding?
+     * @param variance     The variance of the gaussian.
+     * @param xMin         The minimum feature values (inclusive).
+     * @param xMax         The maximum feature values (exclusive).
+     * @param seed         The rng seed to use.
+     * @return A dataset drawn from several gaussian generated labels.
+     */
+    public static MutableDataset<MultiLabel> generateDataset(int numSamples, float[] yZeroWeights, float[] yOneWeights, float[] yTwoWeights,
+                                                      float[] threshold, boolean[] negate, float variance, float[] xMin, float[] xMax,
+                                                      long seed) {
+        MultiLabelGaussianDataSource source = new MultiLabelGaussianDataSource(numSamples, yZeroWeights, yOneWeights, yTwoWeights, threshold, negate, variance,
+                xMin, xMax, seed);
+        return new MutableDataset<>(source);
+    }
+
+
+    /**
+     * Generates a multi label output drawn from a series of functions.
+     * <p>
+     * The functions are:
+     * <ul>
+     *     <li>y_0 is positive if N(w_00*x_0 + w_01*x_1 + w_02*x_1*x_0 + w_03*x_1*x_1*x_1,variance) > threshold_0.</li>
+     *     <li>y_1 is positive if N(w_10*x_0 + w_11*x_1 + w_12*x_1*x_0 + w_13*x_1*x_1*x_1,variance) < threshold_1.</li>
+     *     <li>y_2 is positive if N(w_20*x_0 + w_21*x_2 + w_22*x_1*x_0 + w_23*x_1*x_2*x_2,variance) > threshold_2.</li>
+     * </ul>
+     * There are 4 features x_0, x_1, x_2, x_3. x_0 and x_1 are used by all three labels,
+     * x_2 is only used by y_2, and x_3 is irrelevant.
+     * <p>
+     * By default y_1 is the inverse of y_0, and y_2 shares the same weights w_0 and w_2.
+     * <ul>
+     *     <li>y_0 weights = [1.0,1.0,1.0,1.0]</li>
+     *     <li>y_1 weights = [1.0,1.0,1.0,1.0]</li>
+     *     <li>y_2 weights = [1.0,-3.0,1.0,3.0]</li>
+     *     <li>threshold = [0.0,0.0,2.0</li>
+     * </ul>
+     * <p>
+     * The features are drawn from a uniform distribution over the range.
+     *
+     * @param numSamples The number of samples to draw.
+     * @param seed       The RNG seed.
+     * @return A dataset drawn from multiple Gaussians.
+     */
+    public static MultiLabelGaussianDataSource makeDefaultSource(int numSamples, long seed) {
+        MultiLabelGaussianDataSource source = new MultiLabelGaussianDataSource();
+        source.numSamples = numSamples;
+        source.seed = seed;
+        source.postConfig();
+        return source;
+    }
+
+    /**
+     * Provenance for {@link MultiLabelGaussianDataSource}.
+     */
+    public static class MultiLabelGaussianDataSourceProvenance extends SkeletalConfiguredObjectProvenance implements ConfiguredDataSourceProvenance {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Constructs a provenance from the host data source.
+         *
+         * @param host The host to read.
+         */
+        MultiLabelGaussianDataSourceProvenance(MultiLabelGaussianDataSource host) {
+            super(host, "DataSource");
+        }
+
+        /**
+         * Constructs a provenance from the marshalled form.
+         *
+         * @param map The map of field values.
+         */
+        public MultiLabelGaussianDataSourceProvenance(Map<String, Provenance> map) {
+            this(extractProvenanceInfo(map));
+        }
+
+        private MultiLabelGaussianDataSourceProvenance(ExtractedInfo info) {
+            super(info);
+        }
+
+        /**
+         * Extracts the relevant provenance information fields for this class.
+         *
+         * @param map The map to remove values from.
+         * @return The extracted information.
+         */
+        protected static ExtractedInfo extractProvenanceInfo(Map<String, Provenance> map) {
+            Map<String, Provenance> configuredParameters = new HashMap<>(map);
+            String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters, CLASS_NAME, StringProvenance.class, MultiLabelGaussianDataSourceProvenance.class.getSimpleName()).getValue();
+            String hostTypeStringName = ObjectProvenance.checkAndExtractProvenance(configuredParameters, HOST_SHORT_NAME, StringProvenance.class, MultiLabelGaussianDataSourceProvenance.class.getSimpleName()).getValue();
+
+            return new ExtractedInfo(className, hostTypeStringName, configuredParameters, Collections.emptyMap());
+        }
+    }
+}

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/example/package-info.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/example/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 
 /**
- * Provides a multi-label data generator for testing implementations.
+ * Provides a multi-label data generator for testing implementations and a
+ * configurable data source suitable for demos and tests.
  */
 package org.tribuo.multilabel.example;

--- a/Regression/Core/src/main/java/org/tribuo/regression/example/GaussianDataSource.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/example/GaussianDataSource.java
@@ -159,7 +159,7 @@ public class GaussianDataSource implements ConfigurableDataSource<Regressor> {
      * @param seed The rng seed to use.
      * @return A dataset drawn from a gaussian.
      */
-    public static Dataset<Regressor> generateDataset(int numSamples, float slope, float intercept, float variance, float xMin, float xMax, long seed) {
+    public static MutableDataset<Regressor> generateDataset(int numSamples, float slope, float intercept, float variance, float xMin, float xMax, long seed) {
         GaussianDataSource source = new GaussianDataSource(numSamples,slope,intercept,variance,xMin,xMax,seed);
         return new MutableDataset<>(source);
     }

--- a/Regression/Core/src/main/java/org/tribuo/regression/example/NonlinearGaussianDataSource.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/example/NonlinearGaussianDataSource.java
@@ -182,7 +182,7 @@ public class NonlinearGaussianDataSource implements ConfigurableDataSource<Regre
      * @param seed The rng seed to use.
      * @return A dataset drawn from a gaussian.
      */
-    public static Dataset<Regressor> generateDataset(int numSamples, float[] weights, float intercept, float variance,
+    public static MutableDataset<Regressor> generateDataset(int numSamples, float[] weights, float intercept, float variance,
                                                      float xZeroMin, float xZeroMax, float xOneMin, float xOneMax,
                                                      long seed) {
         NonlinearGaussianDataSource source = new NonlinearGaussianDataSource(numSamples,weights,intercept,variance,

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -113,7 +113,7 @@ Many of Tribuo's trainers, datasources and other classes implement the
 `Configurable` interface. This is provided by
 [OLCUT](https://github.com/oracle/olcut), and allows for runtime configuration
 of classes based on configuration files written in a variety of formats. The
-default format is xml. Other available formats include JSON & edn.
+default format is xml. Other available formats include JSON, protobuf & edn.
 
 The configuration system is integrated into the command line arguments
 `Options` system build into OLCUT's `ConfigurationManager`. Values in
@@ -250,8 +250,8 @@ Example :
 </config>
 ```
 
-It's also possible to access this information programmatically, but there are several ways of doing that in OLCUT
-each appropriate to different use cases.
+It's also possible to access this information programmatically, but there are
+several ways of doing that in OLCUT each appropriate to different use cases.
 
 
 ## Data Loading
@@ -276,9 +276,11 @@ objects.
 There are two CSV loaders:  A simple one for reading a CSV file (with or
 without a header) where all the columns are either features or responses, and a
 complex loader based on Tribuo's `RowProcessor`. The `RowProcessor` also
-underlies the SQL and JSON loaders, and is extremely configurable. For more
-details see the [Columnar Inputs](#columnar-inputs) section below or look at
-the [columnar data tutorial](https://github.com/oracle/tribuo/blob/main/tutorials/columnar-tribuo-v4.ipynb).
+underlies the SQL and JSON loaders, and is extremely configurable. From v4.2
+the simple `CSVLoader` wraps a `RowProcessor` to allow simple upgrading as the
+CSVs become more complicated. For more details see the [Columnar
+Inputs](#columnar-inputs) section below or look at the 
+[columnar data tutorial](https://github.com/oracle/tribuo/blob/main/tutorials/columnar-tribuo-v4.ipynb).
 If there are other common formats of interest, let us know by filing an issue.
 
 Tribuo's interfaces are extensible, and implementing another format simply

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -151,8 +151,8 @@ systems come from [OLCUT](https://github.com/oracle/olcut) (Oracle Labs
 Configuration and Utility Toolkit), a long lived internal library from Oracle
 Labs which has roots in the configuration system used in Sphinx4. OLCUT
 provides configuration files in multiple formats and includes ways to operate
-on provenance in JSON format (other provenance file formats will be added in
-the future).
+on provenance in XML, JSON and protobuf format (other provenance file formats
+may be added in the future).
 
 ### What's the difference between configuration and provenance?
 

--- a/docs/PackageOverview.md
+++ b/docs/PackageOverview.md
@@ -105,11 +105,12 @@ The independent binary predictor breaks each multi-label prediction into n
 binary predictions, one for each possible label.  To achieve this, the supplied
 trainer takes a classification trainer and uses it to build n models, one per
 label, which are then run in sequence on a test example to produce the final
-multi-label output.
+multi-label output. A similar approach is used in the classifier chains to
+convert a classification trainer into a multi-label trainer.
 
 | Folder | ArtifactID | Package root | Description |
 | --- | --- | --- | --- |
-| Core | `tribuo-multilabel-core` | `org.tribuo.multilabel` | Contains an Output subclass for multi-label prediction, evaluation code for checking the performance of a multi-label model, and a basic implementation of independent binary predictions. |
+| Core | `tribuo-multilabel-core` | `org.tribuo.multilabel` | Contains an Output subclass for multi-label prediction, evaluation code for checking the performance of a multi-label model, and a basic implementation of independent binary predictions. It also contains implementations of Classifier Chains and Classifier Chain Ensembles, which are more powerful ensemble techniques for multi-label prediction tasks. |
 | SGD | `tribuo-multilabel-sgd` | `org.tribuo.multilabel.sgd` | An implementation of stochastic gradient descent based classifiers. It includes a linear package for independent logistic regression and linear-SVM (using log and hinge losses, respectively) for each output label. These implementations depend upon the stochastic gradient optimisers in the main Math package. The linear package can use any of the provided gradient optimisers, which enforce various different kinds of regularisation or convergence metrics. |
 
 ## Regression

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -14,6 +14,7 @@ The tutorials cover:
 - [Configuration files, provenance and feature transformations on MNIST](configuration-tribuo-v4.ipynb)
 - [Clustering with K-Means](clustering-tribuo-v4.ipynb)
 - [Anomaly Detection with LibSVM](anomaly-tribuo-v4.ipynb)
+- [Multi-label classification with Classifier Chains](multi-label-tribuo-v4.ipynb)
 - [Loading columnar data](columnar-tribuo-v4.ipynb)
 - [Document classification and extracting features from text](document-classification-tribuo-v4.ipynb)
 - [Importing third-party models](external-models-tribuo-v4.ipynb)

--- a/tutorials/multi-label-tribuo-v4.ipynb
+++ b/tutorials/multi-label-tribuo-v4.ipynb
@@ -1,0 +1,515 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multi-Label Classification Tutorial\n",
+    "\n",
+    "This tutorial shows how to use Tribuo's MultiLabel package to perform [multi-label classification](https://en.wikipedia.org/wiki/Multi-label_classification) tasks. Multi-label classification is the task of assigning a *set* of labels to a given example from a specific label domain, as opposed to multi-class classification which is assigning a *single* label to a given example.\n",
+    "\n",
+    "Tribuo provides linear model and factorization machine algorithms for native multi-label prediction, along with ensemble methods that either predict each label independently or as part of a [classifier chain](http://www.cs.waikato.ac.nz/~ml/publications/2009/chains.pdf), using any of Tribuo's classification algorithms as the base learners. Both the linear models, factorization machines and the `IndependentMultiLabelTrainer` use the *Binary Relevance* approach to multi-label prediction, where each label is predicted independently. The `ClassifierChainTrainer` and `CCEnsembleTrainer` use classifier chains which incorporate label structure into the prediction. In this tutorial we'll cover loading in multi-label data, performing predictions using several binary relevance based classifiers along with some classifier chains, and finally we'll evaluate the multi-label models using Tribuo's multi-label evaluation package.\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "First you'll need a copy of the multi-label yeast dataset (we'll download these from the [LibSVM](https://www.csie.ntu.edu.tw/~cjlin/libsvm/) dataset repo):\n",
+    "\n",
+    "```\n",
+    "wget https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multilabel/yeast_train.svm.bz2\n",
+    "wget https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multilabel/yeast_test.svm.bz2\n",
+    "```\n",
+    "\n",
+    "Then you should extract it using your preferred method. On macOS and Linux you can use `bunzip2`, and on Windows there are several packages which can extract bz2 files (e.g., [7-zip](https://www.7-zip.org/)).\n",
+    "\n",
+    "This dataset has 14 labels which represent different functional groups and the task is to predict the functional groups a gene belongs in based on micro-array expression measurements. Fortunately we don't need a PhD in Genetics to use this dataset as a benchmark, though obviously domain knowledge would be critical if we wanted to actually deploy any model based on this data.\n",
+    "\n",
+    "Now we'll load in the necessary jars and import some packages from the JDK and Tribuo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%jars ./tribuo-multilabel-sgd-4.2.0-SNAPSHOT-jar-with-dependencies.jar\n",
+    "%jars ./tribuo-classification-experiments-4.2.0-SNAPSHOT-jar-with-dependencies.jar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import java.nio.file.Paths;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import org.tribuo.*;\n",
+    "import org.tribuo.classification.dtree.CARTClassificationTrainer;\n",
+    "import org.tribuo.classification.dtree.impurity.*;\n",
+    "import org.tribuo.datasource.*;\n",
+    "import org.tribuo.math.optimisers.*;\n",
+    "import org.tribuo.multilabel.*;\n",
+    "import org.tribuo.multilabel.baseline.*;\n",
+    "import org.tribuo.multilabel.ensemble.*;\n",
+    "import org.tribuo.multilabel.evaluation.*;\n",
+    "import org.tribuo.multilabel.sgd.linear.*;\n",
+    "import org.tribuo.multilabel.sgd.objectives.*;\n",
+    "import org.tribuo.util.Util;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading the data\n",
+    "\n",
+    "The yeast dataset we downloaded is stored in libsvm format, so we'll use Tribuo's `LibSVMDataSource` to load it in, and process the outputs through a `MultiLabelFactory`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training data size = 1500, number of features = 103, number of classes = 14\n",
+      "Testing data size = 917, number of features = 103, number of classes = 14\n"
+     ]
+    }
+   ],
+   "source": [
+    "var factory = new MultiLabelFactory();\n",
+    "var trainSource = new LibSVMDataSource<>(Paths.get(\".\",\"yeast_train.svm\"),factory);\n",
+    "var testSource = new LibSVMDataSource<>(Paths.get(\".\",\"yeast_test.svm\"),factory,trainSource.isZeroIndexed(),trainSource.getMaxFeatureID());\n",
+    "var train = new MutableDataset<>(trainSource);\n",
+    "var test = new MutableDataset<>(testSource);\n",
+    "System.out.println(String.format(\"Training data size = %d, number of features = %d, number of classes = %d\",train.size(),train.getFeatureMap().size(),train.getOutputInfo().size()));\n",
+    "System.out.println(String.format(\"Testing data size = %d, number of features = %d, number of classes = %d\",test.size(),test.getFeatureMap().size(),test.getOutputInfo().size()));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In Tribuo we represent a multi-label task using the `org.tribuo.multilabel.MultiLabel` output, which internally uses a set of `org.tribuo.classification.Label` objects to store the individual labels. This means that unlike most Tribuo prediction type packages, `tribuo-multilabel-core` depends on another output core package `tribuo-classification-core`.\n",
+    "\n",
+    "We can inspect the first output from the training dataset to see this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First output = (LabelSet={2,3})\n",
+      "Second output = (LabelSet={11,12,6,7})\n"
+     ]
+    }
+   ],
+   "source": [
+    "System.out.println(\"First output = \" + train.getExample(0).getOutput());\n",
+    "System.out.println(\"Second output = \" + train.getExample(1).getOutput());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This first example is tagged with labels 2 & 3, and the second one is tagged with 6, 7, 11 and 12. Unfortunately the LibSVM format we loaded in uses numbers rather than names for the labels, but if there are more descriptive names present when the data is loaded in then those would be used as the label names.\n",
+    "\n",
+    "## The task of multi-label prediction\n",
+    "\n",
+    "Multi-label problems can be approached in several different ways. A common approach is to treat each label as an independent function of the input features, this leads to the *binary relevance* approach where each label is independent from each other, and multi-label classification can be thought of as a set of standard binary classification problems. This approach scales well, but if there is underlying structure in the label space (e.g., the label \"human\" implies the label \"animal\", but the label \"animal\" does not imply \"human\", so they are not independent), then this approach ignores useful information from the training data and may underperform more complicated approaches. Another popular way to convert a multi-label problem into a standard classification problem is via a *label powerset*, where each unique combination of the individual labels is treated as a single label in a large multi-class classification problem. While this allows the learning algorithm to fully capture any interactions between the labels, the label powerset is exponential in the number of labels, which rapidly makes this approach intractable as the number of labels increases though it can be useful in small label spaces. Tribuo currently focuses on binary relevance and other approaches which don't require exponential computation, though we're happy to discuss incorporating label powerset methods if people have need for them. \n",
+    "\n",
+    "## Training Binary Relevance models\n",
+    "\n",
+    "Now we'll train a few different binary relevance models (i.e., independent predictions of each label). First we'll use Tribuo's multi-label `LinearSGDModel`, then we'll wrap a binary classification decision tree into a multi-label predictor using `IndependentMultiLabelTrainer` and `IndependentMultiLabelModel`.\n",
+    "\n",
+    "Tribuo's multi-label SGD package supports two different objective functions, Binary Cross-Entropy and Hinge loss. The BCE loss produces probabilitistic outputs thresholded at 0.5, whereas the hinge loss produces scores thresholded at 0. As Tribuo usually produces scores for each possible label, these thresholds are used to determine when a particular label is present in the `MultiLabel` object representing the predicted label set. As you may have seen in other tutorials, Tribuo uses stochastic gradient descent to fit it's linear models, so we'll define a gradient optimizer along with the loss function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var linTrainer = new LinearSGDTrainer(new BinaryCrossEntropy(),new AdaGrad(0.1,0.1),5,1000,1,Trainer.DEFAULT_SEED);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We train the model the same way we train the rest of Tribuo's models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Linear model training took (00:00:00:145)\n"
+     ]
+    }
+   ],
+   "source": [
+    "var linStartTime = System.currentTimeMillis();\n",
+    "var linModel = linTrainer.train(train);\n",
+    "var linEndTime = System.currentTimeMillis();\n",
+    "System.out.println();\n",
+    "System.out.println(\"Linear model training took \" + Util.formatDuration(linStartTime,linEndTime));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll also train a model using a decision tree to predict each label independently. First we define the binary classification trainer, then we'll use `IndependentMultiLabelTrainer` to wrap that `Trainer<Label>` and convert it into a `Trainer<MultiLabel>`, before training as usual."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Tree model training took (00:00:04:844)\n"
+     ]
+    }
+   ],
+   "source": [
+    "var treeTrainer = new CARTClassificationTrainer(6,10,0.0f,1.0f,false,new Entropy(),1L);\n",
+    "var dtTrainer = new IndependentMultiLabelTrainer(treeTrainer);\n",
+    "var dtStartTime = System.currentTimeMillis();\n",
+    "var dtModel = dtTrainer.train(train);\n",
+    "var dtEndTime = System.currentTimeMillis();\n",
+    "System.out.println();\n",
+    "System.out.println(\"Tree model training took \" + Util.formatDuration(dtStartTime,dtEndTime));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We've now got two different models, so let's measure their performance.\n",
+    "\n",
+    "## Evaluating multi-class problems\n",
+    "\n",
+    "Multi-label problems have many evaluation options available, as many standard classification evaluation measures like accuracy, precision, recall and F1 can be applied at the label level, and there are also many set level metric such as the [Jaccard Index](https://en.wikipedia.org/wiki/Jaccard_index) which can be used to compare the predicted label set against the ground truth one. In Tribuo we have access to most of the metrics available for multi-class classification problems, and v4.2 began adding set level metrics as well. If there are useful metrics that aren't implemented in Tribuo raise an issue on Tribuo's [Github page](https://github.com/oracle/tribuo).\n",
+    "\n",
+    "We use the same evaluation paradigm as other Tribuo prediction tasks, first we construct an `Evaluator` and then feed it a model and some test data to produce an `Evaluation` which contains the appropriate performance metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var eval = new MultiLabelEvaluator();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we'll look at the linear model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Linear model evaluation took (00:00:00:049)\n",
+      "Class                           n          tp          fn          fp      recall        prec          f1\n",
+      "(LabelSet={12})               683         677         230           6       0.746       0.991       0.852\n",
+      "(LabelSet={13})                13           0           0          13       0.000       0.000       0.000\n",
+      "(LabelSet={0})                286         131          45         155       0.744       0.458       0.567\n",
+      "(LabelSet={1})                393         162         130         231       0.555       0.412       0.473\n",
+      "(LabelSet={2})                385         231          95         154       0.709       0.600       0.650\n",
+      "(LabelSet={3})                330         169          79         161       0.681       0.512       0.585\n",
+      "(LabelSet={4})                281         106          35         175       0.752       0.377       0.502\n",
+      "(LabelSet={5})                219          26          14         193       0.650       0.119       0.201\n",
+      "(LabelSet={6})                167           0           0         167       0.000       0.000       0.000\n",
+      "(LabelSet={7})                191           0           0         191       0.000       0.000       0.000\n",
+      "(LabelSet={8})                 80           0           0          80       0.000       0.000       0.000\n",
+      "(LabelSet={9})                 92           0           0          92       0.000       0.000       0.000\n",
+      "(LabelSet={10})                91           0           0          91       0.000       0.000       0.000\n",
+      "(LabelSet={11})               688         684         226           4       0.752       0.994       0.856\n",
+      "Total                       3,899       2,186         854       1,713\n",
+      "Accuracy                                                                    0.561\n",
+      "Micro Average                                                               0.719       0.561       0.630\n",
+      "Macro Average                                                               0.399       0.319       0.335\n",
+      "Balanced Error Rate                                                         0.601\n",
+      "Jaccard Score                                                               0.497\n"
+     ]
+    }
+   ],
+   "source": [
+    "var linTStartTime = System.currentTimeMillis();\n",
+    "var linEval = eval.evaluate(linModel,test);\n",
+    "var linTEndTime = System.currentTimeMillis();\n",
+    "System.out.println();\n",
+    "System.out.println(\"Linear model evaluation took \" + Util.formatDuration(linTStartTime,linTEndTime));\n",
+    "System.out.println(linEval);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, the decision tree:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Tree model evaluation took (00:00:00:050)\n",
+      "Class                           n          tp          fn          fp      recall        prec          f1\n",
+      "(LabelSet={12})               683         607         201          76       0.751       0.889       0.814\n",
+      "(LabelSet={13})                13           0           2          13       0.000       0.000       0.000\n",
+      "(LabelSet={0})                286         111          98         175       0.531       0.388       0.448\n",
+      "(LabelSet={1})                393         187         181         206       0.508       0.476       0.491\n",
+      "(LabelSet={2})                385         251         193         134       0.565       0.652       0.606\n",
+      "(LabelSet={3})                330         131          67         199       0.662       0.397       0.496\n",
+      "(LabelSet={4})                281          92          41         189       0.692       0.327       0.444\n",
+      "(LabelSet={5})                219          88         189         131       0.318       0.402       0.355\n",
+      "(LabelSet={6})                167          30          41         137       0.423       0.180       0.252\n",
+      "(LabelSet={7})                191          29          46         162       0.387       0.152       0.218\n",
+      "(LabelSet={8})                 80           1          12          79       0.077       0.013       0.022\n",
+      "(LabelSet={9})                 92          14          35          78       0.286       0.152       0.199\n",
+      "(LabelSet={10})                91          20          83          71       0.194       0.220       0.206\n",
+      "(LabelSet={11})               688         633         202          55       0.758       0.920       0.831\n",
+      "Total                       3,899       2,194       1,391       1,705\n",
+      "Accuracy                                                                    0.563\n",
+      "Micro Average                                                               0.612       0.563       0.586\n",
+      "Macro Average                                                               0.439       0.369       0.384\n",
+      "Balanced Error Rate                                                         0.561\n",
+      "Jaccard Score                                                               0.439\n"
+     ]
+    }
+   ],
+   "source": [
+    "var dtTStartTime = System.currentTimeMillis();\n",
+    "var dtEval = eval.evaluate(dtModel,test);\n",
+    "var dtTEndTime = System.currentTimeMillis();\n",
+    "System.out.println();\n",
+    "System.out.println(\"Tree model evaluation took \" + Util.formatDuration(dtTStartTime,dtTEndTime));\n",
+    "System.out.println(dtEval);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Unfortunately some of the metrics we might like to examine for regular multi-class classification aren't as easy to consume in the multi-label case. For example, a multi-class confusion matrix has no direct analogue in the multi-label case, as there could be an arbitrary number of labels predicted for each output, meaning there is no notion of a label being mispredicted as another label. This means a multi-label confusion matrix is best presented as a series of binary confusion matrices, one per label. This tends to take up a lot of space, so we'll skip inspecting them in this tutorial, though they are accessible on the `MultiLabelEvaluation` object.\n",
+    "\n",
+    "Now let's look at a more complicated multi-label classification approach, using *Classifier Chains*.\n",
+    "\n",
+    "## Training Classifier Chains\n",
+    "\n",
+    "A classifier chain is similar to a binary relevance model, except there is a sequential order to the predictions (forming a chain), and each member of the chain receives extra features in the form of the predictions of earlier members of the chain. This means that if the chain is correctly ordered according to the causal structure of the labels (which is tricky to do) then it can start with the most independent label first, and then predict each label in sequence so it can use the earlier predictions to improve predictions for each subsequent label (e.g., we could predict if the example is an \"animal\" first, and then when we come to predict if it's a \"human\" we know that humans are animals making the prediction task easier).\n",
+    "\n",
+    "In practice we don't usually know the correct ordering of the labels as the causal structure is unknown, and if we supply the incorrect structure then we can reduce performance back to the level of the binary relevance models. Fortunately in Machine Learning we have a trick we can use when we need to deal with uncertain data, which is to randomize it many times, and take an average. So we could take many different classifier chains each with an random label order, and then each chain votes on the labels that should be predicted. This improves statistical performance over a single chain with a random order, and over a single chain with a poorly chosen order, though it's unlikely to beat a single classifier chain with the correct label ordering (if such an ordering exists). Unfortunately the classifier chain ensemble is more expensive computationally than the single chain, which is already relatively expensive compared to a single classifier like `LinearSGDModel`, but the chains can be straightforwardly parallelized (and we'll add support for this to a future version of Tribuo).\n",
+    "\n",
+    "We're going to use a single classifier chain with a random order, and then an ensemble of 20 classifier chains each using random orders to see how they perform."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var ccTrainer = new ClassifierChainTrainer(treeTrainer,1L);\n",
+    "var ccEnsembleTrainer = new CCEnsembleTrainer(treeTrainer,20,1L);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we'll train and evaluate the single chain:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Classifier Chain model training took (00:00:04:631)\n",
+      "Classifier Chain model evaluation took (00:00:00:068)\n",
+      "Class                           n          tp          fn          fp      recall        prec          f1\n",
+      "(LabelSet={12})               683         616         203          67       0.752       0.902       0.820\n",
+      "(LabelSet={13})                13           0           2          13       0.000       0.000       0.000\n",
+      "(LabelSet={0})                286         159         172         127       0.480       0.556       0.515\n",
+      "(LabelSet={1})                393         215         213         178       0.502       0.547       0.524\n",
+      "(LabelSet={2})                385         251         193         134       0.565       0.652       0.606\n",
+      "(LabelSet={3})                330         199         151         131       0.569       0.603       0.585\n",
+      "(LabelSet={4})                281         112         124         169       0.475       0.399       0.433\n",
+      "(LabelSet={5})                219          74         116         145       0.389       0.338       0.362\n",
+      "(LabelSet={6})                167          39          48         128       0.448       0.234       0.307\n",
+      "(LabelSet={7})                191          40          51         151       0.440       0.209       0.284\n",
+      "(LabelSet={8})                 80           0          14          80       0.000       0.000       0.000\n",
+      "(LabelSet={9})                 92           7          30          85       0.189       0.076       0.109\n",
+      "(LabelSet={10})                91           8          32          83       0.200       0.088       0.122\n",
+      "(LabelSet={11})               688         615         192          73       0.762       0.894       0.823\n",
+      "Total                       3,899       2,335       1,541       1,564\n",
+      "Accuracy                                                                    0.599\n",
+      "Micro Average                                                               0.602       0.599       0.601\n",
+      "Macro Average                                                               0.412       0.393       0.392\n",
+      "Balanced Error Rate                                                         0.588\n",
+      "Jaccard Score                                                               0.473\n"
+     ]
+    }
+   ],
+   "source": [
+    "// train the model\n",
+    "var ccStartTime = System.currentTimeMillis();\n",
+    "var ccModel = ccTrainer.train(train);\n",
+    "var ccEndTime = System.currentTimeMillis();\n",
+    "System.out.println();\n",
+    "System.out.println(\"Classifier Chain model training took \" + Util.formatDuration(ccStartTime,ccEndTime));\n",
+    "\n",
+    "// evaluate the model\n",
+    "var ccTStartTime = System.currentTimeMillis();\n",
+    "var ccEval = eval.evaluate(ccModel,test);\n",
+    "var ccTEndTime = System.currentTimeMillis();\n",
+    "System.out.println(\"Classifier Chain model evaluation took \" + Util.formatDuration(ccTStartTime,ccTEndTime));\n",
+    "System.out.println(ccEval);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see the classifier chain improved over the binary relevance model when using trees as the base learner, and took roughly the same amount of time to train and evaluate. It's still not quite up to the linear model, but let's try the chain ensemble and see how it does.\n",
+    "\n",
+    "Now we'll train and evaluate the ensemble:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Classifier Chain Ensemble model training took (00:01:29:927)\n",
+      "Classifier Chain Ensemble model evaluation took (00:00:00:832)\n",
+      "Class                           n          tp          fn          fp      recall        prec          f1\n",
+      "(LabelSet={12})               683         629         216          54       0.744       0.921       0.823\n",
+      "(LabelSet={13})                13           0           1          13       0.000       0.000       0.000\n",
+      "(LabelSet={0})                286         112          64         174       0.636       0.392       0.485\n",
+      "(LabelSet={1})                393         170         140         223       0.548       0.433       0.484\n",
+      "(LabelSet={2})                385         254         146         131       0.635       0.660       0.647\n",
+      "(LabelSet={3})                330         194         111         136       0.636       0.588       0.611\n",
+      "(LabelSet={4})                281         112          45         169       0.713       0.399       0.511\n",
+      "(LabelSet={5})                219          49          40         170       0.551       0.224       0.318\n",
+      "(LabelSet={6})                167          14           6         153       0.700       0.084       0.150\n",
+      "(LabelSet={7})                191          14          19         177       0.424       0.073       0.125\n",
+      "(LabelSet={8})                 80           0           0          80       0.000       0.000       0.000\n",
+      "(LabelSet={9})                 92           0           4          92       0.000       0.000       0.000\n",
+      "(LabelSet={10})                91           2           2          89       0.500       0.022       0.042\n",
+      "(LabelSet={11})               688         640         205          48       0.757       0.930       0.835\n",
+      "Total                       3,899       2,190         999       1,709\n",
+      "Accuracy                                                                    0.562\n",
+      "Micro Average                                                               0.687       0.562       0.618\n",
+      "Macro Average                                                               0.489       0.337       0.359\n",
+      "Balanced Error Rate                                                         0.511\n",
+      "Jaccard Score                                                               0.485\n"
+     ]
+    }
+   ],
+   "source": [
+    "// train the model\n",
+    "var ccEnsembleStartTime = System.currentTimeMillis();\n",
+    "var ccEnsembleModel = ccEnsembleTrainer.train(train);\n",
+    "var ccEnsembleEndTime = System.currentTimeMillis();\n",
+    "System.out.println();\n",
+    "System.out.println(\"Classifier Chain Ensemble model training took \" + Util.formatDuration(ccEnsembleStartTime,ccEnsembleEndTime));\n",
+    "\n",
+    "// evaluate the model\n",
+    "var ccETStartTime = System.currentTimeMillis();\n",
+    "var ccEnsembleEval = eval.evaluate(ccEnsembleModel,test);\n",
+    "var ccETEndTime = System.currentTimeMillis();\n",
+    "System.out.println(\"Classifier Chain Ensemble model evaluation took \" + Util.formatDuration(ccETStartTime,ccETEndTime));\n",
+    "System.out.println(ccEnsembleEval);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As expected the classifier chain ensemble outperformed the binary relevance model, and also the single classifier chain both using trees as the base learner, at the cost of the greatest runtime. We didn't quite beat the performance of the linear model, but in general classifier chains are a powerful multi-label approach, and we could always use a the linear model as a base learner (and if you do, then you do improve the jaccard index above 0.497). We leave the implementation of that as an exercise for the reader.\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "We looked at Tribuo's multi-label classification package, trying out several different models using different approaches to the multi-label problem, namely binary relevance models and classifier chains. We're interested in expanding Tribuo's support for multi-label problems, so if there are algorithms or metrics Tribuo is missing head over to our [Github page](https://github.com/oracle/tribuo) and contributions are always welcome."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Java",
+   "language": "java",
+   "name": "java"
+  },
+  "language_info": {
+   "codemirror_mode": "java",
+   "file_extension": ".jshell",
+   "mimetype": "text/x-java-source",
+   "name": "Java",
+   "pygments_lexer": "java",
+   "version": "17+35-2724"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tutorials/multi-label-tribuo-v4.ipynb
+++ b/tutorials/multi-label-tribuo-v4.ipynb
@@ -52,6 +52,7 @@
    "outputs": [],
    "source": [
     "import org.tribuo.*;\n",
+    "import org.tribuo.classification.Label;\n",
     "import org.tribuo.classification.dtree.CARTClassificationTrainer;\n",
     "import org.tribuo.classification.dtree.impurity.*;\n",
     "import org.tribuo.datasource.*;\n",
@@ -71,7 +72,7 @@
    "source": [
     "## Loading the data\n",
     "\n",
-    "There are two main forms for multi-label data in columnar representations. Either the dataset stores the labels in a single column using some delimiter, resulting in a sparse representation of the labels, or each label is stored in it's own column with a flag representing if that label is present (e.g., \"TRUE\" or \"1\"), resulting in a dense representation of the labels. Tribuo can load both formats, though currently the `MultiLabelFactory` only supports comma separated labels when parsing inputs directly from a `String`. When processing multi-label values through a `RowProcessor` then the factory receives a `List<String>` and processes each separate label appropriately.\n",
+    "There are two main forms for multi-label data in columnar representations. Either the dataset stores the labels in a single column using some delimiter (e.g., \"first_label,third_label\"), resulting in a sparse representation of the labels, or each label is stored in it's own column with a flag representing if that label is present (e.g., \"TRUE\" or \"1\"), resulting in a dense representation of the labels. Tribuo can load both formats, though currently the `MultiLabelFactory` only supports comma separated labels when parsing inputs directly from a `String`. When processing multi-label values through a `RowProcessor` then the factory receives a `List<String>` and processes each separate label appropriately.\n",
     "\n",
     "The yeast dataset we downloaded is stored in libsvm format which uses a sparse representation of the labels, so we'll use Tribuo's `LibSVMDataSource` to load it in, and process the outputs through a `MultiLabelFactory`."
    ]
@@ -104,14 +105,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In Tribuo we represent a multi-label task using the `org.tribuo.multilabel.MultiLabel` output, which internally uses a set of `org.tribuo.classification.Label` objects to store the individual labels. This means that unlike most Tribuo prediction type packages, `tribuo-multilabel-core` depends on another output core package `tribuo-classification-core`. This is a sparse representation of the labels, only the `Label`s which are present are stored in the `MultiLabel` object. When working with `Prediction<MultiLabel>` the `Map<String,MultiLabel>` used to represent the scores contains many `MultiLabel` objects each of which only contains a single `Label` to make it easier to recover the full distribution. This is a little uncomfortable if you're only working with multi-label data, but it is done to ensure conformity across Tribuo's different prediction APIs.\n",
+    "In Tribuo we represent a multi-label task using the `org.tribuo.multilabel.MultiLabel` output, which internally uses a set of `org.tribuo.classification.Label` objects to store the individual labels. This means that unlike most Tribuo prediction type packages, `tribuo-multilabel-core` depends on another output core package `tribuo-classification-core`. `MultiLabel` is a sparse representation of the labels, only the `Label`s which are active are stored in the `MultiLabel` object.\n",
     "\n",
     "We can inspect the first output from the training dataset to see this:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -140,7 +141,7 @@
     "\n",
     "## Training Binary Relevance models\n",
     "\n",
-    "Now we'll train a few different binary relevance models (i.e., independent predictions of each label). First we'll use Tribuo's multi-label `LinearSGDModel`, then we'll wrap a binary classification decision tree into a multi-label predictor using `IndependentMultiLabelTrainer` and `IndependentMultiLabelModel`.\n",
+    "Now we'll train a few different binary relevance models (i.e., independent predictions of each label). First we'll use Tribuo's multi-label `LinearSGDModel` which natively makes multi-label predictions, then we'll wrap a binary classification decision tree into a multi-label predictor using `IndependentMultiLabelTrainer` and `IndependentMultiLabelModel`. Note: Tribuo has three classes called `LinearSGDModel`, one each for `Label`, `MultiLabel`, and `Regressor`, so the `LinearSGDModel` used in this tutorial is `org.tribuo.multilabel.sgd.linear.LinearSGDModel`, and the one used in the *multi-class* classification tutorials is `org.tribuo.classification.sgd.linear.LinearSGDModel`.\n",
     "\n",
     "Tribuo's multi-label SGD package supports two different objective functions, Binary Cross-Entropy and Hinge loss. The BCE loss produces probabilitistic outputs thresholded at 0.5, whereas the hinge loss produces scores thresholded at 0. As Tribuo usually produces scores for each possible label, these thresholds are used to determine when a particular label is present in the `MultiLabel` object representing the predicted label set. As you may have seen in other tutorials, Tribuo uses stochastic gradient descent to fit it's linear models, so we'll define a gradient optimizer along with the loss function."
    ]
@@ -171,7 +172,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Linear model training took (00:00:00:145)\n"
+      "Linear model training took (00:00:00:266)\n"
      ]
     }
    ],
@@ -187,7 +188,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll also train a model using a decision tree to predict each label independently. First we define the binary classification trainer, then we'll use `IndependentMultiLabelTrainer` to wrap that `Trainer<Label>` and convert it into a `Trainer<MultiLabel>`, before training as usual."
+    "Tribuo doesn't have a native implementation of a multi-label decision tree, but it does have a multi-class decision tree, which we can convert into a multi-label predictor using `IndependentMultiLabelTrainer`. Now let's train a model using a decision tree to predict each label independently. First we define the binary classification trainer, then we'll use `IndependentMultiLabelTrainer` to wrap that `Trainer<Label>` and convert it into a `Trainer<MultiLabel>`, before training as usual."
    ]
   },
   {
@@ -200,13 +201,13 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Tree model training took (00:00:04:844)\n"
+      "Tree model training took (00:00:03:725)\n"
      ]
     }
    ],
    "source": [
-    "var treeTrainer = new CARTClassificationTrainer(6,10,0.0f,1.0f,false,new Entropy(),1L);\n",
-    "var dtTrainer = new IndependentMultiLabelTrainer(treeTrainer);\n",
+    "Trainer<Label> treeTrainer = new CARTClassificationTrainer(6,10,0.0f,1.0f,false,new Entropy(),1L);\n",
+    "Trainer<MultiLabel> dtTrainer = new IndependentMultiLabelTrainer(treeTrainer);\n",
     "var dtStartTime = System.currentTimeMillis();\n",
     "var dtModel = dtTrainer.train(train);\n",
     "var dtEndTime = System.currentTimeMillis();\n",
@@ -223,6 +224,8 @@
     "## Evaluating multi-class problems\n",
     "\n",
     "Multi-label problems have many evaluation options available, as many standard classification evaluation measures like accuracy, precision, recall and F1 can be applied at the label level, and there are also many set level metric such as the [Jaccard Index](https://en.wikipedia.org/wiki/Jaccard_index) which can be used to compare the predicted label set against the ground truth one. In Tribuo we have access to most of the metrics available for multi-class classification problems, and v4.2 began adding set level metrics as well. If there are useful metrics that aren't implemented in Tribuo raise an issue on Tribuo's [Github page](https://github.com/oracle/tribuo).\n",
+    "\n",
+    "If you want to use the predicted scores for each of the labels separately (e.g., to analyse the model's performance) then as usual the `Map<String,MultiLabel>` available from `Prediction.getOutputScores()` has the full distribution. This map behaves slightly counter-intuitively, as each value is a `MultiLabel` object containing a single `Label`, and the key is the output of `Label.toString()`. This allows the labels to be inspected individually, but it is a little uncomfortable if you're used to working with a multi-label specific API. However it maintains conformity across all of Tribuo's different prediction APIs, both for predictions and evaluations, which makes it easier to incorporate lots of ML models into a larger system.\n",
     "\n",
     "We use the same evaluation paradigm as other Tribuo prediction tasks, first we construct an `Evaluator` and then feed it a model and some test data to produce an `Evaluation` which contains the appropriate performance metrics."
    ]
@@ -253,7 +256,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Linear model evaluation took (00:00:00:049)\n",
+      "Linear model evaluation took (00:00:00:067)\n",
       "Class                           n          tp          fn          fp      recall        prec          f1\n",
       "(LabelSet={12})               683         677         230           6       0.746       0.991       0.852\n",
       "(LabelSet={13})                13           0           0          13       0.000       0.000       0.000\n",
@@ -304,7 +307,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Tree model evaluation took (00:00:00:050)\n",
+      "Tree model evaluation took (00:00:00:127)\n",
       "Class                           n          tp          fn          fp      recall        prec          f1\n",
       "(LabelSet={12})               683         607         201          76       0.751       0.889       0.814\n",
       "(LabelSet={13})                13           0           2          13       0.000       0.000       0.000\n",
@@ -342,13 +345,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can see the native multi-label linear model outperformed the wrapped decision tree in terms of Jaccard Score, though the picture is more mixed in the other metrics, and it's ignoring some of the labels.\n",
+    "\n",
     "Unfortunately some of the metrics we might like to examine for regular multi-class classification aren't as easy to consume in the multi-label case. For example, a multi-class confusion matrix has no direct analogue in the multi-label case, as there could be an arbitrary number of labels predicted for each output, meaning there is no notion of a label being mispredicted as another label. This means a multi-label confusion matrix is best presented as a series of binary confusion matrices, one per label. This tends to take up a lot of space, so we'll skip inspecting them in this tutorial, though they are accessible on the `MultiLabelEvaluation` object.\n",
     "\n",
     "Now let's look at a more complicated multi-label classification approach, using *Classifier Chains*.\n",
     "\n",
     "## Training Classifier Chains\n",
     "\n",
-    "A classifier chain is similar to a binary relevance model, except there is a sequential order to the predictions (forming a chain), and each member of the chain receives extra features in the form of the predictions of earlier members of the chain. This means that if the chain is correctly ordered according to the causal structure of the labels (which is tricky to do) then it can start with the most independent label first, and then predict each label in sequence so it can use the earlier predictions to improve predictions for each subsequent label (e.g., we could predict if the example is an \"animal\" first, and then when we come to predict if it's a \"human\" we know that humans are animals making the prediction task easier).\n",
+    "A [classifier chain](http://www.cs.waikato.ac.nz/~ml/publications/2009/chains.pdf) is similar to a binary relevance model, except there is a sequential order to the predictions (forming a chain), and each member of the chain receives extra features in the form of the predictions of earlier members of the chain. This means that if the chain is correctly ordered according to the causal structure of the labels (which is tricky to do) then it can start with the most independent label first, and then predict each label in sequence so it can use the earlier predictions to improve predictions for each subsequent label (e.g., we could predict if the example is an \"animal\" first, and then when we come to predict if it's a \"human\" we know that humans are animals making the prediction task easier).\n",
     "\n",
     "In practice we don't usually know the correct ordering of the labels as the causal structure is unknown, and if we supply the incorrect structure then we can reduce performance back to the level of the binary relevance models. Fortunately in Machine Learning we have a trick we can use when we need to deal with uncertain data, which is to randomize it many times, and take an average. So we could take many different classifier chains each with an random label order, and then each chain votes on the labels that should be predicted. This improves statistical performance over a single chain with a random order, and over a single chain with a poorly chosen order, though it's unlikely to beat a single classifier chain with the correct label ordering (if such an ordering exists). Unfortunately the classifier chain ensemble is more expensive computationally than the single chain, which is already relatively expensive compared to a single classifier like `LinearSGDModel`, but the chains can be straightforwardly parallelized (and we'll add support for this to a future version of Tribuo).\n",
     "\n",
@@ -382,8 +387,8 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Classifier Chain model training took (00:00:04:631)\n",
-      "Classifier Chain model evaluation took (00:00:00:068)\n",
+      "Classifier Chain model training took (00:00:03:366)\n",
+      "Classifier Chain model evaluation took (00:00:00:141)\n",
       "Class                           n          tp          fn          fp      recall        prec          f1\n",
       "(LabelSet={12})               683         616         203          67       0.752       0.902       0.820\n",
       "(LabelSet={13})                13           0           2          13       0.000       0.000       0.000\n",
@@ -443,8 +448,8 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Classifier Chain Ensemble model training took (00:01:29:927)\n",
-      "Classifier Chain Ensemble model evaluation took (00:00:00:832)\n",
+      "Classifier Chain Ensemble model training took (00:01:04:509)\n",
+      "Classifier Chain Ensemble model evaluation took (00:00:02:091)\n",
       "Class                           n          tp          fn          fp      recall        prec          f1\n",
       "(LabelSet={12})               683         629         216          54       0.744       0.921       0.823\n",
       "(LabelSet={13})                13           0           1          13       0.000       0.000       0.000\n",
@@ -509,7 +514,7 @@
    "mimetype": "text/x-java-source",
    "name": "Java",
    "pygments_lexer": "java",
-   "version": "17-ea+22-1964"
+   "version": "11.0.10+8-LTS-162"
   }
  },
  "nbformat": 4,

--- a/tutorials/multi-label-tribuo-v4.ipynb
+++ b/tutorials/multi-label-tribuo-v4.ipynb
@@ -71,7 +71,9 @@
    "source": [
     "## Loading the data\n",
     "\n",
-    "The yeast dataset we downloaded is stored in libsvm format, so we'll use Tribuo's `LibSVMDataSource` to load it in, and process the outputs through a `MultiLabelFactory`."
+    "There are two main forms for multi-label data in columnar representations. Either the dataset stores the labels in a single column using some delimiter, resulting in a sparse representation of the labels, or each label is stored in it's own column with a flag representing if that label is present (e.g., \"TRUE\" or \"1\"), resulting in a dense representation of the labels. Tribuo can load both formats, though currently the `MultiLabelFactory` only supports comma separated labels when parsing inputs directly from a `String`. When processing multi-label values through a `RowProcessor` then the factory receives a `List<String>` and processes each separate label appropriately.\n",
+    "\n",
+    "The yeast dataset we downloaded is stored in libsvm format which uses a sparse representation of the labels, so we'll use Tribuo's `LibSVMDataSource` to load it in, and process the outputs through a `MultiLabelFactory`."
    ]
   },
   {
@@ -102,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In Tribuo we represent a multi-label task using the `org.tribuo.multilabel.MultiLabel` output, which internally uses a set of `org.tribuo.classification.Label` objects to store the individual labels. This means that unlike most Tribuo prediction type packages, `tribuo-multilabel-core` depends on another output core package `tribuo-classification-core`.\n",
+    "In Tribuo we represent a multi-label task using the `org.tribuo.multilabel.MultiLabel` output, which internally uses a set of `org.tribuo.classification.Label` objects to store the individual labels. This means that unlike most Tribuo prediction type packages, `tribuo-multilabel-core` depends on another output core package `tribuo-classification-core`. This is a sparse representation of the labels, only the `Label`s which are present are stored in the `MultiLabel` object. When working with `Prediction<MultiLabel>` the `Map<String,MultiLabel>` used to represent the scores contains many `MultiLabel` objects each of which only contains a single `Label` to make it easier to recover the full distribution. This is a little uncomfortable if you're only working with multi-label data, but it is done to ensure conformity across Tribuo's different prediction APIs.\n",
     "\n",
     "We can inspect the first output from the training dataset to see this:"
    ]
@@ -507,7 +509,7 @@
    "mimetype": "text/x-java-source",
    "name": "Java",
    "pygments_lexer": "java",
-   "version": "17+35-2724"
+   "version": "17-ea+22-1964"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Description
Adds a tutorial on multi-label problems showing the multi-label `LinearSGDTrainer`, the binary relevance based `IndependentMultiLabelTrainer`, a single classifier chain using `ClassifierChainTrainer`, and an ensemble of classifier chains using `CCEnsembleTrainer`. 

It also adds a configurable data source generator for multi-label data.

Note the configurable data source won't provenance correctly until Tribuo depends on a version of OLCUT with this PR merged (https://github.com/oracle/olcut/pull/37), and so it's not part of the unit tests yet.

### Motivation
We'd like tutorials for each prediction type in Tribuo and multi-label was the last type without a tutorial.

It also adds the last configurable data source needed to round out the set of demo sources for each prediction type (see https://github.com/oracle/tribuo/pull/160 for longer motivation).
