### PR TITLE
ONNX export support for LibLinear and LibSVM

### DIFF
--- a/Classification/LibLinear/pom.xml
+++ b/Classification/LibLinear/pom.xml
@@ -57,6 +57,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-onnx</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/Classification/LibLinear/pom.xml
+++ b/Classification/LibLinear/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+  ~ Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -48,6 +48,12 @@
             <artifactId>tribuo-core</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-onnx</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationModel.java
+++ b/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationModel.java
@@ -389,15 +389,15 @@ public class LibLinearClassificationModel extends LibLinearModel<Label> implemen
 
         // Make gemm
         String[] gemmInputs = new String[]{inputValueProto.getName(),weightBuilder.getName(),biasBuilder.getName()};
-        OnnxMl.NodeProto gemm = ONNXOperators.GEMM.build(context,gemmInputs,new String[]{context.generateUniqueName("gemm_output")});
+        OnnxMl.NodeProto gemm = ONNXOperators.GEMM.build(context,gemmInputs,context.generateUniqueName("gemm_output"));
         graphBuilder.addNode(gemm);
 
         if (model.isProbabilityModel()) {
             // Make output normalizer if producing probabilities
-            graphBuilder.addNode(ONNXOperators.SOFTMAX.build(context,new String[]{gemm.getOutput(0)},new String[]{"output"}, Collections.singletonMap("axis",1)));
+            graphBuilder.addNode(ONNXOperators.SOFTMAX.build(context,gemm.getOutput(0),"output", Collections.singletonMap("axis",1)));
         } else {
             // Add identity path if not
-            graphBuilder.addNode(ONNXOperators.IDENTITY.build(context,new String[]{gemm.getOutput(0)},new String[]{"output"}));
+            graphBuilder.addNode(ONNXOperators.IDENTITY.build(context,gemm.getOutput(0),"output"));
         }
 
         return graphBuilder.build();

--- a/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationModel.java
+++ b/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationModel.java
@@ -306,6 +306,13 @@ public class LibLinearClassificationModel extends LibLinearModel<Label> implemen
         builder.setDocString(toString());
         builder.addOpsetImport(ONNXOperators.getOpsetProto());
         builder.setIrVersion(6);
+
+        // Extract provenance and store in metadata
+        OnnxMl.StringStringEntryProto.Builder metaBuilder = OnnxMl.StringStringEntryProto.newBuilder();
+        metaBuilder.setKey(ONNXExportable.PROVENANCE_METADATA_FIELD);
+        metaBuilder.setValue(serializeProvenance(getProvenance()));
+        builder.addMetadataProps(metaBuilder.build());
+
         return builder.build();
     }
 

--- a/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationModel.java
+++ b/Classification/LibLinear/src/main/java/org/tribuo/classification/liblinear/LibLinearClassificationModel.java
@@ -312,6 +312,7 @@ public class LibLinearClassificationModel extends LibLinearModel<Label> implemen
     @Override
     public OnnxMl.GraphProto exportONNXGraph(ONNXContext context) {
         OnnxMl.GraphProto.Builder graphBuilder = OnnxMl.GraphProto.newBuilder();
+        graphBuilder.setName("LibLinear-Classification");
 
         de.bwaldvogel.liblinear.Model model = models.get(0);
         double[] weights = model.getFeatureWeights();

--- a/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
+++ b/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
@@ -16,9 +16,7 @@
 
 package org.tribuo.classification.liblinear;
 
-import ai.onnxruntime.OrtEnvironment;
 import ai.onnxruntime.OrtException;
-import ai.onnxruntime.OrtSession;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.CategoricalIDInfo;
 import org.tribuo.CategoricalInfo;
@@ -30,8 +28,6 @@ import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Model;
 import org.tribuo.Prediction;
-import org.tribuo.VariableIDInfo;
-import org.tribuo.VariableInfo;
 import org.tribuo.classification.Label;
 import org.tribuo.classification.LabelFactory;
 import org.tribuo.classification.evaluation.LabelEvaluation;
@@ -48,11 +44,7 @@ import org.tribuo.impl.ListExample;
 import de.bwaldvogel.liblinear.FeatureNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.tribuo.interop.onnx.DenseTransformer;
-import org.tribuo.interop.onnx.LabelTransformer;
-import org.tribuo.interop.onnx.ONNXExternalModel;
 import org.tribuo.interop.onnx.OnnxTestUtils;
-import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.test.Helpers;
 import org.tribuo.util.tokens.impl.BreakIteratorTokenizer;
 
@@ -64,21 +56,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestLibLinearModel {
     private static final Logger logger = Logger.getLogger(TestLibLinearModel.class.getName());

--- a/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
+++ b/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.tribuo.interop.onnx.DenseTransformer;
 import org.tribuo.interop.onnx.LabelTransformer;
 import org.tribuo.interop.onnx.ONNXExternalModel;
+import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.test.Helpers;
 import org.tribuo.util.tokens.impl.BreakIteratorTokenizer;
 
@@ -66,12 +67,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -318,6 +321,14 @@ public class TestLibLinearModel {
                     }
                 }
             }
+
+            // Check that the provenance can be extracted and is the same
+            ModelProvenance modelProv = model.getProvenance();
+            Optional<ModelProvenance> optProv = onnxModel.getTribuoProvenance();
+            assertTrue(optProv.isPresent());
+            ModelProvenance onnxProv = optProv.get();
+            assertNotSame(onnxProv, modelProv);
+            assertEquals(modelProv,onnxProv);
 
             onnxModel.close();
         } else {

--- a/Classification/LibSVM/pom.xml
+++ b/Classification/LibSVM/pom.xml
@@ -53,6 +53,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-onnx</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/Classification/LibSVM/pom.xml
+++ b/Classification/LibSVM/pom.xml
@@ -47,6 +47,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-onnx</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationModel.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationModel.java
@@ -180,6 +180,13 @@ public class LibSVMClassificationModel extends LibSVMModel<Label> implements ONN
         builder.setDocString(toString());
         builder.addOpsetImport(ONNXOperators.getOpsetProto());
         builder.setIrVersion(6);
+
+        // Extract provenance and store in metadata
+        OnnxMl.StringStringEntryProto.Builder metaBuilder = OnnxMl.StringStringEntryProto.newBuilder();
+        metaBuilder.setKey(ONNXExportable.PROVENANCE_METADATA_FIELD);
+        metaBuilder.setValue(serializeProvenance(getProvenance()));
+        builder.addMetadataProps(metaBuilder.build());
+
         return builder.build();
     }
 

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationModel.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationModel.java
@@ -213,7 +213,7 @@ public class LibSVMClassificationModel extends LibSVMModel<Label> implements ONN
 
         // Build SVM node
         String[] outputs = new String[]{context.generateUniqueName("class_output"),outputValueProto.getName()};
