### PR TITLE
LibLinear and LibSVM have unmanaged global RNGs

### DIFF
--- a/AnomalyDetection/LibLinear/src/main/java/org/tribuo/anomaly/liblinear/LibLinearAnomalyTrainer.java
+++ b/AnomalyDetection/LibLinear/src/main/java/org/tribuo/anomaly/liblinear/LibLinearAnomalyTrainer.java
@@ -41,7 +41,9 @@ import java.util.logging.Logger;
 
 /**
  * A {@link Trainer} which wraps a liblinear-java anomaly detection trainer using a one-class SVM.
- *
+ * <p>
+ * Note the train method is synchronized on {@code LibLinearTrainer.class} due to a global RNG in liblinear-java.
+ * <p>
  * See:
  * <pre>
  * Fan RE, Chang KW, Hsieh CJ, Wang XR, Lin CJ.

--- a/AnomalyDetection/LibLinear/src/main/java/org/tribuo/anomaly/liblinear/LibLinearAnomalyTrainer.java
+++ b/AnomalyDetection/LibLinear/src/main/java/org/tribuo/anomaly/liblinear/LibLinearAnomalyTrainer.java
@@ -43,6 +43,8 @@ import java.util.logging.Logger;
  * A {@link Trainer} which wraps a liblinear-java anomaly detection trainer using a one-class SVM.
  * <p>
  * Note the train method is synchronized on {@code LibLinearTrainer.class} due to a global RNG in liblinear-java.
+ * This is insufficient to ensure reproducibility if liblinear-java is used directly in the same JVM as Tribuo, but
+ * avoids locking on classes Tribuo does not control.
  * <p>
  * See:
  * <pre>
@@ -130,6 +132,7 @@ public class LibLinearAnomalyTrainer extends LibLinearTrainer<Event> {
         data.n = numFeatures;
 
         // Note this isn't sufficient for reproducibility as it doesn't cope with concurrency.
+        // Concurrency safety is handled by the global lock on LibLinearTrainer.class in LibLinearTrainer.train.
         Linear.resetRandom();
         return Collections.singletonList(Linear.train(data,curParams));
     }

--- a/AnomalyDetection/LibLinear/src/main/java/org/tribuo/anomaly/liblinear/LibLinearAnomalyTrainer.java
+++ b/AnomalyDetection/LibLinear/src/main/java/org/tribuo/anomaly/liblinear/LibLinearAnomalyTrainer.java
@@ -127,6 +127,8 @@ public class LibLinearAnomalyTrainer extends LibLinearTrainer<Event> {
         data.x = features;
         data.n = numFeatures;
 
+        // Note this isn't sufficient for reproducibility as it doesn't cope with concurrency.
+        Linear.resetRandom();
         return Collections.singletonList(Linear.train(data,curParams));
     }
 

--- a/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/LibSVMAnomalyTrainer.java
+++ b/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/LibSVMAnomalyTrainer.java
@@ -45,6 +45,10 @@ import java.util.logging.Logger;
 /**
  * A trainer for anomaly models that uses LibSVM.
  * <p>
+ * Note the train method is synchronized on {@code LibSVMTrainer.class} due to a global RNG in LibSVM.
+ * This is insufficient to ensure reproducibility if LibSVM is used directly in the same JVM as Tribuo, but
+ * avoids locking on classes Tribuo does not control.
+ * <p>
  * See:
  * <pre>
  * Chang CC, Lin CJ.
@@ -123,7 +127,8 @@ public class LibSVMAnomalyTrainer extends LibSVMTrainer<Event> {
         if(checkString != null) {
             throw new IllegalArgumentException("Error checking SVM parameters: " + checkString);
         }
-        // This is safe because we synchronize on LibSVMTrainer.class in the train method.
+        // This is safe because we synchronize on LibSVMTrainer.class in the train method to
+        // ensure there is no concurrent use of the rng.
         svm.rand.setSeed(localRNG.nextLong());
         return Collections.singletonList(svm.svm_train(problem, curParams));
     }

--- a/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/LibSVMAnomalyTrainer.java
+++ b/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/LibSVMAnomalyTrainer.java
@@ -22,6 +22,7 @@ import org.tribuo.Dataset;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
+import org.tribuo.Trainer;
 import org.tribuo.anomaly.Event;
 import org.tribuo.anomaly.Event.EventType;
 import org.tribuo.common.libsvm.LibSVMModel;
@@ -38,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.SplittableRandom;
 import java.util.logging.Logger;
 
 /**
@@ -66,11 +68,20 @@ public class LibSVMAnomalyTrainer extends LibSVMTrainer<Event> {
     protected LibSVMAnomalyTrainer() {}
 
     /**
-     * Creates a one-class LibSVM trainer using the supplied parameters.
-     * @param parameters The training parameters.
+     * Creates a one-class LibSVM trainer using the supplied parameters and {@link Trainer#DEFAULT_SEED}.
+     * @param parameters The SVM training parameters.
      */
     public LibSVMAnomalyTrainer(SVMParameters<Event> parameters) {
-        super(parameters);
+        this(parameters, Trainer.DEFAULT_SEED);
+    }
+
+    /**
+     * Creates a one-class LibSVM trainer using the supplied parameters and RNG seed.
+     * @param parameters The SVM parameters.
+     * @param seed The RNG seed for LibSVM's internal RNG.
+     */
+    public LibSVMAnomalyTrainer(SVMParameters<Event> parameters, long seed) {
+        super(parameters,seed);
     }
 
     /**
@@ -100,7 +111,7 @@ public class LibSVMAnomalyTrainer extends LibSVMTrainer<Event> {
     }
 
     @Override
-    protected List<svm_model> trainModels(svm_parameter curParams, int numFeatures, svm_node[][] features, double[][] outputs) {
+    protected List<svm_model> trainModels(svm_parameter curParams, int numFeatures, svm_node[][] features, double[][] outputs, SplittableRandom localRNG) {
         svm_problem problem = new svm_problem();
         problem.l = outputs[0].length;
         problem.x = features;
@@ -112,6 +123,8 @@ public class LibSVMAnomalyTrainer extends LibSVMTrainer<Event> {
         if(checkString != null) {
             throw new IllegalArgumentException("Error checking SVM parameters: " + checkString);
         }
+        // This is safe because we synchronize on LibSVMTrainer.class in the train method.
+        svm.rand.setSeed(localRNG.nextLong());
         return Collections.singletonList(svm.svm_train(problem, curParams));
     }
 

--- a/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/SVMAnomalyType.java
+++ b/AnomalyDetection/LibSVM/src/main/java/org/tribuo/anomaly/libsvm/SVMAnomalyType.java
@@ -64,7 +64,7 @@ public class SVMAnomalyType implements SVMType<Event> {
 
     @Override
     public boolean isClassification() {
-        return true;
+        return false;
     }
 
     @Override
@@ -74,7 +74,7 @@ public class SVMAnomalyType implements SVMType<Event> {
 
     @Override
     public boolean isAnomaly() {
-        return false;
+        return true;
     }
 
     @Override

--- a/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationTrainer.java
+++ b/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationTrainer.java
@@ -44,7 +44,9 @@ import java.util.logging.Logger;
 
 /**
  * A {@link Trainer} which wraps a liblinear-java classifier trainer.
- *
+ * <p>
+ * Note the train method is synchronized on {@code LibLinearTrainer.class} due to a global RNG in liblinear-java.
+ * <p>
  * See:
  * <pre>
  * Fan RE, Chang KW, Hsieh CJ, Wang XR, Lin CJ.

--- a/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationTrainer.java
+++ b/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationTrainer.java
@@ -46,6 +46,8 @@ import java.util.logging.Logger;
  * A {@link Trainer} which wraps a liblinear-java classifier trainer.
  * <p>
  * Note the train method is synchronized on {@code LibLinearTrainer.class} due to a global RNG in liblinear-java.
+ * This is insufficient to ensure reproducibility if liblinear-java is used directly in the same JVM as Tribuo, but
+ * avoids locking on classes Tribuo does not control.
  * <p>
  * See:
  * <pre>
@@ -117,6 +119,7 @@ public class LibLinearClassificationTrainer extends LibLinearTrainer<Label> impl
         data.bias = 1.0;
 
         // Note this isn't sufficient for reproducibility as it doesn't cope with concurrency.
+        // Concurrency safety is handled by the global lock on LibLinearTrainer.class in LibLinearTrainer.train.
         Linear.resetRandom();
         return Collections.singletonList(Linear.train(data,curParams));
     }

--- a/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationTrainer.java
+++ b/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationTrainer.java
@@ -114,6 +114,8 @@ public class LibLinearClassificationTrainer extends LibLinearTrainer<Label> impl
         data.n = numFeatures;
         data.bias = 1.0;
 
+        // Note this isn't sufficient for reproducibility as it doesn't cope with concurrency.
+        Linear.resetRandom();
         return Collections.singletonList(Linear.train(data,curParams));
     }
 

--- a/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
+++ b/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
@@ -112,7 +112,6 @@ public class TestLibLinearModel {
         for (Example<Label> example : examples) {
             model.getExcuse(example);
         }
-        //System.out.println("*** PASSED: " + prefix);
     }
 
     private void checkModelType(LinearType modelType) throws IOException, ClassNotFoundException {
@@ -129,7 +128,6 @@ public class TestLibLinearModel {
         for (Example<Label> example : examples) {
             model.getExcuse(example);
         }
-        //System.out.println("*** PASSED: " + prefix);
     }
 
 
@@ -182,6 +180,19 @@ public class TestLibLinearModel {
         Assertions.assertNotNull(features);
         Assertions.assertFalse(features.isEmpty());
         return m;
+    }
+
+    @Test
+    public void testReproducible() {
+        // Note this test will need to change if LibLinearTrainer grows a per Problem RNG.
+        Pair<Dataset<Label>,Dataset<Label>> p = LabelledDataGenerator.denseTrainTest();
+        Model<Label> m = t.train(p.getA());
+        Map<String, List<Pair<String,Double>>> mFeatures = m.getTopFeatures(-1);
+
+        Model<Label> mTwo = t.train(p.getA());
+        Map<String, List<Pair<String,Double>>> mTwoFeatures = mTwo.getTopFeatures(-1);
+
+        assertEquals(mFeatures,mTwoFeatures);
     }
 
     @Test

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationModel.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationModel.java
@@ -92,6 +92,10 @@ public class LibSVMClassificationModel extends LibSVMModel<Label> {
         }
     }
 
+    /**
+     * Returns the number of support vectors.
+     * @return The number of support vectors.
+     */
     public int getNumberOfSupportVectors() {
         return models.get(0).SV.length;
     }

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
@@ -22,6 +22,7 @@ import org.tribuo.Dataset;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
+import org.tribuo.Trainer;
 import org.tribuo.classification.Label;
 import org.tribuo.classification.WeightedLabels;
 import org.tribuo.common.libsvm.LibSVMModel;
