### PR TITLE
Bumping to liblinear-java 2.44

### DIFF
--- a/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
+++ b/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -187,15 +188,21 @@ public class TestLibLinearModel {
 
     @Test
     public void testReproducible() {
-        // Note this test will need to change if LibLinearTrainer grows a per Problem RNG.
         Pair<Dataset<Label>,Dataset<Label>> p = LabelledDataGenerator.denseTrainTest();
+        t.setInvocationCount(0);
         Model<Label> m = t.train(p.getA());
         Map<String, List<Pair<String,Double>>> mFeatures = m.getTopFeatures(-1);
 
+        t.setInvocationCount(0);
         Model<Label> mTwo = t.train(p.getA());
         Map<String, List<Pair<String,Double>>> mTwoFeatures = mTwo.getTopFeatures(-1);
 
         assertEquals(mFeatures,mTwoFeatures);
+
+        Model<Label> mThree = t.train(p.getA());
+        Map<String, List<Pair<String,Double>>> mThreeFeatures = mThree.getTopFeatures(-1);
+
+        assertNotEquals(mFeatures, mThreeFeatures);
     }
 
     @Test

--- a/Regression/LibLinear/src/test/java/org/tribuo/regression/liblinear/TestLibLinear.java
+++ b/Regression/LibLinear/src/test/java/org/tribuo/regression/liblinear/TestLibLinear.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,9 @@ public class TestLibLinear {
     @Test
     public void testThreeDenseData() {
         Pair<Dataset<Regressor>,Dataset<Regressor>> p = RegressionDataGenerator.threeDimDenseTrainTest(1.0, false);
-        LibLinearModel<Regressor> llModel = t.train(p.getA());
+        LibLinearRegressionTrainer localTrainer = new LibLinearRegressionTrainer(new LinearRegressionType(LinearType.L2R_L2LOSS_SVR_DUAL),1.0,1000,0.1,0.5);
+        localTrainer.forceZero = true;
+        LibLinearModel<Regressor> llModel = localTrainer.train(p.getA());
         RegressionEvaluation llEval = e.evaluate(llModel,p.getB());
         double expectedDim1 = 0.6634367596601265;
         double expectedDim2 = 0.6634367596601265;
@@ -116,7 +118,7 @@ public class TestLibLinear {
         assertEquals(expectedAve,llEval.averageR2(),1e-6);
 
         p = RegressionDataGenerator.threeDimDenseTrainTest(1.0, true);
-        llModel = t.train(p.getA());
+        llModel = localTrainer.train(p.getA());
         llEval = e.evaluate(llModel,p.getB());
 
         assertEquals(expectedDim1,llEval.r2(new Regressor(RegressionDataGenerator.firstDimensionName,Double.NaN)),1e-6);

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+  ~ Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@
         <oci.sdk.version>2.12.0</oci.sdk.version>
 
         <!-- 3rd party backend dependencies -->
-        <liblinear.version>2.43</liblinear.version>
+        <liblinear.version>2.44</liblinear.version>
         <libsvm.version>3.25</libsvm.version>
         <onnxruntime.version>1.9.0</onnxruntime.version>
         <tensorflow.version>0.4.1</tensorflow.version>


### PR DESCRIPTION
### Description
liblinear-java 2.44 has the fix for https://github.com/bwaldvogel/liblinear-java/issues/40, and so this PR migrates Tribuo over to use the new RNG setting methods available in that version. As a consequence it removes all the global locks on liblinear use that were in place from 4.2. This does mean that models trained in 4.2 will not reproduce exactly in 4.3+, though we could consider moving the `forceZero` trick used in the regression tests into the base class and exposing it to the reproducibility framework as a special case.

### Motivation
Allows liblinear models to be trained in parallel with consistent RNG behaviour as compared to the rest of Tribuo.
