### PR TITLE
Adds support for merging MeanVarianceAccumulators

### DIFF
--- a/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostFeatureImportance.java
+++ b/Common/XGBoost/src/main/java/org/tribuo/common/xgboost/XGBoostFeatureImportance.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.tribuo.common.xgboost;
 
 import ml.dmlc.xgboost4j.java.Booster;

--- a/Core/src/main/java/org/tribuo/transform/transformations/IDFTransformation.java
+++ b/Core/src/main/java/org/tribuo/transform/transformations/IDFTransformation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.tribuo.transform.transformations;
 
 import com.oracle.labs.mlrg.olcut.provenance.Provenance;

--- a/Core/src/main/java/org/tribuo/util/MeanVarianceAccumulator.java
+++ b/Core/src/main/java/org/tribuo/util/MeanVarianceAccumulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,22 @@ public final class MeanVarianceAccumulator implements Serializable {
         this.mean = other.mean;
         this.sumSquares = other.sumSquares;
         this.count = other.count;
+    }
+
+    /**
+     * Internal constructor for merge.
+     * @param max The max value.
+     * @param min The min value.
+     * @param mean The mean value.
+     * @param sumSquares The running sum of squares.
+     * @param count The count of values.
+     */
+    private MeanVarianceAccumulator(double max, double min, double mean, double sumSquares, long count) {
+        this.max = max;
+        this.min = min;
+        this.mean = mean;
+        this.sumSquares = sumSquares;
+        this.count = count;
     }
 
     /**
@@ -186,5 +202,24 @@ public final class MeanVarianceAccumulator implements Serializable {
      */
     public void standardizeInPlace(double[] input) {
         Util.standardizeInPlace(input,getMean(),getVariance());
+    }
+
+    /**
+     * Implement Chan's algorithm for merging two mean variance accumulators.
+     * @param first The first mean variance accumulator.
+     * @param second The second mean variance accumulator.
+     * @return A merged mean variance accumulator.
+     */
+    public static MeanVarianceAccumulator merge(MeanVarianceAccumulator first, MeanVarianceAccumulator second) {
+        double max = Math.max(first.max, second.max);
+        double min = Math.min(first.min, second.min);
+
+        long count = first.count + second.count;
+        double mean = (first.mean + second.mean) / 2.0;
+        double delta = second.mean - first.mean;
+        double countFraction = ((double) first.count) / count;
+        double sumSquares = first.sumSquares + second.sumSquares + ((delta*delta) * (countFraction * second.count));
+
+        return new MeanVarianceAccumulator(max,min,mean,sumSquares,count);
     }
 }

--- a/Core/src/test/java/org/tribuo/util/MeanVarianceAccumulatorTest.java
+++ b/Core/src/test/java/org/tribuo/util/MeanVarianceAccumulatorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.tribuo.util;
 
 import com.oracle.labs.mlrg.olcut.util.Pair;
@@ -72,6 +87,38 @@ public class MeanVarianceAccumulatorTest {
         Pair<Double, Double> meanVarPair = Util.meanAndVariance(values);
         Assertions.assertEquals(meanVarPair.getA(),accumulator.getMean(), DELTA);
         Assertions.assertEquals(meanVarPair.getB(),accumulator.getVariance(), DELTA);
+    }
+
+    @Test
+    public void testMerge() {
+        SplittableRandom rng = new SplittableRandom(Trainer.DEFAULT_SEED);
+
+        double[] values = new double[4096];
+
+        for (int i = 0; i < values.length; i++) {
+            values[i] = rng.nextDouble();
+        }
+
+        double[] firstValues = new double[2048];
+        double[] secondValues = new double[2048];
+
+        for (int i = 0; i < firstValues.length; i++) {
+            firstValues[i] = values[i];
+            secondValues[i] = values[i+2048];
+        }
+
+        MeanVarianceAccumulator totalAccumulator = new MeanVarianceAccumulator(values);
+
+        MeanVarianceAccumulator first = new MeanVarianceAccumulator(firstValues);
+        MeanVarianceAccumulator second = new MeanVarianceAccumulator(secondValues);
+
+        MeanVarianceAccumulator sum = MeanVarianceAccumulator.merge(first,second);
+
+        Assertions.assertEquals(totalAccumulator.getMin(),sum.getMin(), DELTA);
+        Assertions.assertEquals(totalAccumulator.getMax(),sum.getMax(), DELTA);
+        Assertions.assertEquals(totalAccumulator.getMean(),sum.getMean(), DELTA);
+        Assertions.assertEquals(totalAccumulator.getVariance(),sum.getVariance(), DELTA);
+        Assertions.assertEquals(totalAccumulator.getCount(),sum.getCount());
     }
 
 }

--- a/Data/src/test/java/org/tribuo/data/columnar/processors/response/EmptyResponseProcessorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/processors/response/EmptyResponseProcessorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.tribuo.data.columnar.processors.response;
 
 import org.junit.jupiter.api.Assertions;

--- a/Data/src/test/java/org/tribuo/data/columnar/processors/response/MultioutputResponseProcessorTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/processors/response/MultioutputResponseProcessorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.tribuo.data.columnar.processors.response;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/Data/src/test/java/org/tribuo/data/columnar/processors/response/ResponseProcessorRoundtripTest.java
+++ b/Data/src/test/java/org/tribuo/data/columnar/processors/response/ResponseProcessorRoundtripTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020-2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.tribuo.data.columnar.processors.response;
 
 import org.junit.jupiter.api.Test;

--- a/Json/src/main/java/org/tribuo/json/JsonUtil.java
+++ b/Json/src/main/java/org/tribuo/json/JsonUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.tribuo.json;
 
 import com.fasterxml.jackson.databind.JsonNode;


### PR DESCRIPTION
### Description
Adds support for merging two `MeanVarianceAccumulators`. At the moment this class isn't used, but we plan to consolidate all the online mean & variance calculations to use this implementation as there are several implementations in the Tribuo codebase. That will require some complicated serialization management so will happen after we've migrated to protobuf serialization.

Also adds some missing copyright statements for a few files.

### Motivation
Merging two accumulators lets us compute the updates in parallel.