-        OnnxMl.NodeProto svm = ONNXOperators.SVM_CLASSIFIER.build(context,new String[]{inputValueProto.getName()},outputs,attributes);
+        OnnxMl.NodeProto svm = ONNXOperators.SVM_CLASSIFIER.build(context,inputValueProto.getName(),outputs,attributes);
         graphBuilder.addNode(svm);
 
         return graphBuilder.build();

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationModel.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationModel.java
@@ -18,6 +18,9 @@ package org.tribuo.classification.libsvm;
 
 import ai.onnx.proto.OnnxMl;
 import com.oracle.labs.mlrg.olcut.util.Pair;
+import libsvm.svm;
+import libsvm.svm_model;
+import libsvm.svm_node;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
@@ -33,9 +36,6 @@ import org.tribuo.onnx.ONNXOperators;
 import org.tribuo.onnx.ONNXShape;
 import org.tribuo.onnx.ONNXUtils;
 import org.tribuo.provenance.ModelProvenance;
-import libsvm.svm;
-import libsvm.svm_model;
-import libsvm.svm_node;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
+++ b/Classification/LibSVM/src/main/java/org/tribuo/classification/libsvm/LibSVMClassificationTrainer.java
@@ -18,6 +18,11 @@ package org.tribuo.classification.libsvm;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
 import com.oracle.labs.mlrg.olcut.util.Pair;
+import libsvm.svm;
+import libsvm.svm_model;
+import libsvm.svm_node;
+import libsvm.svm_parameter;
+import libsvm.svm_problem;
 import org.tribuo.Dataset;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
@@ -29,11 +34,6 @@ import org.tribuo.common.libsvm.LibSVMModel;
 import org.tribuo.common.libsvm.LibSVMTrainer;
 import org.tribuo.common.libsvm.SVMParameters;
 import org.tribuo.provenance.ModelProvenance;
-import libsvm.svm;
-import libsvm.svm_model;
-import libsvm.svm_node;
-import libsvm.svm_parameter;
-import libsvm.svm_problem;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
+++ b/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
@@ -16,9 +16,7 @@
 
 package org.tribuo.classification.libsvm;
 
-import ai.onnxruntime.OrtEnvironment;
 import ai.onnxruntime.OrtException;
-import ai.onnxruntime.OrtSession;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 import libsvm.svm_model;
 import libsvm.svm_node;
@@ -34,8 +32,6 @@ import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Model;
 import org.tribuo.Prediction;
-import org.tribuo.VariableIDInfo;
-import org.tribuo.VariableInfo;
 import org.tribuo.classification.Label;
 import org.tribuo.classification.LabelFactory;
 import org.tribuo.classification.evaluation.LabelEvaluation;
@@ -53,13 +49,7 @@ import org.tribuo.data.text.impl.SimpleTextDataSource;
 import org.tribuo.data.text.impl.TextFeatureExtractorImpl;
 import org.tribuo.dataset.DatasetView;
 import org.tribuo.impl.ListExample;
-import org.tribuo.interop.onnx.DenseTransformer;
-import org.tribuo.interop.onnx.LabelOneVOneTransformer;
-import org.tribuo.interop.onnx.LabelTransformer;
-import org.tribuo.interop.onnx.ONNXExternalModel;
 import org.tribuo.interop.onnx.OnnxTestUtils;
-import org.tribuo.interop.onnx.OutputTransformer;
-import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.test.Helpers;
 import org.tribuo.util.tokens.impl.BreakIteratorTokenizer;
 
@@ -75,14 +65,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
+++ b/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
@@ -248,7 +248,6 @@ public class TestLibSVM {
     public void testOnnxSerialization() throws IOException, OrtException {
         Pair<Dataset<Label>, Dataset<Label>> binary = LabelledDataGenerator.binarySparseTrainTest();
 
-        /*
         Map<Label,Integer> mapping = new HashMap<>();
         mapping.put(new Label("Foo"),0);
         mapping.put(new Label("Bar"),1);
@@ -258,7 +257,6 @@ public class TestLibSVM {
         ImmutableDataset<Label> newTest = ImmutableDataset.copyDataset(binary.getB(), binary.getA().getFeatureIDMap(), newInfo);
 
         testOnnxSerialization(new Pair<>(newTrain,newTest), C_LINEAR);
-         */
 
         testOnnxSerialization(binary, C_LINEAR);
         testOnnxSerialization(binary, C_RBF);

--- a/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
+++ b/Classification/LibSVM/src/test/java/org/tribuo/classification/libsvm/TestLibSVM.java
@@ -58,6 +58,7 @@ import org.tribuo.interop.onnx.LabelOneVOneTransformer;
 import org.tribuo.interop.onnx.LabelTransformer;
 import org.tribuo.interop.onnx.ONNXExternalModel;
 import org.tribuo.interop.onnx.OutputTransformer;
+import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.test.Helpers;
 import org.tribuo.util.tokens.impl.BreakIteratorTokenizer;
 
@@ -73,12 +74,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -342,6 +345,14 @@ public class TestLibSVM {
                     }
                 }
             }
+
+            // Check that the provenance can be extracted and is the same
+            ModelProvenance modelProv = model.getProvenance();
+            Optional<ModelProvenance> optProv = onnxModel.getTribuoProvenance();
+            assertTrue(optProv.isPresent());
+            ModelProvenance onnxProv = optProv.get();
+            assertNotSame(onnxProv, modelProv);
+            assertEquals(modelProv,onnxProv);
 
             onnxModel.close();
         } else {

--- a/Core/src/main/java/org/tribuo/onnx/ONNXAttribute.java
+++ b/Core/src/main/java/org/tribuo/onnx/ONNXAttribute.java
@@ -147,6 +147,7 @@ public final class ONNXAttribute {
                 } else {
                     throw new IllegalArgumentException("Expected TensorProto, found " + value.getClass() + " with value " + value);
                 }
+                break;
             case GRAPH:
             case SPARSE_TENSOR:
             case TENSORS:

--- a/Core/src/main/java/org/tribuo/onnx/ONNXOperators.java
+++ b/Core/src/main/java/org/tribuo/onnx/ONNXOperators.java
@@ -144,7 +144,6 @@ public enum ONNXOperators {
             new ONNXAttribute("transB", OnnxMl.AttributeProto.AttributeType.INT,false)
     )),
     /**
-     * Greater than, returns the element-wise greater than operation on the two tensors.
      * <p>
      * Tensors must be broadcastable to the same shape.
      */
