### PR TITLE
Normalizes the URL created from paths in LibSVMDataSource

### DIFF
--- a/Core/src/main/java/org/tribuo/datasource/LibSVMDataSource.java
+++ b/Core/src/main/java/org/tribuo/datasource/LibSVMDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public final class LibSVMDataSource<T extends Output<T>> implements Configurable
      * @throws IOException If the file could not be read or is an invalid format.
      */
     public LibSVMDataSource(Path path, OutputFactory<T> outputFactory) throws IOException {
-        this(path,path.toUri().toURL(),outputFactory,false,false,0);
+        this(path,path.normalize().toUri().toURL(),outputFactory,false,false,0);
     }
 
     /**
@@ -126,7 +126,7 @@ public final class LibSVMDataSource<T extends Output<T>> implements Configurable
      * @throws IOException If the file could not be read or is an invalid format.
      */
     public LibSVMDataSource(Path path, OutputFactory<T> outputFactory, boolean zeroIndexed, int maxFeatureID) throws IOException {
-        this(path,path.toUri().toURL(),outputFactory,true,zeroIndexed,maxFeatureID);
+        this(path,path.normalize().toUri().toURL(),outputFactory,true,zeroIndexed,maxFeatureID);
     }
 
     /**

--- a/Core/src/main/java/org/tribuo/datasource/LibSVMDataSource.java
+++ b/Core/src/main/java/org/tribuo/datasource/LibSVMDataSource.java
@@ -106,7 +106,7 @@ public final class LibSVMDataSource<T extends Output<T>> implements Configurable
      * @throws IOException If the file could not be read or is an invalid format.
      */
     public LibSVMDataSource(Path path, OutputFactory<T> outputFactory) throws IOException {
-        this(path,path.normalize().toUri().toURL(),outputFactory,false,false,0);
+        this(path.normalize(),path.normalize().toUri().toURL(),outputFactory,false,false,0);
     }
 
     /**
@@ -126,7 +126,7 @@ public final class LibSVMDataSource<T extends Output<T>> implements Configurable
      * @throws IOException If the file could not be read or is an invalid format.
      */
     public LibSVMDataSource(Path path, OutputFactory<T> outputFactory, boolean zeroIndexed, int maxFeatureID) throws IOException {
-        this(path,path.normalize().toUri().toURL(),outputFactory,true,zeroIndexed,maxFeatureID);
+        this(path.normalize(),path.normalize().toUri().toURL(),outputFactory,true,zeroIndexed,maxFeatureID);
     }
 
     /**


### PR DESCRIPTION
### Description
This change normalizes the path before it is converted into a URL in LibSVMDataSource. Adds a test for the fixed behaviour.

### Motivation
`LibSVMDataSource.postConfig` checks to see if the URL and path are the same before throwing an exception if both are set. The `FileProvenance` constructor normalizes and absolutes the path before it is created, however the original codepath in `LibSVMDataSource` did not do this to the URL which is created. This means if the path has a relative element in it like `.` or `..` then the URL created retains the relative element and the path has it normalized out, meaning the two values are not equal and an exception is thrown when the configuration is instantiated from the provenance of a `LibSVMDataSource`.
