### PR TITLE
Bumping LibSVM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,9 @@
 
         <!-- 3rd party backend dependencies -->
         <liblinear.version>2.43</liblinear.version>
-        <libsvm.version>3.24</libsvm.version>
+        <libsvm.version>3.25</libsvm.version>
         <onnxruntime.version>1.7.0</onnxruntime.version>
-        <tensorflow.version>0.3.1</tensorflow.version>
+        <tensorflow.version>0.3.3</tensorflow.version>
         <xgboost.version>1.4.1</xgboost.version>
 
         <!-- 3rd party other dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <liblinear.version>2.43</liblinear.version>
         <libsvm.version>3.25</libsvm.version>
         <onnxruntime.version>1.7.0</onnxruntime.version>
-        <tensorflow.version>0.3.3</tensorflow.version>
+        <tensorflow.version>0.3.1</tensorflow.version>
         <xgboost.version>1.4.1</xgboost.version>
 
         <!-- 3rd party other dependencies -->


### PR DESCRIPTION
### Description
Bump LibSVM to 3.25.

### Motivation
Moving to LibSVM's latest version for compliance reasons (there are no Java fixes in this version vs 3.24 as far as I can tell). 
