### PR TITLE
Fixing a bug where MultiLabelConfusionMatrix swapped FP for FN

### DIFF
--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
@@ -37,17 +37,17 @@ import java.util.stream.Collectors;
  * In a multi-label confusion matrix M,
  * <pre>
  * tn = M[:, 0, 0]
- * fn = M[:, 1, 0]
+ * fn = M[:, 0, 1]
+ * fp = M[:, 1, 0]
  * tp = M[:, 1, 1]
- * fp = M[:, 0, 1]
  * </pre>
  * <p>
  * For class-wise values,
  * <pre>
  * tn(class i) = M[i, 0, 0]
- * fn(class i) = M[i, 1, 0]
+ * fn(class i) = M[i, 0, 1]
+ * fp(class i) = M[i, 1, 0]
  * tp(class i) = M[i, 1, 1]
- * fp(class i) = M[i, 0, 1]
  * </pre>
  */
 public final class MultiLabelConfusionMatrix implements ConfusionMatrix<MultiLabel> {

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,12 +114,12 @@ public final class MultiLabelConfusionMatrix implements ConfusionMatrix<MultiLab
 
     @Override
     public double fp(MultiLabel cls) {
-        return compute(cls, (cm) -> cm.get(0, 1));
+        return compute(cls, (cm) -> cm.get(1, 0));
     }
 
     @Override
     public double fn(MultiLabel cls) {
-        return compute(cls, (cm) -> cm.get(1, 0));
+        return compute(cls, (cm) -> cm.get(0, 1));
     }
 
     @Override

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
@@ -271,4 +271,13 @@ public final class MultiLabelEvaluationImpl implements MultiLabelEvaluation {
                 .getID());
     }
 
+    @Override
+    public double get(MetricID<MultiLabel> key) {
+        Double value = results.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("Metric value not found: " + key.toString());
+        }
+        return value;
+    }
+
 }

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelMetrics.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelMetrics.java
@@ -73,10 +73,19 @@ public enum MultiLabelMetrics {
         this.impl = impl;
     }
 
+    /**
+     * Get the implementation function for this metric.
+     * @return The function.
+     */
     public BiFunction<MetricTarget<MultiLabel>, MultiLabelMetric.Context, Double> getImpl() {
         return impl;
     }
 
+    /**
+     * Get the metric for the supplied target.
+     * @param tgt The metric target.
+     * @return The metric.
+     */
     public MultiLabelMetric forTarget(MetricTarget<MultiLabel> tgt) {
         return new MultiLabelMetric(tgt, this.name(), this.getImpl());
     }

--- a/MultiLabel/SGD/src/test/java/org/tribuo/multilabel/sgd/linear/TestSGDLinear.java
+++ b/MultiLabel/SGD/src/test/java/org/tribuo/multilabel/sgd/linear/TestSGDLinear.java
@@ -91,11 +91,7 @@ public class TestSGDLinear {
 
         MultiLabelEvaluation evaluation = (MultiLabelEvaluation) train.getOutputFactory().getEvaluator().evaluate(model,test);
 
-        if (trainer == hinge) {
-            Assertions.assertEquals(0.6, evaluation.microAveragedRecall());
-        } else {
-            Assertions.assertEquals(1.0, evaluation.microAveragedRecall());
-        }
+        Assertions.assertEquals(1.0, evaluation.microAveragedRecall());
 
         Helpers.testModelSerialization(model, MultiLabel.class);
     }


### PR DESCRIPTION
### Description
The multilabel evaluation package swapped the FPs for FNs when accessing them, causing many of the metrics to be permuted incorrectly producing incorrect values for precisions, recalls and the evaluation.toString().

### Motivation
It's best if the evaluations report the right numbers in the right places.
