### PR TITLE
fix: addressing indeterminate Map orderings in tests

### DIFF
--- a/Classification/Core/src/main/java/org/tribuo/classification/ImmutableLabelInfo.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/ImmutableLabelInfo.java
@@ -22,7 +22,9 @@ import org.tribuo.ImmutableOutputInfo;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -49,21 +51,23 @@ public class ImmutableLabelInfo extends LabelInfo implements ImmutableOutputInfo
 
     private ImmutableLabelInfo(ImmutableLabelInfo info) {
         super(info);
-        idLabelMap = new HashMap<>();
+        idLabelMap = new LinkedHashMap<>();
         idLabelMap.putAll(info.idLabelMap);
-        labelIDMap = new HashMap<>();
+        labelIDMap = new LinkedHashMap<>();
         labelIDMap.putAll(info.labelIDMap);
         domain = Collections.unmodifiableSet(new HashSet<>(labels.values()));
     }
 
     ImmutableLabelInfo(LabelInfo info) {
         super(info);
-        idLabelMap = new HashMap<>();
-        labelIDMap = new HashMap<>();
+        idLabelMap = new LinkedHashMap<>();
+        labelIDMap = new LinkedHashMap<>();
         int counter = 0;
-        for (Map.Entry<String,MutableLong> e : labelCounts.entrySet()) {
-            idLabelMap.put(counter,e.getKey());
-            labelIDMap.put(e.getKey(),counter);
+        List<String> keys = new ArrayList<String>(labelCounts.keySet());
+        Collections.sort(keys);
+        for (String key : keys) {
+            idLabelMap.put(counter,key);
+            labelIDMap.put(key,counter);
             counter++;
         }
         domain = Collections.unmodifiableSet(new HashSet<>(labels.values()));
@@ -75,8 +79,8 @@ public class ImmutableLabelInfo extends LabelInfo implements ImmutableOutputInfo
             throw new IllegalStateException("Mapping and info come from different sources, mapping.size() = " + mapping.size() + ", info.size() = " + info.size());
         }
 
-        idLabelMap = new HashMap<>();
-        labelIDMap = new HashMap<>();
+        idLabelMap = new LinkedHashMap<>();
+        labelIDMap = new LinkedHashMap<>();
         for (Map.Entry<Label,Integer> e : mapping.entrySet()) {
             idLabelMap.put(e.getValue(),e.getKey().label);
             labelIDMap.put(e.getKey().label,e.getValue());

--- a/Data/src/main/java/org/tribuo/data/csv/CSVSaver.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVSaver.java
@@ -37,8 +37,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
+import java.util.Collections;
 import java.util.logging.Logger;
 
 /**
@@ -114,8 +116,10 @@ public class CSVSaver implements Configurable {
             responseToColumn.put(response, col);
             col++;
         }
-        for (VariableInfo feature : features) {
-            headerLine[col++] = feature.getName();
+        List<String> featuresKeys = new ArrayList<String>(features.keySet());
+        Collections.sort(featuresKeys);
+        for (String featuresKey : featuresKeys) {
+            headerLine[col++] = features.get(featuresKey).getName();
         }
         //
         // Write the CSV

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/ImmutableMultiLabelInfo.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/ImmutableMultiLabelInfo.java
@@ -22,7 +22,9 @@ import org.tribuo.ImmutableOutputInfo;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -47,9 +49,9 @@ public class ImmutableMultiLabelInfo extends MultiLabelInfo implements Immutable
 
     private ImmutableMultiLabelInfo(ImmutableMultiLabelInfo info) {
         super(info);
-        idLabelMap = new HashMap<>();
+        idLabelMap = new LinkedHashMap<>();
         idLabelMap.putAll(info.idLabelMap);
-        labelIDMap = new HashMap<>();
+        labelIDMap = new LinkedHashMap<>();
         labelIDMap.putAll(info.labelIDMap);
 
         domain = Collections.unmodifiableSet(new HashSet<>(labels.values()));
@@ -57,12 +59,14 @@ public class ImmutableMultiLabelInfo extends MultiLabelInfo implements Immutable
 
     ImmutableMultiLabelInfo(MultiLabelInfo info) {
         super(info);
-        idLabelMap = new HashMap<>();
-        labelIDMap = new HashMap<>();
+        idLabelMap = new LinkedHashMap<>();
+        labelIDMap = new LinkedHashMap<>();
         int counter = 0;
-        for (Map.Entry<String,MutableLong> e : labelCounts.entrySet()) {
-            idLabelMap.put(counter,e.getKey());
-            labelIDMap.put(e.getKey(),counter);
+        List<String> keys = new ArrayList<String>(labelCounts.keySet());
+        Collections.sort(keys);
+        for (String key : keys) {
+            idLabelMap.put(counter,key);
+            labelIDMap.put(key,counter);
             counter++;
         }
 
@@ -75,8 +79,8 @@ public class ImmutableMultiLabelInfo extends MultiLabelInfo implements Immutable
             throw new IllegalStateException("Mapping and info come from different sources, mapping.size() = " + mapping.size() + ", info.size() = " + info.size());
         }
 
-        idLabelMap = new HashMap<>();
-        labelIDMap = new HashMap<>();
+        idLabelMap = new LinkedHashMap<>();
+        labelIDMap = new LinkedHashMap<>();
         for (Map.Entry<MultiLabel,Integer> e : mapping.entrySet()) {
             MultiLabel ml = e.getKey();
             Set<String> names = ml.getNameSet();


### PR DESCRIPTION
### Description
Using Nondex when running command `mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex` in the `tests` directory after installing all dependencies, several tests in `CSVSaverWithMultiOutputsTest` and `EnsembleExportTest` has flaky results (nondeterministically pass or fail). The reason is that the outputs in the tests are dependent on iterators for hashmaps, which does not guarantee a fixed order by default. (From the Javadoc: "HashMap class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time.") For example, in the function `save(Path csvPath, Dataset<T> dataset, Set<String> responseNames)` in `CSVSaver.java`, the code is using the iterator defined for `ImmutableFeatureMap` that deals with a `Collection` of values in a HashMap. Therefore, there is no guaranteed order for the entries in `headerLine[]`, which leads to possible test flakiness.

To resolve the problem, I changed the code to construct a sorted `ArrayList` for all keys in the referenced HashMap to ensure determinate iteration order. I also let `ImmutableLabelInfo.java` and `ImmutableMultiLabelInfo.java` deal with `LinkedHashMap` to ensure deterministic element orders. All tests pass without flakiness after such changes.

### Motivation
The change is necessary as related functionalities / tests may fail when, for example, the Java version upgrades in the future, or when the code is run in a different environment. 

### OCA
https://oca.opensource.oracle.com/api/v1/oca-requests/6710/documents/6730/download


