### PR TITLE
Adding some accessors to allow deeper model equality checks

### DIFF
--- a/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMModel.java
+++ b/Common/LibSVM/src/main/java/org/tribuo/common/libsvm/LibSVMModel.java
@@ -167,4 +167,42 @@ public abstract class LibSVMModel<T extends Output<T>> extends Model<T> implemen
         return newModel;
     }
 
+    /**
+     * Checks for equality between two svm_models.
+     * <p>
+     * Equality is defined as bit-wise exact for SV, rho, sv_coeff, probA and probB.
+     * @param first The first model.
+     * @param second The second model.
+     * @return True if the models are identical.
+     */
+    public static boolean modelEquals(svm_model first, svm_model second) {
+        boolean svCoeffEquals = Arrays.deepEquals(first.sv_coef, second.sv_coef);
+        boolean probAEquals = Arrays.equals(first.probA, second.probA);
+        boolean probBEquals = Arrays.equals(first.probB, second.probB);
+        boolean nSVEquals = Arrays.equals(first.nSV, second.nSV);
+        boolean rhoEquals = Arrays.equals(first.rho, second.rho);
+        boolean labelEquals = Arrays.equals(first.label, second.label);
+        if (svCoeffEquals && probAEquals && probBEquals && nSVEquals && rhoEquals && labelEquals) {
+            // Check SVs.
+            try {
+                for (int i = 0; i < first.SV.length; i++) {
+                    for (int j = 0; j < first.SV[i].length; j++) {
+                        svm_node firstNode = first.SV[i][j];
+                        svm_node secondNode = second.SV[i][j];
+                        if (firstNode.index != secondNode.index) {
+                            return false;
+                        } else if (Double.compare(firstNode.value,secondNode.value) != 0) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            } catch (NullPointerException e) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/TreeModel.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/TreeModel.java
@@ -279,4 +279,12 @@ public class TreeModel<T extends Output<T>> extends SparseModel<T> {
         return "TreeModel(description="+provenance.toString()+",\n\t\ttree="+root.toString()+")";
     }
 
+    /**
+     * Returns the root node of this tree.
+     * @return The root node.
+     */
+    public Node<T> getRoot() {
+        return root;
+    }
+
 }

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
@@ -109,7 +109,8 @@ public class LibLinearRegressionModel extends LibLinearModel<Regressor> {
         PriorityQueue<Pair<String, Double>> q = new PriorityQueue<>(maxFeatures, comparator);
 
         for (int i = 0; i < featureWeights.length; i++) {
-            int numFeatures = featureWeights[i].length;
+            // Exclude bias
+            int numFeatures = featureWeights[i].length - 1;
             for (int j = 0; j < numFeatures; j++) {
                 Pair<String, Double> cur = new Pair<>(featureIDMap.get(j).getName(), featureWeights[i][j]);
                 if (maxFeatures < 0 || q.size() < maxFeatures) {

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/IndependentRegressionTreeModel.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/IndependentRegressionTreeModel.java
@@ -289,4 +289,24 @@ public final class IndependentRegressionTreeModel extends TreeModel<Regressor> {
         return "IndependentTreeModel(description="+provenance.toString()+",\n"+sb.toString()+")";
     }
 
+    /**
+     * Returns an unmodifiable view on the root node collection.
+     * <p>
+     * The nodes themselves are immutable.
+     * @return The root node collection.
+     */
+    public Map<String,Node<Regressor>> getRoots() {
+        return Collections.unmodifiableMap(roots);
+    }
+
+    /**
+     * Returns null, as this model contains multiple roots, one per regression output dimension.
+     * <p>
+     * Use {@link #getRoots()} instead.
+     * @return null.
+     */
+    @Override
+    public Node<Regressor> getRoot() {
+        return null;
+    }
 }


### PR DESCRIPTION
### Description
Added accessors for TreeModel to get the root node(s) so they can be compared for equality using their equals implementations. Added an equality method for two `svm_model`s as there isn't one on `svm_model`. Also fixed a bug in LibLinearRegressionModel.getTopFeatures where it tried to lookup the bias and threw an exception.

### Motivation
We use the expanded model equality checks when testing the reproducibility work.
