### PR TITLE
CSVDataSource should persist the headers in the provenance

### DIFF
--- a/Data/src/main/java/org/tribuo/data/csv/CSVDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Data/src/main/java/org/tribuo/data/csv/CSVDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVDataSource.java
@@ -146,7 +146,7 @@ public class CSVDataSource<T extends Output<T>> extends ColumnarDataSource<T> {
      * @param quote The quote character in the data file.
      */
     public CSVDataSource(URI dataFile, RowProcessor<T> rowProcessor, boolean outputRequired, char separator, char quote) {
-        this(dataFile, Paths.get(dataFile),rowProcessor,outputRequired,separator,quote);
+        this(dataFile, Paths.get(dataFile),rowProcessor,outputRequired,separator,quote,Collections.emptyList());
     }
 
     /**
@@ -154,6 +154,9 @@ public class CSVDataSource<T extends Output<T>> extends ColumnarDataSource<T> {
      * characters to read the input data file.
      * <p>
      * Used in {@link CSVLoader} to read a CSV without headers.
+     * <p>
+     * If headers is the empty list then the headers are read from the file, otherwise the file is assumed to
+     * not contain headers.
      * @param dataFile A URI for the data file.
      * @param rowProcessor The row processor which converts a row into an {@link Example}.
      * @param outputRequired Is the output required to exist in the data file.
@@ -161,9 +164,8 @@ public class CSVDataSource<T extends Output<T>> extends ColumnarDataSource<T> {
      * @param quote The quote character in the data file.
      * @param headers The CSV file headers.
      */
-    CSVDataSource(URI dataFile, RowProcessor<T> rowProcessor, boolean outputRequired, char separator, char quote, List<String> headers) {
-        this(dataFile, Paths.get(dataFile),rowProcessor,outputRequired,separator,quote);
-        this.headers = headers;
+    public CSVDataSource(URI dataFile, RowProcessor<T> rowProcessor, boolean outputRequired, char separator, char quote, List<String> headers) {
+        this(dataFile, Paths.get(dataFile),rowProcessor,outputRequired,separator,quote,headers);
     }
 
     /**
@@ -176,24 +178,46 @@ public class CSVDataSource<T extends Output<T>> extends ColumnarDataSource<T> {
      * @param quote The quote character in the data file.
      */
     public CSVDataSource(Path dataPath, RowProcessor<T> rowProcessor, boolean outputRequired, char separator, char quote) {
-        this(dataPath.toUri(),dataPath,rowProcessor,outputRequired,separator,quote);
+        this(dataPath.toUri(),dataPath,rowProcessor,outputRequired,separator,quote,Collections.emptyList());
+    }
+
+    /**
+     * Creates a CSVDataSource using the specified RowProcessor to process the data, and the supplied separator and quote
+     * characters to read the input data file.
+     * <p>
+     * If headers is the empty list then the headers are read from the file, otherwise the file is assumed to
+     * not contain headers.
+     * @param dataPath The Path to the data file.
+     * @param rowProcessor The row processor which converts a row into an {@link Example}.
+     * @param outputRequired Is the output required to exist in the data file.
+     * @param separator The separator character in the data file.
+     * @param quote The quote character in the data file.
+     * @param headers The CSV file headers.
+     */
+    public CSVDataSource(Path dataPath, RowProcessor<T> rowProcessor, boolean outputRequired, char separator, char quote, List<String> headers) {
+        this(dataPath.toUri(),dataPath,rowProcessor,outputRequired,separator,quote,headers);
     }
 
     /**
      * Creates a CSVDataSource using the specified RowProcessor to process the data, and the supplied separator, quote
      * characters to read the input data file.
+     * <p>
+     * If headers is the empty list then the headers are read from the file, otherwise the file is assumed to
+     * not contain headers.
      * @param dataFile A URI for the data file.
      * @param rowProcessor The row processor which converts a row into an {@link Example}.
      * @param outputRequired Is the output required to exist in the data file.
      * @param separator The separator character in the data file.
      * @param quote The quote character in the data file.
+     * @param headers The CSV file headers, or an empty list.
      */
-    private CSVDataSource(URI dataFile, Path dataPath, RowProcessor<T> rowProcessor, boolean outputRequired, char separator, char quote) {
+    private CSVDataSource(URI dataFile, Path dataPath, RowProcessor<T> rowProcessor, boolean outputRequired, char separator, char quote, List<String> headers) {
         super(rowProcessor.getResponseProcessor().getOutputFactory(), rowProcessor, outputRequired);
         this.dataPath = dataPath;
         this.dataFile = dataFile;
         this.separator = separator;
         this.quote = quote;
+        this.headers = headers;
         this.provenance = new CSVDataSourceProvenance(this);
     }
 

--- a/Data/src/main/java/org/tribuo/data/csv/CSVIterator.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVIterator.java
@@ -101,7 +101,7 @@ public class CSVIterator extends ColumnarIterator implements AutoCloseable {
     }
 
     /**
-     * Builds a CSVIterator for the supplied URI.
+     * Builds a CSVIterator for the supplied URI. If headers is null or an empty array, read the headers from the csv file.
      * @param dataFile The source to read.
      * @param separator The separator character to use.
      * @param quote The quote character to use.
@@ -125,7 +125,7 @@ public class CSVIterator extends ColumnarIterator implements AutoCloseable {
     }
 
     /**
-     * Builds a CSVIterator for the supplied Reader. If headers is null, read the headers from the csv file.
+     * Builds a CSVIterator for the supplied Reader. If headers is null or an empty array, read the headers from the csv file.
      * @param rdr The source to read.
      * @param separator The separator character to use.
      * @param quote The quote character to use.
@@ -136,7 +136,7 @@ public class CSVIterator extends ColumnarIterator implements AutoCloseable {
     }
 
     /**
-     * Builds a CSVIterator for the supplied Reader. If headers is null, read the headers from the csv file.
+     * Builds a CSVIterator for the supplied Reader. If headers is null or an empty list, read the headers from the csv file.
      * @param rdr The source to read.
      * @param separator The separator character to use.
      * @param quote The quote character to use.

--- a/Data/src/main/java/org/tribuo/data/csv/CSVIterator.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Data/src/test/java/org/tribuo/data/csv/CSVLoaderTest.java
+++ b/Data/src/test/java/org/tribuo/data/csv/CSVLoaderTest.java
@@ -16,6 +16,9 @@
 
 package org.tribuo.data.csv;
 
+import com.oracle.labs.mlrg.olcut.provenance.ListProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
 import org.junit.jupiter.api.Test;
 import org.tribuo.DataSource;
 import org.tribuo.Example;
@@ -36,6 +39,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -101,11 +105,23 @@ public class CSVLoaderTest {
         //
         // Test behavior when CSV file does not have a header row and the user instead supplies the header.
         URL noheader = CSVLoader.class.getResource("/org/tribuo/data/csv/test-noheader.csv");
-        checkDataTestCsv(loader.loadDataSource(noheader, "RESPONSE", header));
+        DataSource<MockOutput> source = loader.loadDataSource(noheader, "RESPONSE", header);
+
+        // Check that the source persisted the headers in the provenance
+        CSVDataSource.CSVDataSourceProvenance prov = (CSVDataSource.CSVDataSourceProvenance) source.getProvenance();
+        Provenance headerProv = prov.getConfiguredParameters().get("headers");
+        assertTrue(headerProv instanceof ListProvenance);
+        @SuppressWarnings("unchecked")
+        ListProvenance<StringProvenance> listProv = (ListProvenance<StringProvenance>) headerProv;
+        assertEquals(header.length,listProv.getList().size());
+        assertEquals(Arrays.asList(header),listProv.getList().stream().map(StringProvenance::getValue).collect(Collectors.toList()));
+
+        // Check the data loaded correctly.
+        checkDataTestCsv(source);
         checkDataTestCsv(loader.loadDataSource(noheader, Collections.singleton("RESPONSE"), header));
     }
 
-    private void checkDataTestCsv(DataSource<MockOutput> source) {
+    private static void checkDataTestCsv(DataSource<MockOutput> source) {
         MutableDataset<MockOutput> data = new MutableDataset<>(source);
         assertEquals(6, data.size());
         assertEquals("monkey", data.getExample(0).getOutput().label);

--- a/Data/src/test/java/org/tribuo/data/csv/CSVLoaderTest.java
+++ b/Data/src/test/java/org/tribuo/data/csv/CSVLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
The headers were set after the provenance was constructed, so the provenance only recorded headers set via configuration. This PR fixes that bug and adds a test for the behaviour. It also makes the CSVDataSource constructor which accepts headers public so it can be used by developers. An additional public constructor which accepts a header and a Path was added to maintain parity.

### Motivation
When using CSVLoader on a file without headers it should persist the headers in the provenance so the configuration is recoverable. Also the CSVDataSource constructor which accepts headers is generally useful if people wish to construct a CSVDataSource for csvs without headers manually.
