### PR TITLE
Fixes for HashSet iteration order problems

### DIFF
--- a/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/ImmutableAnomalyInfo.java
+++ b/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/ImmutableAnomalyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/ImmutableAnomalyInfo.java
+++ b/AnomalyDetection/Core/src/main/java/org/tribuo/anomaly/ImmutableAnomalyInfo.java
@@ -76,4 +76,15 @@ public final class ImmutableAnomalyInfo extends AnomalyInfo implements Immutable
 
         return list.iterator();
     }
+
+    @Override
+    public boolean domainAndIDEquals(ImmutableOutputInfo<Event> other) {
+        if (other instanceof ImmutableAnomalyInfo) {
+            return true;
+        } else {
+            return other.size() == 2
+                    && other.getID(AnomalyFactory.ANOMALOUS_EVENT) == AnomalyFactory.ANOMALOUS_EVENT.getType().getID()
+                    && other.getID(AnomalyFactory.EXPECTED_EVENT) == AnomalyFactory.EXPECTED_EVENT.getType().getID();
+        }
+    }
 }

--- a/Classification/Core/src/main/java/org/tribuo/classification/ImmutableLabelInfo.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/ImmutableLabelInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Classification/Core/src/main/java/org/tribuo/classification/ImmutableLabelInfo.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/ImmutableLabelInfo.java
@@ -31,7 +31,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * An ImmutableOutputInfo object for Labels.
+ * An {@link ImmutableOutputInfo} object for {@link Label}s.
  * <p>
  * Gives each unique label an id number. Also counts each label occurrence like {@link MutableLabelInfo} does,
  * though the counts are frozen in this object.
