### PR TITLE
Bumping CI to Java 17

### DIFF
--- a/.github/workflows/maven-macos.yml
+++ b/.github/workflows/maven-macos.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Tribuo CI (macOS x86_64, OpenJDK 8, 11, latest)
+name: Tribuo CI (macOS x86_64, OpenJDK 8, 11, 17)
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 16 ]
+        java: [ 8, 11, 17 ]
     name: macOS OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Tribuo CI (Ubuntu x86_64, OpenJDK 8, 11, latest)
+name: Tribuo CI (Ubuntu x86_64, OpenJDK 8, 11, 17)
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 16 ]
+        java: [ 8, 11, 17 ]
     name: Ubuntu OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Tribuo CI (Windows x86_64, OpenJDK 8, 11, latest)
+name: Tribuo CI (Windows x86_64, OpenJDK 8, 11, 17)
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 8, 11, 16 ]
+        java: [ 8, 11, 17 ]
     name: Windows OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Description
Runs the CI on Java 8, 11 and 17.

### Motivation
We document that Tribuo is tested on LTS versions of Java.