@@ -172,6 +171,35 @@ public enum ONNXOperators {
      * the second or third input. When the test is true, return the second input, otherwise return the third input.
      */
     WHERE("Where",3,1)
+    /**
+     * SVM Classifier.
+     * <ul>
+     *     <li>{@code classlabels_ints} - Class labels if using integer labels. One and only one of the 'classlabels_*' attributes must be defined.</li>
+     *     <li>{@code classlabels_strings} - Class labels if using string labels. One and only one of the 'classlabels_*' attributes must be defined.</li>
+     *     <li>{@code coefficients} - SVM coefficients</li>
+     *     <li>{@code kernel_params} - Tuple of gamma, coef0 and degree. Set to zero if unused by the kernel.</li>
+     *     <li>{@code kernel_type} - One of 'LINEAR,' 'POLY,' 'RBF,' 'SIGMOID'.</li>
+     *     <li>{@code post_transforms} - Transform to apply to the score (usually unused by SVMs), one of 'NONE,' 'SOFTMAX,' 'LOGISTIC,' 'SOFTMAX_ZERO,' or 'PROBIT'.</li>
+     *     <li>{@code prob_a} - Probability coefficients, if set must be the same size as prob_b.</li>
+     *     <li>{@code prob_b} - Probability coefficients, if set must be the same size as prob_a.</li>
+     *     <li>{@code rho} - Rho vector.</li>
+     *     <li>{@code support_vectors} - linearised support vectors.</li>
+     *     <li>{@code vectors_per_class} - the number of support vectors in each class.</li>
+     * </ul>
+     */
+    SVM_CLASSIFIER("SVMClassifier",1,2, Arrays.asList(
+            new ONNXAttribute("classlabels_ints",OnnxMl.AttributeProto.AttributeType.INTS,false),
+            new ONNXAttribute("classlabels_strings",OnnxMl.AttributeProto.AttributeType.STRINGS,false),
+            new ONNXAttribute("coefficients",OnnxMl.AttributeProto.AttributeType.FLOATS,true),
+            new ONNXAttribute("kernel_params",OnnxMl.AttributeProto.AttributeType.FLOATS,true),
+            new ONNXAttribute("kernel_type",OnnxMl.AttributeProto.AttributeType.STRING,false),
+            new ONNXAttribute("post_transform",OnnxMl.AttributeProto.AttributeType.STRING,false),
+            new ONNXAttribute("prob_a",OnnxMl.AttributeProto.AttributeType.FLOATS,false),
+            new ONNXAttribute("prob_b",OnnxMl.AttributeProto.AttributeType.FLOATS,false),
+            new ONNXAttribute("rho",OnnxMl.AttributeProto.AttributeType.FLOATS,true),
+            new ONNXAttribute("support_vectors",OnnxMl.AttributeProto.AttributeType.FLOATS,true),
+            new ONNXAttribute("vectors_per_class",OnnxMl.AttributeProto.AttributeType.INTS,true)
+    ))
     ;
 
     /**

--- a/Core/src/main/java/org/tribuo/onnx/ONNXOperators.java
+++ b/Core/src/main/java/org/tribuo/onnx/ONNXOperators.java
@@ -350,6 +350,32 @@ public enum ONNXOperators {
     }
 
     /**
+     * Builds this node based on the supplied input and outputs.
+     * Throws {@link IllegalArgumentException} if the number of inputs or outputs is wrong.
+     * @param context The onnx context used to ensure this node has a unique name.
+     * @param input The name of the input.
+     * @param outputs The names of the outputs.
+     * @return The NodeProto.
+     */
+    public OnnxMl.NodeProto build(ONNXContext context, String input, String[] outputs) {
+        return build(context,new String[]{input},outputs,Collections.emptyMap());
+    }
+
+    /**
+     * Builds this node based on the supplied input and outputs.
+     * Throws {@link IllegalArgumentException} if the number of inputs, outputs or attributes is wrong.
+     * May throw {@link UnsupportedOperationException} if the attribute type is not supported.
+     * @param context The onnx context used to ensure this node has a unique name.
+     * @param input The name of the input.
+     * @param outputs The names of the outputs.
+     * @param attributeValues The attribute names and values.
+     * @return The NodeProto.
+     */
+    public OnnxMl.NodeProto build(ONNXContext context, String input, String[] outputs, Map<String,Object> attributeValues) {
+        return build(context,new String[]{input},outputs,attributeValues);
+    }
+
+    /**
      * Builds this node based on the supplied inputs and outputs.
      * Throws {@link IllegalArgumentException} if the number of inputs or outputs is wrong.
      * @param context The onnx context used to ensure this node has a unique name.

--- a/Interop/ONNX/src/main/java/org/tribuo/interop/onnx/LabelOneVOneTransformer.java
+++ b/Interop/ONNX/src/main/java/org/tribuo/interop/onnx/LabelOneVOneTransformer.java
@@ -94,7 +94,7 @@ public final class LabelOneVOneTransformer extends LabelTransformer {
                     throw new IllegalArgumentException("Expected the first element to be a float OnnxTensor, found " + inputs.get(0));
                 }
             } else if (inputs.size() == 2) {
-                if (inputs.get(1) instanceof OnnxTensor) {
+                if (inputs.get(0) instanceof OnnxTensor && inputs.get(1) instanceof OnnxTensor) {
                     OnnxTensor outputLabels = (OnnxTensor) inputs.get(0);
                     OnnxTensor outputScores = (OnnxTensor) inputs.get(1);
                     if (outputScores.getInfo().type == OnnxJavaType.FLOAT) {

--- a/Interop/ONNX/src/main/java/org/tribuo/interop/onnx/LabelOneVOneTransformer.java
+++ b/Interop/ONNX/src/main/java/org/tribuo/interop/onnx/LabelOneVOneTransformer.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.interop.onnx;
+
+import ai.onnxruntime.OnnxJavaType;
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OnnxValue;
+import ai.onnxruntime.OrtException;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
+import org.tribuo.ImmutableOutputInfo;
+import org.tribuo.classification.Label;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+public final class LabelOneVOneTransformer extends LabelTransformer {
+    private static final long serialVersionUID = 1L;
+    private static final Logger logger = Logger.getLogger(LabelTransformer.class.getName());
+
+    /**
+     * Constructs a Label transformer that operates on a one v one output and produces scores via voting.
+     */
+    public LabelOneVOneTransformer() {
+        super(false);
+    }
+
+    @Override
+    public void postConfig() {
+        if (generatesProbabilities) {
+            throw new PropertyException("", "generatesProbabilities", "generatesProbabilities must not be set to true for this class.");
+        }
+    }
+
+    /**
+     * Rationalises the output of an onnx model into a standard format suitable for
+     * downstream work in Tribuo.
+     *
+     * @param inputs       The onnx model output.
+     * @param outputIDInfo The output id mapping.
+     * @return A 2d array of outputs, the first dimension is batch size, the second dimension is the output space.
+     */
+    @Override
+    protected float[][] getBatchPredictions(List<OnnxValue> inputs, ImmutableOutputInfo<Label> outputIDInfo) {
+        try {
+            if (inputs.size() == 1) {
+                // Single OnnxTensor [batchSize][(numOutputs*(numOutputs-1))/2]
+                if (inputs.get(0) instanceof OnnxTensor) {
+                    OnnxTensor outputScores = (OnnxTensor) inputs.get(0);
+                    if (outputScores.getInfo().type == OnnxJavaType.FLOAT) {
+                        long[] shape = outputScores.getInfo().getShape();
+                        if ((shape.length == 2) && (shape[1] == (outputIDInfo.size() * ((long) outputIDInfo.size() - 1) / 2))) {
+                            // Assume the output is one v one and unpack it
+                            // Check that the labels and scores are the right shapes
+                            // Yes it's annoying LibSVM does it this way.
+                            int numOutputs = outputIDInfo.size();
+                            float[][] onevone = (float[][]) outputScores.getValue();
+                            float[][] scores = new float[(int) shape[0]][numOutputs];
+                            for (int k = 0; k < shape[0]; k++) {
+                                int counter = 0;
+                                for (int i = 0; i < numOutputs; i++) {
+                                    for (int j = i + 1; j < numOutputs; j++) {
+                                        if (onevone[k][counter] > 0) {
+                                            scores[k][i]++;
+                                        } else {
+                                            scores[k][j]++;
+                                        }
+                                        counter++;
+                                    }
+                                }
+                            }
+                            return scores;
+                        } else {
+                            throw new IllegalArgumentException("Invalid shape for the score tensor, expected shape [batchSize,(numOutputs*(numOutputs-1))/2], found " + Arrays.toString(shape));
+                        }
+                    } else {
+                        throw new IllegalArgumentException("Expected the first element to be a float OnnxTensor, found " + inputs.get(0));
+                    }
+                } else {
+                    throw new IllegalArgumentException("Expected the first element to be a float OnnxTensor, found " + inputs.get(0));
+                }
+            } else if (inputs.size() == 2) {
+                if (inputs.get(1) instanceof OnnxTensor) {
+                    OnnxTensor outputLabels = (OnnxTensor) inputs.get(0);
+                    OnnxTensor outputScores = (OnnxTensor) inputs.get(1);
+                    if (outputScores.getInfo().type == OnnxJavaType.FLOAT) {
+                        long[] shape = outputScores.getInfo().getShape();
+                        if ((shape.length == 2) && (shape[1] == 2 || (shape[1] == (outputIDInfo.size() * ((long) outputIDInfo.size() - 1) / 2)))) {
+                            // Assume the output is one v one and unpack it
+                            long[] labelsShape = outputLabels.getInfo().getShape();
+                            // Check that the labels and scores are the right shapes
+                            if ((labelsShape.length == 1) && (labelsShape[0] == shape[0])) {
+                                // Yes it's annoying LibSVM does it this way.
+                                int numOutputs = outputIDInfo.size();
+                                float[][] onevone = (float[][]) outputScores.getValue();
+                                float[][] scores = new float[(int) shape[0]][numOutputs];
+                                for (int k = 0; k < shape[0]; k++) {
+                                    int counter = 0;
+                                    for (int i = 0; i < numOutputs; i++) {
+                                        for (int j = i + 1; j < numOutputs; j++) {
+                                            if (onevone[k][counter] > 0) {
+                                                scores[k][i]++;
+                                            } else {
+                                                scores[k][j]++;
+                                            }
+                                            counter++;
+                                        }
+                                    }
+                                }
+                                return scores;
+                            } else {
+                                throw new IllegalArgumentException("Invalid shape for labels, did not match the size of the scores, found labels.shape " + Arrays.toString(labelsShape) + ", and scores.shape " + Arrays.toString(shape));
+                            }
+                        } else {
+                            throw new IllegalArgumentException("Invalid shape for the score tensor, expected shape [batchSize,(numOutputs*(numOutputs-1))/2], found " + Arrays.toString(shape));
+                        }
+                    } else {
+                        throw new IllegalArgumentException("Expected the second element to be a float OnnxTensor, found " + inputs.get(1));
+                    }
+                } else {
+                    throw new IllegalArgumentException("Expected an OnnxTensor, received a " + inputs.get(1).getInfo().toString());
+                }
+            } else {
+                throw new IllegalArgumentException("Unexpected number of OnnxValues returned, expected 2, received " + inputs.size());
+            }
+        } catch (OrtException e) {
+            throw new IllegalStateException("Failed to read a value out of the onnx result.", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "LabelOneVOneTransformer(generatesProbabilities="+generatesProbabilities+")";
+    }
+
+}

--- a/Regression/LibLinear/pom.xml
+++ b/Regression/LibLinear/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+  ~ Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -49,6 +49,12 @@
             <artifactId>tribuo-core</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-onnx</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Regression/LibLinear/pom.xml
+++ b/Regression/LibLinear/pom.xml
@@ -58,6 +58,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-onnx</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.tribuo.regression.liblinear;
 
+import ai.onnx.proto.OnnxMl;
+import com.google.protobuf.ByteString;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.Example;
 import org.tribuo.Excuse;
@@ -24,8 +26,14 @@ import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Model;
 import org.tribuo.Prediction;
+import org.tribuo.Tribuo;
 import org.tribuo.common.liblinear.LibLinearModel;
 import org.tribuo.common.liblinear.LibLinearTrainer;
+import org.tribuo.onnx.ONNXContext;
+import org.tribuo.onnx.ONNXExportable;
+import org.tribuo.onnx.ONNXOperators;
+import org.tribuo.onnx.ONNXShape;
+import org.tribuo.onnx.ONNXUtils;
 import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.regression.ImmutableRegressionInfo;
 import org.tribuo.regression.Regressor;
@@ -33,6 +41,9 @@ import de.bwaldvogel.liblinear.FeatureNode;
 import de.bwaldvogel.liblinear.Linear;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -62,7 +73,7 @@ import java.util.logging.Logger;
  * Machine Learning, 1995.
  * </pre>
  */
-public class LibLinearRegressionModel extends LibLinearModel<Regressor> {
+public class LibLinearRegressionModel extends LibLinearModel<Regressor> implements ONNXExportable {
     private static final long serialVersionUID = 2L;
 
     private static final Logger logger = Logger.getLogger(LibLinearRegressionModel.class.getName());
@@ -181,6 +192,85 @@ public class LibLinearRegressionModel extends LibLinearModel<Regressor> {
 
         return new Excuse<>(e, prediction, weightMap);
     }
+
+    @Override
+    public OnnxMl.ModelProto exportONNXModel(String domain, long modelVersion) {
+        ONNXContext context = new ONNXContext();
+
+        // Build graph
+        OnnxMl.GraphProto graph = exportONNXGraph(context);
+
+        // Build model
+        OnnxMl.ModelProto.Builder builder = OnnxMl.ModelProto.newBuilder();
+        builder.setGraph(graph);
+        builder.setDomain(domain);
+        builder.setProducerName("Tribuo");
+        builder.setProducerVersion(Tribuo.VERSION);
+        builder.setModelVersion(modelVersion);
+        builder.setDocString(toString());
+        builder.addOpsetImport(ONNXOperators.getOpsetProto());
+        builder.setIrVersion(6);
+        return builder.build();
+    }
+
+    @Override
+    public OnnxMl.GraphProto exportONNXGraph(ONNXContext context) {
+        OnnxMl.GraphProto.Builder graphBuilder = OnnxMl.GraphProto.newBuilder();
+
+        // Make inputs and outputs
+        OnnxMl.TypeProto inputType = ONNXUtils.buildTensorTypeNode(new ONNXShape(new long[]{-1,featureIDMap.size()}, new String[]{"batch",null}), OnnxMl.TensorProto.DataType.FLOAT);
+        OnnxMl.ValueInfoProto inputValueProto = OnnxMl.ValueInfoProto.newBuilder().setType(inputType).setName("input").build();
+        graphBuilder.addInput(inputValueProto);
+        OnnxMl.TypeProto outputType = ONNXUtils.buildTensorTypeNode(new ONNXShape(new long[]{-1,outputIDInfo.size()}, new String[]{"batch",null}), OnnxMl.TensorProto.DataType.FLOAT);
+        OnnxMl.ValueInfoProto outputValueProto = OnnxMl.ValueInfoProto.newBuilder().setType(outputType).setName("output").build();
+        graphBuilder.addOutput(outputValueProto);
+
+        double[][] weights = new double[models.size()][];
+        for (int i = 0; i < models.size(); i++) {
+            weights[i] = models.get(i).getFeatureWeights();
+        }
+        int numFeatures = featureIDMap.size();
+
+        // Add weights
+        OnnxMl.TensorProto.Builder weightBuilder = OnnxMl.TensorProto.newBuilder();
+        weightBuilder.setName(context.generateUniqueName("liblinear-weights"));
+        weightBuilder.addDims(featureIDMap.size());
+        weightBuilder.addDims(outputIDInfo.size());
+        weightBuilder.setDataType(OnnxMl.TensorProto.DataType.FLOAT.getNumber());
+        ByteBuffer buffer = ByteBuffer.allocate(featureIDMap.size() * outputIDInfo.size() * 4).order(ByteOrder.LITTLE_ENDIAN);
+        FloatBuffer floatBuffer = buffer.asFloatBuffer();
+        for (int j = 0; j < numFeatures; j++) {
+            for (int i = 0; i < weights.length; i++) {
+                floatBuffer.put((float) weights[i][j]);
+            }
+        }
+        floatBuffer.rewind();
+        weightBuilder.setRawData(ByteString.copyFrom(buffer));
+        graphBuilder.addInitializer(weightBuilder.build());
+
+        // Add biases
+        OnnxMl.TensorProto.Builder biasBuilder = OnnxMl.TensorProto.newBuilder();
+        biasBuilder.setName(context.generateUniqueName("liblinear-biases"));
+        biasBuilder.addDims(outputIDInfo.size());
+        biasBuilder.setDataType(OnnxMl.TensorProto.DataType.FLOAT.getNumber());
+        ByteBuffer biasBuffer = ByteBuffer.allocate(outputIDInfo.size() * 4).order(ByteOrder.LITTLE_ENDIAN);
+        FloatBuffer floatBiasBuffer = biasBuffer.asFloatBuffer();
+        // Biases are stored last in the weight vector
+        for (int i = 0; i < weights.length; i++) {
+            floatBiasBuffer.put((float) weights[i][numFeatures]);
+        }
+        floatBiasBuffer.rewind();
+        biasBuilder.setRawData(ByteString.copyFrom(biasBuffer));
+        graphBuilder.addInitializer(biasBuilder.build());
+
+        // Make gemm
+        String[] gemmInputs = new String[]{inputValueProto.getName(),weightBuilder.getName(),biasBuilder.getName()};
+        OnnxMl.NodeProto gemm = ONNXOperators.GEMM.build(context,gemmInputs,new String[]{"output"});
+        graphBuilder.addNode(gemm);
+
+        return graphBuilder.build();
+    }
+
 
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
@@ -271,7 +271,6 @@ public class LibLinearRegressionModel extends LibLinearModel<Regressor> implemen
         return graphBuilder.build();
     }
 
-
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
 

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
@@ -216,6 +216,7 @@ public class LibLinearRegressionModel extends LibLinearModel<Regressor> implemen
     @Override
     public OnnxMl.GraphProto exportONNXGraph(ONNXContext context) {
         OnnxMl.GraphProto.Builder graphBuilder = OnnxMl.GraphProto.newBuilder();
+        graphBuilder.setName("LibLinear-Regression");
 
         // Make inputs and outputs
         OnnxMl.TypeProto inputType = ONNXUtils.buildTensorTypeNode(new ONNXShape(new long[]{-1,featureIDMap.size()}, new String[]{"batch",null}), OnnxMl.TensorProto.DataType.FLOAT);

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
@@ -265,7 +265,7 @@ public class LibLinearRegressionModel extends LibLinearModel<Regressor> implemen
 
         // Make gemm
         String[] gemmInputs = new String[]{inputValueProto.getName(),weightBuilder.getName(),biasBuilder.getName()};
-        OnnxMl.NodeProto gemm = ONNXOperators.GEMM.build(context,gemmInputs,new String[]{"output"});
+        OnnxMl.NodeProto gemm = ONNXOperators.GEMM.build(context,gemmInputs,"output");
         graphBuilder.addNode(gemm);
 
         return graphBuilder.build();

--- a/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
+++ b/Regression/LibLinear/src/main/java/org/tribuo/regression/liblinear/LibLinearRegressionModel.java
@@ -210,6 +210,13 @@ public class LibLinearRegressionModel extends LibLinearModel<Regressor> implemen
         builder.setDocString(toString());
         builder.addOpsetImport(ONNXOperators.getOpsetProto());
         builder.setIrVersion(6);
+
+        // Extract provenance and store in metadata
+        OnnxMl.StringStringEntryProto.Builder metaBuilder = OnnxMl.StringStringEntryProto.newBuilder();
+        metaBuilder.setKey(ONNXExportable.PROVENANCE_METADATA_FIELD);
+        metaBuilder.setValue(serializeProvenance(getProvenance()));
+        builder.addMetadataProps(metaBuilder.build());
+
         return builder.build();
     }
 

--- a/Regression/LibLinear/src/test/java/org/tribuo/regression/liblinear/TestLibLinear.java
+++ b/Regression/LibLinear/src/test/java/org/tribuo/regression/liblinear/TestLibLinear.java
@@ -16,23 +16,13 @@
 
 package org.tribuo.regression.liblinear;
 
-import ai.onnxruntime.OrtEnvironment;
 import ai.onnxruntime.OrtException;
-import ai.onnxruntime.OrtSession;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.Dataset;
 import org.tribuo.Model;
-import org.tribuo.Prediction;
-import org.tribuo.VariableIDInfo;
-import org.tribuo.VariableInfo;
 import org.tribuo.common.liblinear.LibLinearModel;
 import org.tribuo.common.liblinear.LibLinearTrainer;
-import org.tribuo.interop.onnx.DenseTransformer;
-import org.tribuo.interop.onnx.ONNXExternalModel;
 import org.tribuo.interop.onnx.OnnxTestUtils;
-import org.tribuo.interop.onnx.RegressorTransformer;
-import org.tribuo.provenance.ModelProvenance;
-import org.tribuo.regression.RegressionFactory;
 import org.tribuo.regression.Regressor;
 import org.tribuo.regression.evaluation.RegressionEvaluation;
 import org.tribuo.regression.evaluation.RegressionEvaluator;
@@ -47,18 +37,11 @@ import java.io.ObjectInputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLibLinear {
     private static final Logger logger = Logger.getLogger(TestLibLinear.class.getName());

--- a/Regression/LibLinear/src/test/java/org/tribuo/regression/liblinear/TestLibLinear.java
+++ b/Regression/LibLinear/src/test/java/org/tribuo/regression/liblinear/TestLibLinear.java
@@ -30,6 +30,7 @@ import org.tribuo.common.liblinear.LibLinearTrainer;
 import org.tribuo.interop.onnx.DenseTransformer;
 import org.tribuo.interop.onnx.ONNXExternalModel;
 import org.tribuo.interop.onnx.RegressorTransformer;
+import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.regression.RegressionFactory;
 import org.tribuo.regression.Regressor;
 import org.tribuo.regression.evaluation.RegressionEvaluation;
@@ -48,12 +49,15 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLibLinear {
     private static final Logger logger = Logger.getLogger(TestLibLinear.class.getName());
@@ -220,6 +224,14 @@ public class TestLibLinear {
                 assertArrayEquals(tribuo.getOutput().getNames(),external.getOutput().getNames());
                 assertArrayEquals(tribuo.getOutput().getValues(),external.getOutput().getValues(),1e-5);
             }
+
+            // Check that the provenance can be extracted and is the same
+            ModelProvenance modelProv = model.getProvenance();
+            Optional<ModelProvenance> optProv = onnxModel.getTribuoProvenance();
+            assertTrue(optProv.isPresent());
+            ModelProvenance onnxProv = optProv.get();
+            assertNotSame(onnxProv, modelProv);
+            assertEquals(modelProv,onnxProv);
 
             onnxModel.close();
         } else {

--- a/Regression/LibLinear/src/test/java/org/tribuo/regression/liblinear/TestLibLinear.java
+++ b/Regression/LibLinear/src/test/java/org/tribuo/regression/liblinear/TestLibLinear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,21 @@
 
 package org.tribuo.regression.liblinear;
 
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.Dataset;
 import org.tribuo.Model;
+import org.tribuo.Prediction;
+import org.tribuo.VariableIDInfo;
+import org.tribuo.VariableInfo;
 import org.tribuo.common.liblinear.LibLinearModel;
 import org.tribuo.common.liblinear.LibLinearTrainer;
+import org.tribuo.interop.onnx.DenseTransformer;
+import org.tribuo.interop.onnx.ONNXExternalModel;
+import org.tribuo.interop.onnx.RegressorTransformer;
+import org.tribuo.regression.RegressionFactory;
 import org.tribuo.regression.Regressor;
 import org.tribuo.regression.evaluation.RegressionEvaluation;
 import org.tribuo.regression.evaluation.RegressionEvaluator;
@@ -33,13 +43,20 @@ import org.tribuo.test.Helpers;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestLibLinear {
+    private static final Logger logger = Logger.getLogger(TestLibLinear.class.getName());
 
     private static final LibLinearRegressionTrainer t = new LibLinearRegressionTrainer(new LinearRegressionType(LinearType.L2R_L2LOSS_SVR_DUAL),1.0,1000,0.1,0.5);
     private static final RegressionEvaluator e = new RegressionEvaluator();
@@ -161,5 +178,54 @@ public class TestLibLinear {
             assertEquals(expectedDim3,llEval.r2(new Regressor(RegressionDataGenerator.thirdDimensionName,Double.NaN)),1e-6);
             assertEquals(expectedAve,llEval.averageR2(),1e-6);
         }
+    }
+
+    @Test
+    public void testOnnxSerialization() throws IOException, OrtException {
+        Pair<Dataset<Regressor>,Dataset<Regressor>> p = RegressionDataGenerator.denseTrainTest();
+        LibLinearRegressionModel model = (LibLinearRegressionModel) t.train(p.getA());
+
+        // Write out model
+        Path onnxFile = Files.createTempFile("tribuo-liblinear-test",".onnx");
+        model.saveONNXModel("org.tribuo.regression.liblinear.test",1,onnxFile);
+
+        // Prep mappings
+        Map<String, Integer> featureMapping = new HashMap<>();
+        for (VariableInfo f : model.getFeatureIDMap()){
+            VariableIDInfo id = (VariableIDInfo) f;
+            featureMapping.put(id.getName(),id.getID());
+        }
+        Map<Regressor, Integer> outputMapping = new HashMap<>();
+        for (Pair<Integer,Regressor> l : model.getOutputIDInfo()) {
+            outputMapping.put(l.getB(), l.getA());
+        }
+
+        String arch = System.getProperty("os.arch");
+        if (arch.equalsIgnoreCase("amd64") || arch.equalsIgnoreCase("x86_64")) {
+            // Initialise the OrtEnvironment to load the native library
+            // (as OrtSession.SessionOptions doesn't trigger the static initializer).
+            OrtEnvironment env = OrtEnvironment.getEnvironment();
+            env.close();
+            // Load in via ORT
+            ONNXExternalModel<Regressor> onnxModel = ONNXExternalModel.createOnnxModel(new RegressionFactory(),featureMapping,outputMapping,new DenseTransformer(),new RegressorTransformer(),new OrtSession.SessionOptions(),onnxFile,"input");
+
+            // Generate predictions
+            List<Prediction<Regressor>> nativePredictions = model.predict(p.getB());
+            List<Prediction<Regressor>> onnxPredictions = onnxModel.predict(p.getB());
+
+            // Assert the predictions are identical
+            for (int i = 0; i < nativePredictions.size(); i++) {
+                Prediction<Regressor> tribuo = nativePredictions.get(i);
+                Prediction<Regressor> external = onnxPredictions.get(i);
+                assertArrayEquals(tribuo.getOutput().getNames(),external.getOutput().getNames());
+                assertArrayEquals(tribuo.getOutput().getValues(),external.getOutput().getValues(),1e-5);
+            }
+
+            onnxModel.close();
+        } else {
+            logger.warning("ORT based tests only supported on x86_64, found " + arch);
+        }
+
+        onnxFile.toFile().delete();
     }
 }

--- a/Regression/LibSVM/pom.xml
+++ b/Regression/LibSVM/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+  ~ Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -49,6 +49,12 @@
             <artifactId>tribuo-core</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-onnx</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/Regression/LibSVM/pom.xml
+++ b/Regression/LibSVM/pom.xml
@@ -58,6 +58,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-onnx</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionModel.java
+++ b/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionModel.java
@@ -211,6 +211,13 @@ public class LibSVMRegressionModel extends LibSVMModel<Regressor> implements ONN
         builder.setDocString(toString());
         builder.addOpsetImport(ONNXOperators.getOpsetProto());
         builder.setIrVersion(6);
+
+        // Extract provenance and store in metadata
+        OnnxMl.StringStringEntryProto.Builder metaBuilder = OnnxMl.StringStringEntryProto.newBuilder();
+        metaBuilder.setKey(ONNXExportable.PROVENANCE_METADATA_FIELD);
+        metaBuilder.setValue(serializeProvenance(getProvenance()));
+        builder.addMetadataProps(metaBuilder.build());
+
         return builder.build();
     }
 

--- a/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionModel.java
+++ b/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionModel.java
@@ -217,6 +217,7 @@ public class LibSVMRegressionModel extends LibSVMModel<Regressor> implements ONN
     @Override
     public OnnxMl.GraphProto exportONNXGraph(ONNXContext context) {
         OnnxMl.GraphProto.Builder graphBuilder = OnnxMl.GraphProto.newBuilder();
+        graphBuilder.setName("LibSVM-Regression");
 
         int numFeatures = featureIDMap.size();
 

--- a/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionModel.java
+++ b/Regression/LibSVM/src/main/java/org/tribuo/regression/libsvm/LibSVMRegressionModel.java
@@ -16,21 +16,29 @@
 
 package org.tribuo.regression.libsvm;
 
+import ai.onnx.proto.OnnxMl;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Prediction;
+import org.tribuo.Tribuo;
+import org.tribuo.common.libsvm.KernelType;
 import org.tribuo.common.libsvm.LibSVMModel;
 import org.tribuo.common.libsvm.LibSVMTrainer;
+import org.tribuo.onnx.ONNXContext;
+import org.tribuo.onnx.ONNXExportable;
+import org.tribuo.onnx.ONNXOperators;
+import org.tribuo.onnx.ONNXShape;
+import org.tribuo.onnx.ONNXUtils;
 import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.regression.ImmutableRegressionInfo;
 import org.tribuo.regression.Regressor;
 import libsvm.svm;
 import libsvm.svm_model;
 import libsvm.svm_node;
+import org.tribuo.util.Util;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,7 +69,7 @@ import java.util.Map;
  * Machine Learning, 1995.
  * </pre>
  */
-public class LibSVMRegressionModel extends LibSVMModel<Regressor> {
+public class LibSVMRegressionModel extends LibSVMModel<Regressor> implements ONNXExportable {
     private static final long serialVersionUID = 2L;
 
     private final String[] dimensionNames;
@@ -109,6 +117,14 @@ public class LibSVMRegressionModel extends LibSVMModel<Regressor> {
         this.variances = variances;
         this.standardized = true;
         this.mapping = ((ImmutableRegressionInfo) outputIDInfo).getIDtoNaturalOrderMapping();
+    }
+
+    /**
+     * Is this LibSVMRegressionModel operating in a standardized space.
+     * @return True if the model has been standardized.
+     */
+    boolean isStandardized() {
+        return standardized;
     }
 
     /**
@@ -176,6 +192,96 @@ public class LibSVMRegressionModel extends LibSVMModel<Regressor> {
             newModels.add(copyModel(m));
         }
         return new LibSVMRegressionModel(newName,newProvenance,featureIDMap,outputIDInfo,newModels);
+    }
+
+    @Override
+    public OnnxMl.ModelProto exportONNXModel(String domain, long modelVersion) {
+        ONNXContext context = new ONNXContext();
+
+        // Build graph
+        OnnxMl.GraphProto graph = exportONNXGraph(context);
+
+        // Build model
+        OnnxMl.ModelProto.Builder builder = OnnxMl.ModelProto.newBuilder();
+        builder.setGraph(graph);
+        builder.setDomain(domain);
+        builder.setProducerName("Tribuo");
+        builder.setProducerVersion(Tribuo.VERSION);
+        builder.setModelVersion(modelVersion);
+        builder.setDocString(toString());
+        builder.addOpsetImport(ONNXOperators.getOpsetProto());
+        builder.setIrVersion(6);
+        return builder.build();
+    }
+
+    @Override
+    public OnnxMl.GraphProto exportONNXGraph(ONNXContext context) {
+        OnnxMl.GraphProto.Builder graphBuilder = OnnxMl.GraphProto.newBuilder();
+
+        int numFeatures = featureIDMap.size();
+
+        // Make inputs and outputs
+        OnnxMl.TypeProto inputType = ONNXUtils.buildTensorTypeNode(new ONNXShape(new long[]{-1,featureIDMap.size()}, new String[]{"batch",null}), OnnxMl.TensorProto.DataType.FLOAT);
+        OnnxMl.ValueInfoProto inputValueProto = OnnxMl.ValueInfoProto.newBuilder().setType(inputType).setName("input").build();
+        graphBuilder.addInput(inputValueProto);
+        OnnxMl.TypeProto outputType = ONNXUtils.buildTensorTypeNode(new ONNXShape(new long[]{-1,outputIDInfo.size()}, new String[]{"batch",null}), OnnxMl.TensorProto.DataType.FLOAT);
+        OnnxMl.ValueInfoProto outputValueProto = OnnxMl.ValueInfoProto.newBuilder().setType(outputType).setName("output").build();
+        graphBuilder.addOutput(outputValueProto);
+
+        // Make the individual SVM Regressors for each dimension
+        String[] outputNames = new String[models.size()];
+        for (int i = 0; i < models.size(); i++) {
+            svm_model model = models.get(i);
+            // Extract the attributes
+            Map<String, Object> attributes = new HashMap<>();
+            attributes.put("coefficients", Util.toFloatArray(model.sv_coef[0]));
+            attributes.put("kernel_params", new float[]{(float) model.param.gamma, (float) model.param.coef0, model.param.degree});
+            attributes.put("kernel_type", KernelType.getKernelType(model.param.kernel_type).name());
+            attributes.put("n_supports", model.l);
+            attributes.put("one_class", 0);
+            attributes.put("rho", new float[]{(float)-model.rho[0]});
+            // Extract the support vectors
+            float[] supportVectors = new float[model.l*numFeatures];
+
+            for (int j = 0; j < model.l; j++) {
+                svm_node[] sv = model.SV[j];
+                for (svm_node svm_node : sv) {
+                    int idx = (j * numFeatures) + svm_node.index;
+                    supportVectors[idx] = (float) svm_node.value;
+                }
+            }
+            attributes.put("support_vectors", supportVectors);
+
+            // Build SVM node
+            outputNames[i] = context.generateUniqueName("dimension_output");
+            OnnxMl.NodeProto svm = ONNXOperators.SVM_REGRESSOR.build(context, inputValueProto.getName(), outputNames[i], attributes);
+            graphBuilder.addNode(svm);
+        }
+
+        String concatName = standardized ? context.generateUniqueName("concat_output") : outputValueProto.getName();
+        // Make concat to bring them all together
+        OnnxMl.NodeProto concat = ONNXOperators.CONCAT.build(context, outputNames, concatName, Collections.singletonMap("axis", 1));
+        graphBuilder.addNode(concat);
+
+        if (standardized) {
+            // Add output means
+            OnnxMl.TensorProto outputMeanProto = ONNXUtils.arrayBuilder(context,"y_mean",means);
+            graphBuilder.addInitializer(outputMeanProto);
+
+            // Add output variances
+            OnnxMl.TensorProto outputVarianceProto = ONNXUtils.arrayBuilder(context, "y_var",variances);
+            graphBuilder.addInitializer(outputVarianceProto);
+
+            // Scale outputs
+            String varianceOutput = context.generateUniqueName("y_var_scale_output");
+            OnnxMl.NodeProto varianceScale = ONNXOperators.MUL.build(context, new String[]{concatName,outputVarianceProto.getName()}, varianceOutput);
+            graphBuilder.addNode(varianceScale);
+
+            OnnxMl.NodeProto meanScale = ONNXOperators.ADD.build(context, new String[]{varianceOutput,outputMeanProto.getName()}, outputValueProto.getName());
+            graphBuilder.addNode(meanScale);
+        }
+
+        return graphBuilder.build();
     }
 
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/Regression/LibSVM/src/test/java/org/tribuo/regression/libsvm/TestLibSVM.java
+++ b/Regression/LibSVM/src/test/java/org/tribuo/regression/libsvm/TestLibSVM.java
@@ -286,8 +286,8 @@ public class TestLibSVM {
                     assertEquals(tribuoValues.length,externalValues.length);
                     for (int j = 0; j < tribuoValues.length; j++) {
                         // compute sf comparison
+                        assertEquals(tribuoValues[j], externalValues[j], Math.abs(tribuoValues[j])/1e3);
                     }
-                    assertArrayEquals(tribuo.getOutput().getValues(),external.getOutput().getValues(),1e-1);
                 } else {
                     assertArrayEquals(tribuo.getOutput().getValues(),external.getOutput().getValues(),1e-4);
                 }

--- a/Regression/LibSVM/src/test/java/org/tribuo/regression/libsvm/TestLibSVM.java
+++ b/Regression/LibSVM/src/test/java/org/tribuo/regression/libsvm/TestLibSVM.java
@@ -33,6 +33,7 @@ import org.tribuo.common.libsvm.SVMParameters;
 import org.tribuo.interop.onnx.DenseTransformer;
 import org.tribuo.interop.onnx.ONNXExternalModel;
 import org.tribuo.interop.onnx.RegressorTransformer;
+import org.tribuo.provenance.ModelProvenance;
 import org.tribuo.regression.RegressionFactory;
 import org.tribuo.regression.Regressor;
 import org.tribuo.regression.evaluation.RegressionEvaluation;
@@ -51,12 +52,15 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestLibSVM {
     private static final Logger logger = Logger.getLogger(TestLibSVM.class.getName());
@@ -292,6 +296,14 @@ public class TestLibSVM {
                     assertArrayEquals(tribuo.getOutput().getValues(),external.getOutput().getValues(),1e-4);
                 }
             }
+
+            // Check that the provenance can be extracted and is the same
+            ModelProvenance modelProv = model.getProvenance();
+            Optional<ModelProvenance> optProv = onnxModel.getTribuoProvenance();
+            assertTrue(optProv.isPresent());
+            ModelProvenance onnxProv = optProv.get();
+            assertNotSame(onnxProv, modelProv);
+            assertEquals(modelProv,onnxProv);
 
             onnxModel.close();
         } else {

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -61,6 +61,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>tribuo-classification-libsvm</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tribuo-classification-sgd</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/tests/src/test/java/org/tribuo/tests/onnx/EnsembleExportTest.java
+++ b/tests/src/test/java/org/tribuo/tests/onnx/EnsembleExportTest.java
@@ -25,9 +25,14 @@ import org.tribuo.classification.Label;
 import org.tribuo.classification.ensemble.FullyWeightedVotingCombiner;
 import org.tribuo.classification.ensemble.VotingCombiner;
 import org.tribuo.classification.example.NoisyInterlockingCrescentsDataSource;
+import org.tribuo.classification.libsvm.LibSVMClassificationModel;
+import org.tribuo.classification.libsvm.LibSVMClassificationTrainer;
+import org.tribuo.classification.libsvm.SVMClassificationType;
 import org.tribuo.classification.sgd.fm.FMClassificationTrainer;
 import org.tribuo.classification.sgd.linear.LogisticRegressionTrainer;
 import org.tribuo.classification.sgd.objectives.LogMulticlass;
+import org.tribuo.common.libsvm.KernelType;
+import org.tribuo.common.libsvm.SVMParameters;
 import org.tribuo.common.sgd.AbstractFMModel;
 import org.tribuo.common.sgd.AbstractFMTrainer;
 import org.tribuo.common.sgd.AbstractSGDTrainer;
@@ -118,7 +123,9 @@ public class EnsembleExportTest {
         EnsembleModel<Label> bagModel = t.train(train);
         FMClassificationTrainer fmT = new FMClassificationTrainer(new LogMulticlass(),adagrad,2,100,1,1L,5,0.1);
         AbstractFMModel<Label> fmModel = fmT.train(train);
-        WeightedEnsembleModel<Label> ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("Bag+FM", Arrays.asList(bagModel,fmModel), FULL_VOTING, new float[]{0.3f,0.7f});
+        LibSVMClassificationTrainer svmT = new LibSVMClassificationTrainer(new SVMParameters<>(new SVMClassificationType(SVMClassificationType.SVMMode.NU_SVC), KernelType.RBF));
+        LibSVMClassificationModel svmModel = (LibSVMClassificationModel) svmT.train(train);
+        WeightedEnsembleModel<Label> ensemble = WeightedEnsembleModel.createEnsembleFromExistingModels("Bag+FM", Arrays.asList(bagModel,fmModel,svmModel), FULL_VOTING, new float[]{0.3f,0.5f,0.2f});
 
         // Write out model
         Path onnxFile = Files.createTempFile("tribuo-bagging-test",".onnx");


### PR DESCRIPTION
### Description
Adds ONNX export support for LibLinear and LibSVM classification and regression models. It doesn't add anomaly detection export support, we'll leave that till a future release.

The LibSVM classification export depends on the exact behaviour of ONNX Runtime as the ONNX spec for SVMClassifier is incorrect - https://github.com/microsoft/onnxruntime/issues/9429.

### Motivation
We'd like to export models to ONNX. Also LibSVM uses an operator from the ONNX-ML set and so is a good test of the support.
