### PR TITLE
Two small fixes for provenance.

### DIFF
--- a/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformTrainer.java
@@ -112,7 +112,7 @@ public final class TransformTrainer<T extends Output<T>> implements Trainer<T> {
     @Override
     public TransformedModel<T> train(Dataset<T> examples, Map<String, Provenance> instanceProvenance) {
         
-        logger.fine(String.format("Creating transformers"));
+        logger.fine("Creating transformers");
 
         TransformerMap transformerMap = examples.createTransformers(transformations, includeImplicitZeroFeatures);
 
@@ -121,12 +121,17 @@ public final class TransformTrainer<T extends Output<T>> implements Trainer<T> {
         Dataset<T> transformedDataset = transformerMap.transformDataset(examples,densify);
 
         logger.fine("Running inner trainer");
-        
-        Model<T> innerModel = innerTrainer.train(transformedDataset);
 
-        ModelProvenance provenance = new ModelProvenance(TransformedModel.class.getName(), OffsetDateTime.now(), transformedDataset.getProvenance(), getProvenance(), instanceProvenance);
+        TrainerProvenance provenance;
+        Model<T> innerModel;
+        synchronized (innerTrainer) {
+            provenance = getProvenance();
+            innerModel = innerTrainer.train(transformedDataset);
+        }
 
-        return new TransformedModel<>(provenance,innerModel,transformerMap,densify);
+        ModelProvenance modelProvenance = new ModelProvenance(TransformedModel.class.getName(), OffsetDateTime.now(), transformedDataset.getProvenance(), provenance, instanceProvenance);
+
+        return new TransformedModel<>(modelProvenance,innerModel,transformerMap,densify);
     }
 
     @Override


### PR DESCRIPTION
### Description
Switches around how the provenance is captured in TransformTrainer so it has the right values, and updates XGBoostExternalModel so there is a way to create a model from an in-memory XGBoost `Booster`, which required an extra constructor on `ExternalTrainerProvenance`.

### Motivation
The transform trainer was capturing the incorrect state of the inner trainer's RNG, and the XGBoost external model creator would always throw an exception if you didn't have a valid URL to a path on disk that it could hash.