@@ -39,6 +40,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SplittableRandom;
 import java.util.logging.Logger;
 
 /**
@@ -69,10 +71,27 @@ public class LibSVMClassificationTrainer extends LibSVMTrainer<Label> implements
     @Config(description="Use Label specific weights.")
     private Map<String,Float> labelWeights = Collections.emptyMap();
 
+    /**
+     * For OLCUT.
+     */
     protected LibSVMClassificationTrainer() {}
 
+    /**
+     * Constructs a classification LibSVM trainer using the specified parameters
+     * and {@link Trainer#DEFAULT_SEED}.
+     * @param parameters The SVM parameters.
+     */
     public LibSVMClassificationTrainer(SVMParameters<Label> parameters) {
-        super(parameters);
+        this(parameters, Trainer.DEFAULT_SEED);
+    }
+
+    /**
+     * Constructs a classification LibSVM trainer using the specified parameters and seed.
+     * @param parameters The SVM parameters.
+     * @param seed The RNG seed for LibSVM's internal RNG.
+     */
+    public LibSVMClassificationTrainer(SVMParameters<Label> parameters, long seed) {
+        super(parameters,seed);
     }
 
     /**
@@ -92,7 +111,7 @@ public class LibSVMClassificationTrainer extends LibSVMTrainer<Label> implements
     }
 
     @Override
-    protected List<svm_model> trainModels(svm_parameter curParams, int numFeatures, svm_node[][] features, double[][] outputs) {
+    protected List<svm_model> trainModels(svm_parameter curParams, int numFeatures, svm_node[][] features, double[][] outputs, SplittableRandom localRNG) {
         svm_problem problem = new svm_problem();
         problem.l = outputs[0].length;
         problem.x = features;
@@ -104,6 +123,8 @@ public class LibSVMClassificationTrainer extends LibSVMTrainer<Label> implements
         if(checkString != null) {
             throw new IllegalArgumentException("Error checking SVM parameters: " + checkString);
         }
+        // This is safe because we synchronize on LibSVMTrainer.class in the train method.
+        svm.rand.setSeed(localRNG.nextLong());
         return Collections.singletonList(svm.svm_train(problem, curParams));
     }
 

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
@@ -46,6 +46,10 @@ import java.util.logging.Logger;
 /**
  * A trainer for classification models that uses LibSVM.
  * <p>
+ * Note the train method is synchronized on {@code LibSVMTrainer.class} due to a global RNG in LibSVM.
+ * This is insufficient to ensure reproducibility if LibSVM is used directly in the same JVM as Tribuo, but
+ * avoids locking on classes Tribuo does not control.
+ * <p>
  * See:
  * <pre>
  * Chang CC, Lin CJ.
@@ -123,7 +127,8 @@ public class LibSVMClassificationTrainer extends LibSVMTrainer<Label> implements
         if(checkString != null) {
             throw new IllegalArgumentException("Error checking SVM parameters: " + checkString);
         }
-        // This is safe because we synchronize on LibSVMTrainer.class in the train method.
+        // This is safe because we synchronize on LibSVMTrainer.class in the train method to
+        // ensure there is no concurrent use of the rng.
         svm.rand.setSeed(localRNG.nextLong());
         return Collections.singletonList(svm.svm_train(problem, curParams));
     }

--- a/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
+++ b/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
@@ -201,11 +201,13 @@ public class TestLibSVM {
         LibSVMTrainer<Label> second = new LibSVMClassificationTrainer(params,seed);
         LibSVMModel<Label> secondModel = second.train(p.getA());
 
-        LibSVMModel<Label> thirdModel = second.train(p.getA());
+        LibSVMModel<Label> thirdModel = first.train(p.getA());
+        LibSVMModel<Label> fourthModel = second.train(p.getA());
 
         svm_model m = firstModel.getInnerModels().get(0);
         svm_model mTwo = secondModel.getInnerModels().get(0);
-        svm_model mThree = thirdModel.getInnerModels().get(0);
+        svm_model mThre = thirdModel.getInnerModels().get(0);
+        svm_model mFour = fourthModel.getInnerModels().get(0);
 
         // One and two use the same RNG seed and should be identical
         assertArrayEquals(m.sv_coef,mTwo.sv_coef);
@@ -213,8 +215,14 @@ public class TestLibSVM {
         assertArrayEquals(m.probB,mTwo.probB);
 
         // The RNG state of three has diverged and should produce a different model.
-        assertFalse(Arrays.equals(mTwo.probA,mThree.probA));
-        assertFalse(Arrays.equals(mTwo.probB,mThree.probB));
+        assertFalse(Arrays.equals(mTwo.probA,mFour.probA));
+        assertFalse(Arrays.equals(mTwo.probB,mFour.probB));
+
+        // The RNG state for three and four are the same so the two models should be the same.
+        assertArrayEquals(mFour.sv_coef,mThre.sv_coef);
+        assertArrayEquals(mFour.probA,mThre.probA);
+        assertArrayEquals(mFour.probB,mThre.probB);
+
     }
 
     @Test

--- a/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
+++ b/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
@@ -17,6 +17,7 @@
 package org.tribuo.classification.libsvm;
 
 import com.oracle.labs.mlrg.olcut.util.Pair;
+import libsvm.svm_model;
 import org.tribuo.CategoricalIDInfo;
 import org.tribuo.CategoricalInfo;
 import org.tribuo.Dataset;
@@ -184,6 +185,26 @@ public class TestLibSVM {
         Assertions.assertNotNull(features);
         Assertions.assertTrue(features.isEmpty());
         return m;
+    }
+
+    @Test
+    public void testReproducibility() {
+        Pair<Dataset<Label>,Dataset<Label>> p = LabelledDataGenerator.denseTrainTest();
+        long seed = 42L;
+        SVMParameters<Label> params = new SVMParameters<>(new SVMClassificationType(SVMMode.NU_SVC),KernelType.RBF);
+        params.setProbability();
+        LibSVMTrainer<Label> first = new LibSVMClassificationTrainer(params,seed);
+        LibSVMModel<Label> firstModel = first.train(p.getA());
+
+        LibSVMTrainer<Label> second = new LibSVMClassificationTrainer(params,seed);
+        LibSVMModel<Label> secondModel = second.train(p.getA());
+
+        svm_model m = firstModel.getInnerModels().get(0);
+        svm_model mTwo = secondModel.getInnerModels().get(0);
+
+        assertArrayEquals(m.sv_coef,mTwo.sv_coef);
+        assertArrayEquals(m.probA,mTwo.probA);
+        assertArrayEquals(m.probB,mTwo.probB);
     }
 
     @Test

--- a/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
+++ b/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
@@ -57,12 +57,14 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -199,12 +201,20 @@ public class TestLibSVM {
         LibSVMTrainer<Label> second = new LibSVMClassificationTrainer(params,seed);
         LibSVMModel<Label> secondModel = second.train(p.getA());
 
+        LibSVMModel<Label> thirdModel = second.train(p.getA());
+
         svm_model m = firstModel.getInnerModels().get(0);
         svm_model mTwo = secondModel.getInnerModels().get(0);
+        svm_model mThree = thirdModel.getInnerModels().get(0);
 
+        // One and two use the same RNG seed and should be identical
         assertArrayEquals(m.sv_coef,mTwo.sv_coef);
         assertArrayEquals(m.probA,mTwo.probA);
         assertArrayEquals(m.probB,mTwo.probB);
+
+        // The RNG state of three has diverged and should produce a different model.
+        assertFalse(Arrays.equals(mTwo.probA,mThree.probA));
+        assertFalse(Arrays.equals(mTwo.probB,mThree.probB));
     }
 
     @Test

--- a/Common/LibLinear/src/main/java/org/tribuo/common/liblinear/LibLinearTrainer.java
+++ b/Common/LibLinear/src/main/java/org/tribuo/common/liblinear/LibLinearTrainer.java
@@ -44,6 +44,8 @@ import java.util.logging.Logger;
 /**
  * A {@link Trainer} which wraps a liblinear-java trainer.
  * <p>
+ * Note the train method is synchronized due to a global RNG in liblinear-java.
+ * <p>
  * See:
  * <pre>
  * Fan RE, Chang KW, Hsieh CJ, Wang XR, Lin CJ.
@@ -125,7 +127,7 @@ public abstract class LibLinearTrainer<T extends Output<T>> implements Trainer<T
     }
 
     @Override
-    public LibLinearModel<T> train(Dataset<T> examples, Map<String, Provenance> runProvenance) {
+    public synchronized LibLinearModel<T> train(Dataset<T> examples, Map<String, Provenance> runProvenance) {
         if (examples.getOutputInfo().getUnknownCount() > 0) {
             throw new IllegalArgumentException("The supplied Dataset contained unknown Outputs, and this Trainer is supervised.");
         }

--- a/Common/LibLinear/src/main/java/org/tribuo/common/liblinear/LibLinearTrainer.java
+++ b/Common/LibLinear/src/main/java/org/tribuo/common/liblinear/LibLinearTrainer.java
@@ -45,6 +45,8 @@ import java.util.logging.Logger;
  * A {@link Trainer} which wraps a liblinear-java trainer.
  * <p>
  * Note the train method is synchronized on {@code LibLinearTrainer.class} due to a global RNG in liblinear-java.
+ * This is insufficient to ensure reproducibility if liblinear-java is used directly in the same JVM as Tribuo, but
+ * avoids locking on classes Tribuo does not control.
  * <p>
  * See:
  * <pre>

--- a/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMModel.java
+++ b/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMModel.java
@@ -86,7 +86,7 @@ public abstract class LibSVMModel<T extends Output<T>> extends Model<T> implemen
     /**
      * Returns an unmodifiable copy of the underlying list of libsvm models.
      * <p>
-     * Deprecated to unify the names across LibLinear, LibSVM and XGBoost.
+     * @deprecated Deprecated to unify the names across LibLinear, LibSVM and XGBoost.
      * @return The underlying model list.
      */
     @Deprecated