@@ -166,6 +166,23 @@ public class ImmutableLabelInfo extends LabelInfo implements ImmutableOutputInfo
     @Override
     public Iterator<Pair<Integer, Label>> iterator() {
         return new ImmutableInfoIterator(idLabelMap);
+    }
+
+    @Override
+    public boolean domainAndIDEquals(ImmutableOutputInfo<Label> other) {
+        if (size() == other.size()) {
+            for (Map.Entry<Integer,String> e : idLabelMap.entrySet()) {
+                Label otherLbl = other.getOutput(e.getKey());
+                if (otherLbl == null) {
+                    return false;
+                } else if (!otherLbl.label.equals(e.getValue())) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.tribuo.classification.evaluation;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.classification.Classifiable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.ToDoubleFunction;
 
@@ -131,15 +132,25 @@ public interface ConfusionMatrix<T extends Classifiable<T>> {
 
     /**
      * The label order this confusion matrix uses in {@code toString}.
+     * <p>
+     * The default implementation is provided for compatibility reasons and will be removed
+     * in a future major release.
      * @return An unmodifiable view on the label order.
      */
-    public List<T> getLabelOrder();
+    public default List<T> getLabelOrder() {
+        return new ArrayList<>(getDomain().getDomain());
+    }
 
     /**
      * Sets the label order this confusion matrix uses in {@code toString}.
+     * <p>
+     * The default implementation does not set the label order and is provided for
+     * backwards compatibility reasons. It should be overridden in all subclasses to
+     * ensure correct behaviour, and this default implementation will be removed in a
+     * future major release.
      * @param labelOrder The label order.
      */
-    public void setLabelOrder(List<T> labelOrder);
+    public default void setLabelOrder(List<T> labelOrder) {}
 
     /**
      * Sums the supplied getter over the domain.

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMatrix.java
@@ -20,7 +20,9 @@ import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.classification.Classifiable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.ToDoubleFunction;
 
 /**
@@ -131,14 +133,25 @@ public interface ConfusionMatrix<T extends Classifiable<T>> {
     }
 
     /**
+     * The values this confusion matrix has seen.
+     * <p>
+     * The default implementation is provided for compatibility reasons and will be removed
+     * in a future major release. It defaults to returning the output domain.
+     * @return The set of observed outputs.
+     */
+    default public Set<T> observed() {
+        return getDomain().getDomain();
+    }
+
+    /**
      * The label order this confusion matrix uses in {@code toString}.
      * <p>
      * The default implementation is provided for compatibility reasons and will be removed
-     * in a future major release.
+     * in a future major release. It defaults to the output domain iterated in hash order.
      * @return An unmodifiable view on the label order.
      */
     public default List<T> getLabelOrder() {
-        return new ArrayList<>(getDomain().getDomain());
+        return Collections.unmodifiableList(new ArrayList<>(getDomain().getDomain()));
     }
 
     /**

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMatrix.java
@@ -19,6 +19,7 @@ package org.tribuo.classification.evaluation;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.classification.Classifiable;
 
+import java.util.List;
 import java.util.function.ToDoubleFunction;
 
 /**
@@ -129,6 +130,18 @@ public interface ConfusionMatrix<T extends Classifiable<T>> {
     }
 
     /**
+     * The label order this confusion matrix uses in {@code toString}.
+     * @return An unmodifiable view on the label order.
+     */
+    public List<T> getLabelOrder();
+
+    /**
+     * Sets the label order this confusion matrix uses in {@code toString}.
+     * @param labelOrder The label order.
+     */
+    public void setLabelOrder(List<T> labelOrder);
+
+    /**
      * Sums the supplied getter over the domain.
      * @param domain The domain to sum over.
      * @param getter The getter to use.
@@ -142,4 +155,5 @@ public interface ConfusionMatrix<T extends Classifiable<T>> {
         }
         return total;
     }
+
 }

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/ConfusionMatrix.java
@@ -144,6 +144,9 @@ public interface ConfusionMatrix<T extends Classifiable<T>> {
     /**
      * Sets the label order this confusion matrix uses in {@code toString}.
      * <p>
+     * If the label order is a subset of the labels in the domain, only the
+     * labels present in the label order will be displayed.
+     * <p>
      * The default implementation does not set the label order and is provided for
      * backwards compatibility reasons. It should be overridden in all subclasses to
      * ensure correct behaviour, and this default implementation will be removed in a

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
@@ -206,6 +206,9 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
 
     /**
      * Sets the label order used in {@link #toString}.
+     * <p>
+     * If the label order is a subset of the labels in the domain, only the
+     * labels present in the label order will be displayed.
      *
      * @param newLabelOrder The label order to use.
      */

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
@@ -23,6 +23,7 @@ import org.tribuo.classification.Label;
 import org.tribuo.math.la.DenseMatrix;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -66,7 +67,8 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
     /**
      * Creates a confusion matrix from the supplied predictions, using the label info
      * from the supplied model.
-     * @param model The model to use for the label information.
+     *
+     * @param model       The model to use for the label information.
      * @param predictions The predictions.
      */
     public LabelConfusionMatrix(Model<Label> model, List<Prediction<Label>> predictions) {
@@ -75,9 +77,10 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
 
     /**
      * Creates a confusion matrix from the supplied predictions and label info.
-     * @throws IllegalArgumentException If the domain doesn't contain all the predictions.
-     * @param domain The label information.
+     *
+     * @param domain      The label information.
      * @param predictions The predictions.
+     * @throws IllegalArgumentException If the domain doesn't contain all the predictions.
      */
     public LabelConfusionMatrix(ImmutableOutputInfo<Label> domain, List<Prediction<Label>> predictions) {
         this.domain = domain;
@@ -85,11 +88,13 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
         this.cm = new DenseMatrix(domain.size(), domain.size());
         this.occurrences = new HashMap<>();
         this.observed = new HashSet<>();
+        this.labelOrder = Collections.unmodifiableList(new ArrayList<>(domain.getDomain()));
         tabulate(predictions);
     }
 
     /**
      * Aggregate the predictions into this confusion matrix.
+     *
      * @param predictions The predictions to aggregate.
      */
     private void tabulate(List<Prediction<Label>> predictions) {
@@ -101,7 +106,7 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
             if (y.getLabel().equals(Label.UNKNOWN)) {
                 throw new IllegalArgumentException("Prediction with unknown ground truth. Unable to evaluate.");
             }
-            occurrences.merge(y,1d, Double::sum);
+            occurrences.merge(y, 1d, Double::sum);
             observed.add(y);
             observed.add(p);
             int iy = getIDOrThrow(y);
@@ -170,7 +175,8 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
 
     /**
      * A convenience method for extracting the appropriate label statistic.
-     * @param cls The label to check.
+     *
+     * @param cls    The label to check.
      * @param getter The get function which accepts a label id.
      * @return The statistic for that label id.
      */
@@ -186,6 +192,7 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
     /**
      * Gets the id for the supplied label, or throws an {@link IllegalArgumentException} if it's
      * an unknown label.
+     *
      * @param key The label.
      * @return The int id for that label.
      */
@@ -199,21 +206,34 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
 
     /**
      * Sets the label order used in {@link #toString}.
-     * @param labelOrder The label order to use.
+     *
+     * @param newLabelOrder The label order to use.
      */
-    public void setLabelOrder(List<Label> labelOrder) {
-        this.labelOrder = labelOrder;
+    @Override
+    public void setLabelOrder(List<Label> newLabelOrder) {
+        if (newLabelOrder == null || newLabelOrder.isEmpty()) {
+            throw new IllegalArgumentException("Label order must be non-null and non-empty.");
+        }
+        this.labelOrder = Collections.unmodifiableList(new ArrayList<>(newLabelOrder));
+    }
+
+    /**
+     * Gets the current label order.
+     *
+     * May trigger order instantiation if the label order has not been set.
+     * @return The label order.
+     */
+    public List<Label> getLabelOrder() {
+        return labelOrder;
     }
 
     @Override
     public String toString() {
-        if (labelOrder == null) {
-            labelOrder = new ArrayList<>(domain.getDomain());
-        }
-        labelOrder.retainAll(observed);
-        
+        List<Label> curOrder = new ArrayList<>(labelOrder);
+        curOrder.retainAll(observed);
+
         int maxLen = Integer.MIN_VALUE;
-        for (Label label : labelOrder) {
+        for (Label label : curOrder) {
             maxLen = Math.max(label.getLabel().length(), maxLen);
             maxLen = Math.max(String.format(" %,d", (int)(double)occurrences.getOrDefault(label,0.0)).length(), maxLen);
         }
@@ -229,14 +249,14 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
 
         //
         // Labels across the top for predicted.
-        for (Label predictedLabel : labelOrder) {
+        for (Label predictedLabel : curOrder) {
             sb.append(String.format(predictedLabelFormat, predictedLabel.getLabel()));
         }
         sb.append('\n');
 
-        for (Label trueLabel : labelOrder) {
+        for (Label trueLabel : curOrder) {
             sb.append(String.format(trueLabelFormat, trueLabel.getLabel()));
-            for (Label predictedLabel : labelOrder) {
+            for (Label predictedLabel : curOrder) {
             	int confusion = (int) confusion(predictedLabel, trueLabel);
                 sb.append(String.format(countFormat, confusion));
             }
@@ -250,9 +270,6 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
      * @return The confusion matrix as a HTML table.
      */
     public String toHTML() {
-        if (labelOrder == null) {
-            labelOrder = new ArrayList<>(domain.getDomain());
-        }
         Set<Label> labelsToPrint = new LinkedHashSet<>(labelOrder);
         labelsToPrint.retainAll(observed);
         StringBuilder sb = new StringBuilder();

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelConfusionMatrix.java
@@ -121,6 +121,11 @@ public final class LabelConfusionMatrix implements ConfusionMatrix<Label> {
     }
 
     @Override
+    public Set<Label> observed() {
+        return Collections.unmodifiableSet(observed);
+    }
+
+    @Override
     public double support() {
         return total;
     }

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluation.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluation.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluation.java
@@ -121,7 +121,8 @@ public interface LabelEvaluation extends ClassifierEvaluation<Label> {
      */
     public static String toFormattedString(LabelEvaluation evaluation) {
         ConfusionMatrix<Label> cm = evaluation.getConfusionMatrix();
-        List<Label> labelOrder = cm.getLabelOrder();
+        List<Label> labelOrder = new ArrayList<>(cm.getLabelOrder());
+        labelOrder.retainAll(cm.observed());
         StringBuilder sb = new StringBuilder();
         int tp = 0;
         int fn = 0;

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluation.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluation.java
@@ -95,6 +95,8 @@ public interface LabelEvaluation extends ClassifierEvaluation<Label> {
 
     /**
      * Returns a HTML formatted String representing this evaluation.
+     * <p>
+     * Uses the label order of the confusion matrix.
      * @return A HTML formatted String.
      */
     default String toHTML() {
@@ -106,12 +108,14 @@ public interface LabelEvaluation extends ClassifierEvaluation<Label> {
      * appropriate tabs and newlines, suitable for display on a terminal.
      * It can be used as an implementation of the {@link EvaluationRenderer}
      * functional interface.
+     * <p>
+     * Uses the label order of the confusion matrix.
      * @param evaluation The evaluation to format.
      * @return Formatted output showing the main results of the evaluation.
      */
     public static String toFormattedString(LabelEvaluation evaluation) {
         ConfusionMatrix<Label> cm = evaluation.getConfusionMatrix();
-        List<Label> labelOrder = new ArrayList<>(cm.getDomain().getDomain());
+        List<Label> labelOrder = cm.getLabelOrder();
         StringBuilder sb = new StringBuilder();
         int tp = 0;
         int fn = 0;
@@ -172,12 +176,14 @@ public interface LabelEvaluation extends ClassifierEvaluation<Label> {
      * appropriate tabs and newlines, suitable for integation into a webpage.
      * It can be used as an implementation of the {@link EvaluationRenderer}
      * functional interface.
+     * <p>
+     * Uses the label order of the confusion matrix.
      * @param evaluation The evaluation to format.
      * @return Formatted HTML output showing the main results of the evaluation.
      */
     public static String toHTML(LabelEvaluation evaluation) {
         ConfusionMatrix<Label> cm = evaluation.getConfusionMatrix();
-        List<Label> labelOrder = new ArrayList<>(cm.getDomain().getDomain());
+        List<Label> labelOrder = cm.getLabelOrder();
         StringBuilder sb = new StringBuilder();
         int tp = 0;
         int fn = 0;

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluation.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluation.java
@@ -96,7 +96,10 @@ public interface LabelEvaluation extends ClassifierEvaluation<Label> {
     /**
      * Returns a HTML formatted String representing this evaluation.
      * <p>
-     * Uses the label order of the confusion matrix.
+     * Uses the label order of the confusion matrix, which can be used to display
+     * a subset of the per label metrics. When they are subset the total row
+     * represents only the subset selected, not all the predictions, however
+     * the accuracy and averaged metrics cover all the predictions.
      * @return A HTML formatted String.
      */
     default String toHTML() {
@@ -109,7 +112,10 @@ public interface LabelEvaluation extends ClassifierEvaluation<Label> {
      * It can be used as an implementation of the {@link EvaluationRenderer}
      * functional interface.
      * <p>
-     * Uses the label order of the confusion matrix.
+     * Uses the label order of the confusion matrix, which can be used to display
+     * a subset of the per label metrics. When they are subset the total row
+     * represents only the subset selected, not all the predictions, however
+     * the accuracy and averaged metrics cover all the predictions.
      * @param evaluation The evaluation to format.
      * @return Formatted output showing the main results of the evaluation.
      */
@@ -155,7 +161,7 @@ public interface LabelEvaluation extends ClassifierEvaluation<Label> {
         sb.append(String.format(labelFormatString, "Total"));
         sb.append(String.format("%,12d%,12d%,12d%,12d%n", n, tp, fn, fp));
         sb.append(String.format(labelFormatString, "Accuracy"));
-        sb.append(String.format("%60.3f%n", (double) tp / n));
+        sb.append(String.format("%60.3f%n", evaluation.accuracy()));
         sb.append(String.format(labelFormatString, "Micro Average"));
         sb.append(String.format("%60.3f%12.3f%12.3f%n",
                 evaluation.microAveragedRecall(),
@@ -173,11 +179,14 @@ public interface LabelEvaluation extends ClassifierEvaluation<Label> {
 
     /**
      * This method produces a HTML formatted String output, with
-     * appropriate tabs and newlines, suitable for integation into a webpage.
+     * appropriate tabs and newlines, suitable for integration into a webpage.
      * It can be used as an implementation of the {@link EvaluationRenderer}
      * functional interface.
      * <p>
-     * Uses the label order of the confusion matrix.
+     * Uses the label order of the confusion matrix, which can be used to display
+     * a subset of the per label metrics. When they are subset the total row
+     * represents only the subset selected, not all the predictions, however
+     * the accuracy and averaged metrics cover all the predictions.
      * @param evaluation The evaluation to format.
      * @return Formatted HTML output showing the main results of the evaluation.
      */

--- a/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluationImpl.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/evaluation/LabelEvaluationImpl.java
@@ -247,8 +247,14 @@ final class LabelEvaluationImpl implements LabelEvaluation {
     public EvaluationProvenance getProvenance() { return provenance; }
 
     /**
-     * This produces a formatted String suitable for a terminal.
-     * @return A formatted String representing this {@code LabelEvaluationImpl}.
+     * This method produces a nicely formatted String output, with
+     * appropriate tabs and newlines, suitable for display on a terminal.
+     * <p>
+     * Uses the label order of the confusion matrix, which can be used to display
+     * a subset of the per label metrics. When they are subset the total row
+     * represents only the subset selected, not all the predictions, however
+     * the accuracy and averaged metrics cover all the predictions.
+     * @return Formatted output showing the main results of the evaluation.
      */
     @Override
     public String toString() {

--- a/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelConfusionMatrixTest.java
+++ b/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelConfusionMatrixTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelConfusionMatrixTest.java
+++ b/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelConfusionMatrixTest.java
@@ -85,6 +85,16 @@ public class LabelConfusionMatrixTest {
         			 "b      0   1   1\n" + 
         			 "c      0   1   0\n", cmToString);
 
+        lblOrder.clear();
+        lblOrder.add(c);
+        lblOrder.add(a);
+        cm.setLabelOrder(lblOrder);
+
+        cmToString = cm.toString();
+        assertEquals("       c   a\n" +
+            "c      0   0\n" +
+            "a      0   1\n", cmToString);
+
     }
 
 }

--- a/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelConfusionMatrixTest.java
+++ b/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelConfusionMatrixTest.java
@@ -21,6 +21,7 @@ import org.tribuo.Prediction;
 import org.tribuo.classification.Label;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -70,6 +71,14 @@ public class LabelConfusionMatrixTest {
         assertEquals(1, cm.support(c));
 
         assertEquals(4, cm.support());
+
+        List<Label> lblOrder = new ArrayList<>();
+        lblOrder.add(a);
+        lblOrder.add(b);
+        lblOrder.add(c);
+
+        cm.setLabelOrder(lblOrder);
+
         String cmToString = cm.toString();
         assertEquals("       a   b   c\n" + 
         			 "a      1   0   0\n" + 

--- a/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelEvaluatorTest.java
+++ b/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelEvaluatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelEvaluatorTest.java
+++ b/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelEvaluatorTest.java
@@ -127,6 +127,14 @@ public class LabelEvaluatorTest {
         LabelEvaluation evaluation = new LabelEvaluator()
                 .evaluate(model, testPreds, dataset.getProvenance());
 
+        List<Label> lblOrder = new ArrayList<>();
+        lblOrder.add(new Label("a"));
+        lblOrder.add(new Label("b"));
+        lblOrder.add(new Label("c"));
+        lblOrder.add(new Label("d"));
+
+        evaluation.getConfusionMatrix().setLabelOrder(lblOrder);
+
         // Uses String.format to respect JVM locale
         String expected =     "Class                           n          tp          fn          fp      recall        prec          f1\n" +
                 String.format("a                               1           1           0           0       %1.3f       %1.3f       %1.3f\n",1.0,1.0,1.0) +
@@ -166,6 +174,14 @@ public class LabelEvaluatorTest {
 
         LabelEvaluation evaluation = new LabelEvaluator()
                 .evaluate(model, testPreds, dataset.getProvenance());
+
+        List<Label> lblOrder = new ArrayList<>();
+        lblOrder.add(new Label("a"));
+        lblOrder.add(new Label("b"));
+        lblOrder.add(new Label("c"));
+        lblOrder.add(new Label("d"));
+
+        evaluation.getConfusionMatrix().setLabelOrder(lblOrder);
 
         // Uses String.format to respect JVM locale
         String expected = "<table>\n" +

--- a/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelEvaluatorTest.java
+++ b/Classification/Core/src/test/java/org/tribuo/classification/evaluation/LabelEvaluatorTest.java
@@ -150,6 +150,23 @@ public class LabelEvaluatorTest {
         String actual = evaluation.toString();
         actual = actual.replaceAll("\\r+", "");
         assertEquals(expected, actual);
+
+        String reducedExpected =     "Class                           n          tp          fn          fp      recall        prec          f1\n" +
+            String.format("c                               1           0           1           1       %1.3f       %1.3f       %1.3f\n",0.0,0.0,0.0) +
+            String.format("b                               2           1           1           1       %1.3f       %1.3f       %1.3f\n",0.5,0.5,0.5) +
+            String.format("Total                           3           1           2           2\n") +
+            String.format("Accuracy                                                                    %1.3f\n",0.6) +
+            String.format("Micro Average                                                               %1.3f       %1.3f       %1.3f\n",0.6,0.6,0.6) +
+            String.format("Macro Average                                                               %1.3f       %1.3f       %1.3f\n",0.625,0.625,0.625) +
+            String.format("Balanced Error Rate                                                         %1.3f",0.375);
+
+        lblOrder.clear();
+        lblOrder.add(new Label("c"));
+        lblOrder.add(new Label("b"));
+        evaluation.getConfusionMatrix().setLabelOrder(lblOrder);
+        String reducedActual = evaluation.toString();
+        reducedActual = reducedActual.replaceAll("\\r+", "");
+        assertEquals(reducedExpected, reducedActual);
     }
 
     @Test

--- a/Clustering/Core/src/main/java/org/tribuo/clustering/ImmutableClusteringInfo.java
+++ b/Clustering/Core/src/main/java/org/tribuo/clustering/ImmutableClusteringInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Clustering/Core/src/main/java/org/tribuo/clustering/ImmutableClusteringInfo.java
+++ b/Clustering/Core/src/main/java/org/tribuo/clustering/ImmutableClusteringInfo.java
@@ -100,6 +100,11 @@ public class ImmutableClusteringInfo extends ClusteringInfo implements Immutable
         return new ImmutableInfoIterator(clusterCounts.keySet());
     }
 
+    @Override
+    public boolean domainAndIDEquals(ImmutableOutputInfo<ClusterID> other) {
+        return getDomain().equals(other.getDomain());
+    }
+
     private static class ImmutableInfoIterator implements Iterator<Pair<Integer,ClusterID>> {
 
         private final Iterator<Integer> itr;

--- a/Core/src/main/java/org/tribuo/CategoricalIDInfo.java
+++ b/Core/src/main/java/org/tribuo/CategoricalIDInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,6 @@
  */
 
 package org.tribuo;
-
-import com.oracle.labs.mlrg.olcut.util.MutableLong;
-
-import java.util.Map;
 
 /**
  * Same as a {@link CategoricalInfo}, but with an additional int id field.
@@ -61,39 +57,8 @@ public class CategoricalIDInfo extends CategoricalInfo implements VariableIDInfo
      */
     @Override
     public RealIDInfo generateRealInfo() {
-        double min = Double.POSITIVE_INFINITY;
-        double max = Double.NEGATIVE_INFINITY;
-        double sum = 0.0;
-        double sumSquares = 0.0;
-        double mean;
-
-        if (valueCounts != null) {
-            for (Map.Entry<Double, MutableLong> e : valueCounts.entrySet()) {
-                double value = e.getKey();
-                double valCount = e.getValue().longValue();
-                if (value > max) {
-                    max = value;
-                }
-                if (value < min) {
-                    min = value;
-                }
-                sum += value * valCount;
-            }
-            mean = sum / count;
-
-            for (Map.Entry<Double, MutableLong> e : valueCounts.entrySet()) {
-                double value = e.getKey();
-                double valCount = e.getValue().longValue();
-                sumSquares += (value - mean) * (value - mean) * valCount;
-            }
-        } else {
-            min = observedValue;
-            max = observedValue;
-            mean = observedValue;
-            sumSquares = 0.0;
-        }
-
-        return new RealIDInfo(name,count,max,min,mean,sumSquares,id);
+        RealInfo realInfo = super.generateRealInfo();
+        return new RealIDInfo(realInfo,id);
     }
 
     @Override

--- a/Core/src/main/java/org/tribuo/CategoricalInfo.java
+++ b/Core/src/main/java/org/tribuo/CategoricalInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,13 @@ import com.oracle.labs.mlrg.olcut.util.MutableNumber;
 import org.tribuo.util.Util;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.SplittableRandom;
+import java.util.stream.Collectors;
 
 /**
  * Stores information about Categorical features.
@@ -186,7 +189,9 @@ public class CategoricalInfo extends SkeletalVariableInfo {
         double mean;
 
         if (valueCounts != null) {
-            for (Map.Entry<Double, MutableLong> e : valueCounts.entrySet()) {
+            List<Map.Entry<Double, MutableLong>> entries = valueCounts.entrySet().stream()
+                .sorted(Comparator.comparingDouble(Map.Entry::getKey)).collect(Collectors.toList());
+            for (Map.Entry<Double, MutableLong> e : entries) {
                 double value = e.getKey();
                 double valCount = e.getValue().longValue();
                 if (value > max) {
@@ -199,7 +204,7 @@ public class CategoricalInfo extends SkeletalVariableInfo {
             }
             mean = sum / count;
 
-            for (Map.Entry<Double, MutableLong> e : valueCounts.entrySet()) {
+            for (Map.Entry<Double, MutableLong> e : entries) {
                 double value = e.getKey();
                 double valCount = e.getValue().longValue();
                 sumSquares += (value - mean) * (value - mean) * valCount;
@@ -286,7 +291,9 @@ public class CategoricalInfo extends SkeletalVariableInfo {
             counts[0] = newTotalObservations;
             int counter = 1;
             long total = 0;
-            for (Map.Entry<Double,MutableLong> e : valueCounts.entrySet()) {
+            List<Map.Entry<Double, MutableLong>> entries = valueCounts.entrySet().stream()
+                .sorted(Comparator.comparingDouble(Map.Entry::getKey)).collect(Collectors.toList());
+            for (Map.Entry<Double,MutableLong> e : entries){
                 if (e.getKey() != 0.0) {
                     values[counter] = e.getKey();
                     counts[counter] = e.getValue().longValue();
@@ -338,7 +345,7 @@ public class CategoricalInfo extends SkeletalVariableInfo {
                 values[0] = 0;
                 counter = 1;
             }
-            for (Double key : valueCounts.keySet()) {
+            for (Double key : valueCounts.keySet().stream().sorted().collect(Collectors.toList())) {
                 values[counter] = key;
                 counter++;
             }

--- a/Core/src/main/java/org/tribuo/FeatureMap.java
+++ b/Core/src/main/java/org/tribuo/FeatureMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Core/src/main/java/org/tribuo/FeatureMap.java
+++ b/Core/src/main/java/org/tribuo/FeatureMap.java
@@ -117,4 +117,23 @@ public abstract class FeatureMap implements Serializable, Iterable<VariableInfo>
         return sb.toString();
     }
 
+    /**
+     * Check if this feature map contains the same features as the supplied one.
+     * @param other The feature map to check.
+     * @return True if the two feature maps contain the same named features.
+     */
+    public boolean domainEquals(FeatureMap other) {
+        if (size() == other.size()) {
+            for (Map.Entry<String, VariableInfo> e : m.entrySet()) {
+                VariableInfo otherInfo = other.get(e.getKey());
+                if (otherInfo == null) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/Core/src/main/java/org/tribuo/ImmutableOutputInfo.java
+++ b/Core/src/main/java/org/tribuo/ImmutableOutputInfo.java
@@ -45,4 +45,12 @@ public interface ImmutableOutputInfo<T extends Output<T>> extends OutputInfo<T>,
      */
     public long getTotalObservations();
 
+    /**
+     * Checks if the domain is the same as the other output info's domain, and that
+     * each element is mapped to the same id number.
+     * @param other The output info to compare.
+     * @return True if the domains and ids are the same.
+     */
+    public boolean domainAndIDEquals(ImmutableOutputInfo<T> other);
+
 }

--- a/Core/src/main/java/org/tribuo/ImmutableOutputInfo.java
+++ b/Core/src/main/java/org/tribuo/ImmutableOutputInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,10 @@
 package org.tribuo;
 
 import com.oracle.labs.mlrg.olcut.util.Pair;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * An {@link OutputInfo} that is fixed, and contains an id number for each valid output.
@@ -48,9 +52,26 @@ public interface ImmutableOutputInfo<T extends Output<T>> extends OutputInfo<T>,
     /**
      * Checks if the domain is the same as the other output info's domain, and that
      * each element is mapped to the same id number.
+     * <p>
+     * Note the default behaviour will be removed in a future major release, and should be
+     * overridden for performance reasons in all implementing classes.
      * @param other The output info to compare.
      * @return True if the domains and ids are the same.
      */
-    public boolean domainAndIDEquals(ImmutableOutputInfo<T> other);
+    default public boolean domainAndIDEquals(ImmutableOutputInfo<T> other) {
+        List<Pair<Integer,T>> self = new ArrayList<>();
+        for (Pair<Integer, T> p : this) {
+            self.add(p);
+        }
+        self.sort(Comparator.comparingInt(Pair::getA));
+
+        List<Pair<Integer,T>> otherList = new ArrayList<>();
+        for (Pair<Integer, T> p : other) {
+            otherList.add(p);
+        }
+        otherList.sort(Comparator.comparingInt(Pair::getA));
+
+        return self.equals(otherList);
+    }
 
 }

--- a/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
+++ b/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
+++ b/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
@@ -41,6 +41,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -193,16 +194,18 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
 
         // Validate output domains
         ImmutableOutputInfo<T> outputInfo = models.get(0).getOutputIDInfo();
-        List<Pair<Integer,T>> firstList = new ArrayList<>();
+        List<T> firstList = new ArrayList<>();
         for (Pair<Integer,T> p : outputInfo) {
-            firstList.add(p);
+            firstList.add(p.getB());
         }
-        List<Pair<Integer,T>> comparisonList = new ArrayList<>();
+        firstList.sort(Comparator.comparing(a -> a.getSerializableForm(false)));
+        List<T> comparisonList = new ArrayList<>();
         for (int i = 1; i < models.size(); i++) {
             comparisonList.clear();
             for (Pair<Integer,T> p : models.get(i).getOutputIDInfo()) {
-                comparisonList.add(p);
+                comparisonList.add(p.getB());
             }
+            comparisonList.sort(Comparator.comparing(a -> a.getSerializableForm(false)));
             if (!firstList.equals(comparisonList)) {
                 throw new IllegalArgumentException("Model output domains are not equal.");
             }

--- a/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
+++ b/Core/src/main/java/org/tribuo/ensemble/WeightedEnsembleModel.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * An ensemble model that uses weights to combine the ensemble member predictions.
@@ -192,27 +193,18 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
             throw new IllegalArgumentException("Must supply one weight per model, models.size() = " + models.size() + ", weights.length = " + weights.length);
         }
 
-        // Validate output domains
+        // Validate output & feature domains
         ImmutableOutputInfo<T> outputInfo = models.get(0).getOutputIDInfo();
-        List<T> firstList = new ArrayList<>();
-        for (Pair<Integer,T> p : outputInfo) {
-            firstList.add(p.getB());
-        }
-        firstList.sort(Comparator.comparing(a -> a.getSerializableForm(false)));
-        List<T> comparisonList = new ArrayList<>();
+        ImmutableFeatureMap featureMap = models.get(0).getFeatureIDMap();
+        Set<T> firstOutputDomain = outputInfo.getDomain();
         for (int i = 1; i < models.size(); i++) {
-            comparisonList.clear();
-            for (Pair<Integer,T> p : models.get(i).getOutputIDInfo()) {
-                comparisonList.add(p.getB());
-            }
-            comparisonList.sort(Comparator.comparing(a -> a.getSerializableForm(false)));
-            if (!firstList.equals(comparisonList)) {
+            if (!models.get(i).getOutputIDInfo().getDomain().equals(firstOutputDomain)) {
                 throw new IllegalArgumentException("Model output domains are not equal.");
             }
+            if (!models.get(i).getFeatureIDMap().domainEquals(featureMap)) {
+                throw new IllegalArgumentException("Model feature domains are not equal.");
+            }
         }
-
-        // Extract feature domain
-        ImmutableFeatureMap featureMap = models.get(0).getFeatureIDMap();
 
         // Defensive copy the model list (the weights are copied in the constructor)
         List<Model<T>> modelList = new ArrayList<>(models);
@@ -257,18 +249,34 @@ public final class WeightedEnsembleModel<T extends Output<T>> extends EnsembleMo
     public ONNXNode writeONNXGraph(ONNXRef<?> input) {
         ONNXContext onnx = input.onnxContext();
         ONNXInitializer unsqueezeAxes = onnx.array("unsqueeze_ensemble_output", new long[]{2});
-        List<ONNXNode> unsquuezedMembers = new ArrayList<>();
+        List<ONNXNode> unsqueezedMembers = new ArrayList<>();
         for(Model<T> model : models) {
             if(model instanceof ONNXExportable) {
                 ONNXNode memberOutput = ((ONNXExportable) model).writeONNXGraph(input);
-                unsquuezedMembers.add(memberOutput.apply(ONNXOperators.UNSQUEEZE, unsqueezeAxes));
+                ONNXNode unsqueezedOutput = memberOutput.apply(ONNXOperators.UNSQUEEZE, unsqueezeAxes);
+                if (model.getOutputIDInfo().domainAndIDEquals(outputIDInfo)) {
+                    // Output domains line up
+                    unsqueezedMembers.add(unsqueezedOutput);
+                } else {
+                    // Output domains don't line up, add a gather to rearrange them
+                    int[] outputRemapping = new int[outputIDInfo.size()];
+                    for (int i = 0; i < outputRemapping.length; i++) {
+                        int otherId = outputIDInfo.getID(model.getOutputIDInfo().getOutput(i));
+                        outputRemapping[otherId] = i;
+                    }
+
+                    ONNXInitializer indices = onnx.array("ensemble_output_gather_indices", outputRemapping);
+
+                    ONNXNode gatheredOutput = unsqueezedOutput.apply(ONNXOperators.GATHER, indices, Collections.singletonMap("axis", 1));
+                    unsqueezedMembers.add(gatheredOutput);
+                }
             } else {
                 throw new IllegalStateException("Ensemble member '" + model.toString() + "' is not ONNXExportable.");
             }
         }
 
         ONNXInitializer ensembleWeights = onnx.array("ensemble_weights", weights);
-        ONNXNode concat = onnx.operation(ONNXOperators.CONCAT, unsquuezedMembers, "ensemble_concat", Collections.singletonMap("axis", 2));
+        ONNXNode concat = onnx.operation(ONNXOperators.CONCAT, unsqueezedMembers, "ensemble_concat", Collections.singletonMap("axis", 2));
 
         return combiner.exportCombiner(concat, ensembleWeights);
     }

--- a/Core/src/test/java/org/tribuo/test/ImmutableMockMultiOutputInfo.java
+++ b/Core/src/test/java/org/tribuo/test/ImmutableMockMultiOutputInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Core/src/test/java/org/tribuo/test/ImmutableMockMultiOutputInfo.java
+++ b/Core/src/test/java/org/tribuo/test/ImmutableMockMultiOutputInfo.java
@@ -70,6 +70,12 @@ public class ImmutableMockMultiOutputInfo extends MockMultiOutputInfo implements
         return totalCount;
     }
 
+    @Override
+    public boolean domainAndIDEquals(ImmutableOutputInfo<MockMultiOutput> other) {
+        ImmutableMockMultiOutputInfo otherInfo = (ImmutableMockMultiOutputInfo) other;
+        return otherInfo.idLabelMap.equals(idLabelMap);
+    }
+
     public long getLabelCount(int id) {
         String label = idLabelMap.get(id);
         if (label != null) {

--- a/Core/src/test/java/org/tribuo/test/MockOutputInfo.java
+++ b/Core/src/test/java/org/tribuo/test/MockOutputInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Core/src/test/java/org/tribuo/test/MockOutputInfo.java
+++ b/Core/src/test/java/org/tribuo/test/MockOutputInfo.java
@@ -161,6 +161,12 @@ public class MockOutputInfo implements MutableOutputInfo<MockOutput>, ImmutableO
     }
 
     @Override
+    public boolean domainAndIDEquals(ImmutableOutputInfo<MockOutput> other) {
+        MockOutputInfo otherInfo = (MockOutputInfo) other;
+        return otherInfo.idLabelMap.equals(idLabelMap);
+    }
+
+    @Override
     public Iterator<Pair<Integer, MockOutput>> iterator() {
         return new ImmutableInfoIterator(idLabelMap);
     }

--- a/Data/src/main/java/org/tribuo/data/csv/CSVSaver.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVSaver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Data/src/main/java/org/tribuo/data/csv/CSVSaver.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVSaver.java
@@ -27,17 +27,14 @@ import org.tribuo.Feature;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.Output;
 import org.tribuo.VariableIDInfo;
-import org.tribuo.VariableInfo;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;

--- a/Data/src/main/java/org/tribuo/data/csv/CSVSaver.java
+++ b/Data/src/main/java/org/tribuo/data/csv/CSVSaver.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/ImmutableMultiLabelInfo.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/ImmutableMultiLabelInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/ImmutableMultiLabelInfo.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/ImmutableMultiLabelInfo.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * An ImmutableOutputInfo for working with multi-label tasks.
+ * An {@link ImmutableOutputInfo} for working with {@link MultiLabel} tasks.
  */
 public class ImmutableMultiLabelInfo extends MultiLabelInfo implements ImmutableOutputInfo<MultiLabel> {
     private static final Logger logger = Logger.getLogger(ImmutableMultiLabelInfo.class.getName());
@@ -188,6 +188,23 @@ public class ImmutableMultiLabelInfo extends MultiLabelInfo implements Immutable
     @Override
     public Iterator<Pair<Integer, MultiLabel>> iterator() {
         return new ImmutableInfoIterator(idLabelMap);
+    }
+
+    @Override
+    public boolean domainAndIDEquals(ImmutableOutputInfo<MultiLabel> other) {
+        if (size() == other.size()) {
+            for (Map.Entry<Integer,String> e : idLabelMap.entrySet()) {
+                MultiLabel otherLbl = other.getOutput(e.getKey());
+                if (otherLbl == null) {
+                    return false;
+                } else if (!otherLbl.getLabelString().equals(e.getValue())) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
     private static class ImmutableInfoIterator implements Iterator<Pair<Integer,MultiLabel>> {

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
@@ -169,6 +169,9 @@ public final class MultiLabelConfusionMatrix implements ConfusionMatrix<MultiLab
 
     /**
      * Sets the label order used in {@link #toString}.
+     * <p>
+     * If the label order is a subset of the labels in the domain, only the
+     * labels present in the label order will be displayed.
      *
      * @param labelOrder The label order to use.
      */
@@ -182,8 +185,10 @@ public final class MultiLabelConfusionMatrix implements ConfusionMatrix<MultiLab
 
     /**
      * Gets the current label order.
+     * <p>
+     * If the label order is a subset of the labels in the domain, only the
+     * labels present in the label order will be displayed.
      *
-     * May trigger order instantiation if the label order has not been set.
      * @return The label order.
      */
     public List<MultiLabel> getLabelOrder() {

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrix.java
@@ -25,6 +25,8 @@ import org.tribuo.math.la.DenseMatrix;
 import org.tribuo.multilabel.MultiLabel;
 import org.tribuo.multilabel.MultiLabelFactory;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -56,6 +58,8 @@ public final class MultiLabelConfusionMatrix implements ConfusionMatrix<MultiLab
     private final DenseMatrix[] mcm;
     private final DenseMatrix confusion;
 
+    private List<MultiLabel> labelOrder;
+
     /**
      * Constructs a multi-label confusion matrix for the specified model and predictions.
      * @param model The model.
@@ -67,6 +71,7 @@ public final class MultiLabelConfusionMatrix implements ConfusionMatrix<MultiLab
 
     MultiLabelConfusionMatrix(ImmutableOutputInfo<MultiLabel> domain, List<Prediction<MultiLabel>> predictions) {
         this.domain = domain;
+        this.labelOrder = Collections.unmodifiableList(new ArrayList<>(domain.getDomain()));
         ConfusionMatrixTuple tab = tabulate(domain, predictions);
         this.mcm = tab.mcm;
         this.confusion = tab.confusion;
@@ -162,9 +167,32 @@ public final class MultiLabelConfusionMatrix implements ConfusionMatrix<MultiLab
         return total;
     }
 
+    /**
+     * Sets the label order used in {@link #toString}.
+     *
+     * @param labelOrder The label order to use.
+     */
+    @Override
+    public void setLabelOrder(List<MultiLabel> labelOrder) {
+        if (labelOrder == null || labelOrder.isEmpty()) {
+            throw new IllegalArgumentException("Label order must be non-null and non-empty.");
+        }
+        this.labelOrder = Collections.unmodifiableList(new ArrayList<>(labelOrder));
+    }
+
+    /**
+     * Gets the current label order.
+     *
+     * May trigger order instantiation if the label order has not been set.
+     * @return The label order.
+     */
+    public List<MultiLabel> getLabelOrder() {
+        return labelOrder;
+    }
+
     @Override
     public String toString() {
-        return getDomain().getDomain().stream()
+        return labelOrder.stream()
             .map(multiLabel -> {
                   final int tp = (int) tp(multiLabel);
                   final int fn = (int) fn(multiLabel);

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
@@ -228,6 +228,8 @@ public final class MultiLabelEvaluationImpl implements MultiLabelEvaluation {
      * @return Formatted output showing the main results of the evaluation.
      */
     private String toString(List<MultiLabel> labelOrder) {
+        List<MultiLabel> retainedLabelOrder = new ArrayList<>(labelOrder);
+        retainedLabelOrder.retainAll(cm.observed());
         StringBuilder sb = new StringBuilder();
         int tp = 0;
         int fn = 0;
@@ -237,14 +239,14 @@ public final class MultiLabelEvaluationImpl implements MultiLabelEvaluation {
         // Figure out the biggest class label and therefore the format string
         // that we should use for them.
         int maxLabelSize = "Balanced Error Rate".length();
-        for(MultiLabel label : labelOrder) {
+        for(MultiLabel label : retainedLabelOrder) {
             maxLabelSize = Math.max(maxLabelSize, label.getLabelString().length());
         }
         String labelFormatString = String.format("%%-%ds", maxLabelSize+2);
         sb.append(String.format(labelFormatString, "Class"));
         sb.append(String.format("%12s%12s%12s%12s", "n", "tp", "fn", "fp"));
         sb.append(String.format("%12s%12s%12s%n", "recall", "prec", "f1"));
-        for (MultiLabel label : labelOrder) {
+        for (MultiLabel label : retainedLabelOrder) {
             if (cm.support(label) == 0) {
                 continue;
             }

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
@@ -202,8 +202,7 @@ public final class MultiLabelEvaluationImpl implements MultiLabelEvaluation {
 
     @Override
     public String toString() {
-        List<MultiLabel> labelOrder = new ArrayList<>(cm.getDomain().getDomain());
-        return toString(labelOrder);
+        return toString(cm.getLabelOrder());
     }
 
     private String toString(List<MultiLabel> labelOrder) {

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/evaluation/MultiLabelEvaluationImpl.java
@@ -200,11 +200,33 @@ public final class MultiLabelEvaluationImpl implements MultiLabelEvaluation {
         return provenance;
     }
 
+    /**
+     * This method produces a nicely formatted String output, with
+     * appropriate tabs and newlines, suitable for display on a terminal.
+     * <p>
+     * Uses the label order of the confusion matrix, which can be used to display
+     * a subset of the per label metrics. When they are subset the total row
+     * represents only the subset selected, not all the predictions, however
+     * the accuracy and averaged metrics cover all the predictions.
+     * @return Formatted output showing the main results of the evaluation.
+     */
     @Override
     public String toString() {
         return toString(cm.getLabelOrder());
     }
 
+    /**
+     * This method produces a nicely formatted String output, with
+     * appropriate tabs and newlines, suitable for display on a terminal.
+     * <p>
+     * Uses the label order of the confusion matrix, which can be used to display
+     * a subset of the per label metrics. When they are subset the total row
+     * represents only the subset selected, not all the predictions, however
+     * the accuracy and averaged metrics cover all the predictions.
+     *
+     * @param labelOrder The label order to use.
+     * @return Formatted output showing the main results of the evaluation.
+     */
     private String toString(List<MultiLabel> labelOrder) {
         StringBuilder sb = new StringBuilder();
         int tp = 0;
@@ -242,7 +264,7 @@ public final class MultiLabelEvaluationImpl implements MultiLabelEvaluation {
         sb.append(String.format(labelFormatString, "Total"));
         sb.append(String.format("%,12d%,12d%,12d%,12d%n", n, tp, fn, fp));
         sb.append(String.format(labelFormatString, "Accuracy"));
-        sb.append(String.format("%60.3f%n", ((double) tp) / n));
+        sb.append(String.format("%60.3f%n", cm.tp() / cm.support()));
         sb.append(String.format(labelFormatString, "Micro Average"));
         sb.append(String.format("%60.3f%12.3f%12.3f%n", microAveragedRecall(), microAveragedPrecision(), microAveragedF1()));
         sb.append(String.format(labelFormatString, "Macro Average"));

--- a/MultiLabel/Core/src/test/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrixTest.java
+++ b/MultiLabel/Core/src/test/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrixTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/MultiLabel/Core/src/test/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrixTest.java
+++ b/MultiLabel/Core/src/test/java/org/tribuo/multilabel/evaluation/MultiLabelConfusionMatrixTest.java
@@ -92,11 +92,14 @@ public class MultiLabelConfusionMatrixTest {
 
     @Test
     public void testTabulateSingleLabel() {
+        MultiLabel a = label("a");
+        MultiLabel b = label("b");
+        MultiLabel c = label("c");
         List<Prediction<MultiLabel>> predictions = Arrays.asList(
-                mkPrediction(label("a"), label("a")),
-                mkPrediction(label("c"), label("b")),
-                mkPrediction(label("b"), label("b")),
-                mkPrediction(label("b"), label("c"))
+            mkPrediction(a, a),
+            mkPrediction(c, b),
+            mkPrediction(b, b),
+            mkPrediction(b, c)
         );
         ImmutableOutputInfo<MultiLabel> domain = mkDomain(predictions);
 
@@ -104,18 +107,23 @@ public class MultiLabelConfusionMatrixTest {
                 .tabulate(domain, predictions)
                 .getMCM();
 
+        int aIndex = domain.getID(a);
+        int bIndex = domain.getID(b);
+        int cIndex = domain.getID(c);
+
         assertEquals(domain.size(), mcm.length);
-        assertEquals(3d, mcm[0].get(0, 0));
-        assertEquals(1d, mcm[0].get(1, 1));
 
-        assertEquals(1d, mcm[1].get(0, 0));
-        assertEquals(1d, mcm[1].get(0, 1));
-        assertEquals(1d, mcm[1].get(1, 0));
-        assertEquals(1d, mcm[1].get(1, 1));
+        assertEquals(3d, mcm[aIndex].get(0, 0));
+        assertEquals(1d, mcm[aIndex].get(1, 1));
 
-        assertEquals(2d, mcm[2].get(0, 0));
-        assertEquals(1d, mcm[2].get(0, 1));
-        assertEquals(1d, mcm[2].get(1, 0));
+        assertEquals(1d, mcm[bIndex].get(0, 0));
+        assertEquals(1d, mcm[bIndex].get(0, 1));
+        assertEquals(1d, mcm[bIndex].get(1, 0));
+        assertEquals(1d, mcm[bIndex].get(1, 1));
+
+        assertEquals(2d, mcm[cIndex].get(0, 0));
+        assertEquals(1d, mcm[cIndex].get(0, 1));
+        assertEquals(1d, mcm[cIndex].get(1, 0));
     }
 
     /**
@@ -162,6 +170,9 @@ public class MultiLabelConfusionMatrixTest {
 
     @Test
     public void testTabulateMultiLabel() {
+        MultiLabel a = label("a");
+        MultiLabel b = label("b");
+        MultiLabel c = label("c");
         List<Prediction<MultiLabel>> predictions = Arrays.asList(
                 mkPrediction(label("a"), label("a", "b")),
                 mkPrediction(label("c", "b"), label("b")),
@@ -176,17 +187,21 @@ public class MultiLabelConfusionMatrixTest {
                 .tabulate(domain, predictions)
                 .getMCM();
 
+        int aIndex = domain.getID(a);
+        int bIndex = domain.getID(b);
+        int cIndex = domain.getID(c);
+
         assertEquals(domain.size(), mcm.length);
-        assertEquals(3d, mcm[0].get(0, 0));
-        assertEquals(1d, mcm[0].get(1, 1));
+        assertEquals(3d, mcm[aIndex].get(0, 0));
+        assertEquals(1d, mcm[aIndex].get(1, 1));
 
-        assertEquals(1d, mcm[1].get(0, 1));
-        assertEquals(1d, mcm[1].get(1, 0));
-        assertEquals(2d, mcm[1].get(1, 1));
+        assertEquals(1d, mcm[bIndex].get(0, 1));
+        assertEquals(1d, mcm[bIndex].get(1, 0));
+        assertEquals(2d, mcm[bIndex].get(1, 1));
 
-        assertEquals(2d, mcm[2].get(0, 0));
-        assertEquals(1d, mcm[2].get(0, 1));
-        assertEquals(1d, mcm[2].get(1, 0));
+        assertEquals(2d, mcm[cIndex].get(0, 0));
+        assertEquals(1d, mcm[cIndex].get(0, 1));
+        assertEquals(1d, mcm[cIndex].get(1, 0));
     }
 
     @Test

--- a/Regression/Core/src/main/java/org/tribuo/regression/ImmutableRegressionInfo.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/ImmutableRegressionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Regression/Core/src/main/java/org/tribuo/regression/ImmutableRegressionInfo.java
+++ b/Regression/Core/src/main/java/org/tribuo/regression/ImmutableRegressionInfo.java
@@ -334,6 +334,23 @@ public class ImmutableRegressionInfo extends RegressionInfo implements Immutable
         return new ImmutableInfoIterator(idLabelMap);
     }
 
+    @Override
+    public boolean domainAndIDEquals(ImmutableOutputInfo<Regressor> other) {
+        if (size() == other.size()) {
+            for (Map.Entry<Integer,String> e : idLabelMap.entrySet()) {
+                Regressor otherReg = other.getOutput(e.getKey());
+                if (otherReg == null) {
+                    return false;
+                } else if (!otherReg.getDimensionNamesString().equals(e.getValue())) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     private static class ImmutableInfoIterator implements Iterator<Pair<Integer, Regressor>> {
 
         private final Iterator<Map.Entry<Integer,String>> itr;


### PR DESCRIPTION
### Description
When looking at the fix for #220 we found several other issues where Tribuo's behaviour depended on the iteration order of `HashSet`. These fell into a few categories: 

- issues where a test failed due to sorting functions being stable, but the presentation order being slightly non-deterministic (MNB, XGBoost, LinearSGD) - these were left as fixing them required changes in dependencies or intrusive changes to how predictions are generated.
- issues where the output of an evaluation `toString` depended on the label indices - these were fixed by adding/exposing methods to fix the label order, then updating the tests to use those methods.
- `WeightedEnsembleModel` assumed that the output indices of the ensemble members were the same, which in practice only affects ONNX export of ensemble models - this is fixed by tightening up the validation during ensemble creation, and adding ONNX gather ops to ensure that the output indices are consistent across models.
- `CategoricalInfo.uniformSample` and `CategoricalInfo.frequencyBasedSample` used methods which iterate the key or entry set of a `HashMap` to construct the sampling tables. While the outputs were always a valid sample from the distribution, this sample depended on the iteration order of the `HashMap` and so was not necessarily portable between machines or runs of the JVM. This has been fixed by sorting the entries using double's natural ordering before building the tables. This produces different samples to Tribuo 4.2.0 and earlier, but it is now self-consistent and will remain so.

### Motivation
Non-determinism is bad for a reproducible ML library.