--- a/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMTrainer.java
+++ b/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMTrainer.java
@@ -36,10 +36,10 @@ import org.tribuo.util.Util;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.SplittableRandom;
 import java.util.logging.Logger;
 
 /**
@@ -112,6 +112,11 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
     @Config(description="Generate probability estimates.")
     private boolean probability = false;
 
+    @Config(description="RNG seed.")
+    private long seed = Trainer.DEFAULT_SEED;
+
+    private SplittableRandom rng;
+
     private int trainInvocationCounter = 0;
 
     /**
@@ -123,7 +128,7 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
      * Constructs a LibSVMTrainer from the parameters.
      * @param parameters The SVM parameters.
      */
-    protected LibSVMTrainer(SVMParameters<T> parameters) {
+    protected LibSVMTrainer(SVMParameters<T> parameters, long seed) {
         this.parameters = parameters.getParameters();
         // Unpack the parameters for the provenance system.
         this.svmType = parameters.getSvmType();
@@ -138,6 +143,8 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
         this.p = this.parameters.p;
         this.shrinking = this.parameters.shrinking == 1;
         this.probability = this.parameters.probability == 1;
+        this.seed = seed;
+        this.rng = new SplittableRandom(seed);
     }
 
     /**
@@ -158,6 +165,7 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
         parameters.p = p;
         parameters.shrinking = shrinking ? 1 : 0;
         parameters.probability = probability ? 1 : 0;
+        this.rng = new SplittableRandom(seed);
     }
 
     @Override
@@ -167,6 +175,8 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
         buffer.append("LibSVMTrainer(");
         buffer.append("svm_params=");
         buffer.append(SVMParameters.svmParamsToString(parameters));
+        buffer.append(",seed=");
+        buffer.append(seed);
         buffer.append(")");
 
         return buffer.toString();
@@ -185,16 +195,25 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
         ImmutableFeatureMap featureIDMap = examples.getFeatureIDMap();
         ImmutableOutputInfo<T> outputIDInfo = examples.getOutputIDInfo();
 
-        TrainerProvenance trainerProvenance = getProvenance();
-        ModelProvenance provenance = new ModelProvenance(LibSVMModel.class.getName(), OffsetDateTime.now(), examples.getProvenance(), trainerProvenance, runProvenance);
-        trainInvocationCounter++;
+        // Creates a new RNG, adds one to the invocation count, generates a local optimiser.
+        TrainerProvenance trainerProvenance;
+        SplittableRandom localRNG;
+        synchronized(this) {
+            localRNG = rng.split();
+            trainerProvenance = getProvenance();
+            trainInvocationCounter++;
+        }
 
         svm_parameter curParams = setupParameters(outputIDInfo);
 
         Pair<svm_node[][],double[][]> data = extractData(examples,outputIDInfo,featureIDMap);
 
-        List<svm_model> models = trainModels(curParams,featureIDMap.size()+1,data.getA(),data.getB());
+        List<svm_model> models;
+        synchronized (LibSVMTrainer.class) {
+            models = trainModels(curParams, featureIDMap.size() + 1, data.getA(), data.getB(), localRNG);
+        }
 
+        ModelProvenance provenance = new ModelProvenance(LibSVMModel.class.getName(), OffsetDateTime.now(), examples.getProvenance(), trainerProvenance, runProvenance);
         return createModel(provenance,featureIDMap,outputIDInfo,models);
     }
 
@@ -209,17 +228,18 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
     protected abstract LibSVMModel<T> createModel(ModelProvenance provenance, ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<T> outputIDInfo, List<svm_model> models);
 
     /**
-     * Train all the liblinear instances necessary for this dataset.
-     * @param curParams The LibLinear parameters.
+     * Train all the LibSVM instances necessary for this dataset.
+     * @param curParams The LibSVM parameters.
      * @param numFeatures The number of features in this dataset.
      * @param features The features themselves.
      * @param outputs The outputs.
-     * @return A list of liblinear models.
+     * @param localRNG The RNG to use for seeding LibSVM's RNG.
+     * @return A list of LibSVM models.
      */
-    protected abstract List<svm_model> trainModels(svm_parameter curParams, int numFeatures, svm_node[][] features, double[][] outputs);
+    protected abstract List<svm_model> trainModels(svm_parameter curParams, int numFeatures, svm_node[][] features, double[][] outputs, SplittableRandom localRNG);
 
     /**
-     * Extracts the features and {@link Output}s in LibLinear's format.
+     * Extracts the features and {@link Output}s in LibSVM's format.
      * @param data The input data.
      * @param outputInfo The output info.
      * @param featureMap The feature info.

--- a/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMTrainer.java
+++ b/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMTrainer.java
@@ -45,6 +45,10 @@ import java.util.logging.Logger;
 /**
  * A trainer that will train using libsvm's Java implementation.
  * <p>
+ * Note the train method is synchronized on {@code LibSVMTrainer.class} due to a global RNG in LibSVM.
+ * This is insufficient to ensure reproducibility if LibSVM is used directly in the same JVM as Tribuo, but
+ * avoids locking on classes Tribuo does not control.
+ * <p>
  * See:
  * <pre>
  * Chang CC, Lin CJ.
@@ -210,6 +214,7 @@ public abstract class LibSVMTrainer<T extends Output<T>> implements Trainer<T> {
 
         List<svm_model> models;
         synchronized (LibSVMTrainer.class) {
+            // localRNG is used to seed LibSVM's global RNG before each call to svm.svm_train
             models = trainModels(curParams, featureIDMap.size() + 1, data.getA(), data.getB(), localRNG);
         }
 

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionTrainer.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionTrainer.java
@@ -98,6 +98,8 @@ public class LibLinearRegressionTrainer extends LibLinearTrainer<Regressor> {
         ArrayList<Model> models = new ArrayList<>();
 
         for (int i = 0; i < outputs.length; i++) {
+            // Note this isn't sufficient for reproducibility as it doesn't cope with concurrency.
+            Linear.resetRandom();
             Problem data = new Problem();
 
             data.l = features.length;

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionTrainer.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionTrainer.java
@@ -43,6 +43,8 @@ import java.util.logging.Logger;
  * This generates an independent liblinear model for each regression dimension.
  * <p>
  * Note the train method is synchronized on {@code LibLinearTrainer.class} due to a global RNG in liblinear-java.
+ * This is insufficient to ensure reproducibility if liblinear-java is used directly in the same JVM as Tribuo, but
+ * avoids locking on classes Tribuo does not control.
  * <p>
  * See:
  * <pre>
@@ -109,6 +111,7 @@ public class LibLinearRegressionTrainer extends LibLinearTrainer<Regressor> {
             data.bias = 1.0;
 
             // Note this isn't sufficient for reproducibility as it doesn't cope with concurrency.
+            // Concurrency safety is handled by the global lock on LibLinearTrainer.class in LibLinearTrainer.train.
             Linear.resetRandom();
             models.add(Linear.train(data, curParams));
         }

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionTrainer.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionTrainer.java
@@ -42,6 +42,8 @@ import java.util.logging.Logger;
  * <p>
  * This generates an independent liblinear model for each regression dimension.
  * <p>
+ * Note the train method is synchronized on {@code LibLinearTrainer.class} due to a global RNG in liblinear-java.
+ * <p>
  * See:
  * <pre>
  * Fan RE, Chang KW, Hsieh CJ, Wang XR, Lin CJ.
@@ -98,8 +100,6 @@ public class LibLinearRegressionTrainer extends LibLinearTrainer<Regressor> {
         ArrayList<Model> models = new ArrayList<>();
 
         for (int i = 0; i < outputs.length; i++) {
-            // Note this isn't sufficient for reproducibility as it doesn't cope with concurrency.
-            Linear.resetRandom();
             Problem data = new Problem();
 
             data.l = features.length;
@@ -108,6 +108,8 @@ public class LibLinearRegressionTrainer extends LibLinearTrainer<Regressor> {
             data.n = numFeatures;
             data.bias = 1.0;
 
+            // Note this isn't sufficient for reproducibility as it doesn't cope with concurrency.
+            Linear.resetRandom();
             models.add(Linear.train(data, curParams));
         }
 

--- a/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionTrainer.java
+++ b/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionTrainer.java
@@ -22,6 +22,7 @@ import org.tribuo.Dataset;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
+import org.tribuo.Trainer;
 import org.tribuo.common.libsvm.LibSVMModel;
 import org.tribuo.common.libsvm.LibSVMTrainer;
 import org.tribuo.common.libsvm.SVMParameters;
@@ -37,6 +38,7 @@ import org.tribuo.util.Util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.SplittableRandom;
 import java.util.logging.Logger;
 
 /**
@@ -77,16 +79,26 @@ public class LibSVMRegressionTrainer extends LibSVMTrainer<Regressor> {
      * @param parameters The SVM parameters.
      */
     public LibSVMRegressionTrainer(SVMParameters<Regressor> parameters) {
-        this(parameters, false);
+        this(parameters, false, Trainer.DEFAULT_SEED);
     }
 
     /**
-     * Constructs a LibSVMRegressionTrainer using the supplied parameters.
+     * Constructs a LibSVMRegressionTrainer using the supplied parameters and {@link Trainer#DEFAULT_SEED}.
      * @param parameters The SVM parameters.
      * @param standardize Standardize the regression outputs before training.
      */
     public LibSVMRegressionTrainer(SVMParameters<Regressor> parameters, boolean standardize) {
-        super(parameters);
+        this(parameters,standardize,Trainer.DEFAULT_SEED);
+    }
+
+    /**
+     * Constructs a LibSVMRegressionTrainer using the supplied parameters and seed.
+     * @param parameters The SVM parameters.
+     * @param standardize Standardize the regression outputs before training.
+     * @param seed The RNG seed for LibSVM's internal RNG.
+     */
+    public LibSVMRegressionTrainer(SVMParameters<Regressor> parameters, boolean standardize, long seed) {
+        super(parameters,seed);
         this.standardize = standardize;
     }
 
@@ -121,7 +133,7 @@ public class LibSVMRegressionTrainer extends LibSVMTrainer<Regressor> {
     }
 
     @Override
-    protected List<svm_model> trainModels(svm_parameter curParams, int numFeatures, svm_node[][] features, double[][] outputs) {
+    protected List<svm_model> trainModels(svm_parameter curParams, int numFeatures, svm_node[][] features, double[][] outputs, SplittableRandom localRNG) {
         ArrayList<svm_model> models = new ArrayList<>();
 
         for (int i = 0; i < outputs.length; i++) {
@@ -132,13 +144,15 @@ public class LibSVMRegressionTrainer extends LibSVMTrainer<Regressor> {
             if (curParams.gamma == 0) {
                 curParams.gamma = 1.0 / numFeatures;
             }
+            // This is safe because we synchronize on LibSVMTrainer.class in the train method.
+            svm.rand.setSeed(localRNG.nextLong());
             if (standardize) {
                 Pair<Double,Double> meanVar = Util.meanAndVariance(outputs[i]);
                 double mean = meanVar.getA();
                 double variance = meanVar.getB();
                 Util.standardizeInPlace(outputs[i],mean,variance);
                 String checkString = svm.svm_check_parameter(problem, curParams);
-                if(checkString != null) {
+                if (checkString != null) {
                     throw new IllegalArgumentException("Error checking SVM parameters: " + checkString);
                 }
                 svm_model trained = svm.svm_train(problem, curParams);


### PR DESCRIPTION
### Description
This change fixes Tribuo's LibLinear and LibSVM interfaces so they use trackable RNG states. 

LibLinear has a protected global RNG with a reset method (to a fixed seed), so now Tribuo sequentialises all LibLinear training runs under a lock on `LibLinearTrainer.class` and resets the seed before each call to `Linear.train`. There's a new reproducibility test in the classification LibLinear module which fails without these changes. This fix may change depending on the resolution of https://github.com/bwaldvogel/liblinear-java/issues/40.

LibSVM has a public global RNG so we use Tribuo's standard RNG idiom (a per train call `localRNG` split from the trainer's instance of `SplittableRandom`), LibSVM's global RNG's seed is set to a draw from `localRNG` and all LibSVM training runs under a lock on `LibSVMTrainer.class`. There's a new reproducibility test in the classification LibSVM module which fails without these changes. Unfortunately it's quite a chatty test as LibSVM prints a lot during this run.

### Motivation
We need Tribuo models to be reproducible.
