### PR TITLE
Exposes views on the HDBSCAN cluster exemplars

### DIFF
--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanModel.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanModel.java
@@ -19,6 +19,7 @@ package org.tribuo.clustering.hdbscan;
 import com.oracle.labs.mlrg.olcut.util.Pair;
 import org.tribuo.Example;
 import org.tribuo.Excuse;
+import org.tribuo.Feature;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Model;
@@ -29,6 +30,7 @@ import org.tribuo.math.distance.DistanceType;
 import org.tribuo.math.la.DenseVector;
 import org.tribuo.math.la.SGDVector;
 import org.tribuo.math.la.SparseVector;
+import org.tribuo.math.la.VectorTuple;
 import org.tribuo.provenance.ModelProvenance;
 
 import java.io.IOException;
@@ -116,6 +118,31 @@ public final class HdbscanModel extends Model<ClusterID> {
         for (HdbscanTrainer.ClusterExemplar e : clusterExemplars) {
             list.add(e.copy());
         }
+        return list;
+    }
+
+    /**
+     * Returns the features in each cluster exemplar.
+     * <p>
+     * In many cases this should be used in preference to {@link #getClusterExemplars()}
+     * as it performs the mapping from Tribuo's internal feature ids to
+     * the externally visible feature names.
+     * @return The cluster exemplars.
+     */
+    public List<Pair<Integer,List<Feature>>> getClusters() {
+        List<Pair<Integer,List<Feature>>> list = new ArrayList<>(clusterExemplars.size());
+
+        for (HdbscanTrainer.ClusterExemplar e : clusterExemplars) {
+            List<Feature> features = new ArrayList<>(e.getFeatures().numActiveElements());
+
+            for (VectorTuple v : e.getFeatures()) {
+                Feature f = new Feature(featureIDMap.get(v.index).getName(),v.value);
+                features.add(f);
+            }
+
+            list.add(new Pair<>(e.getLabel(),features));
+        }
+
         return list;
     }
 

--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanModel.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanModel.java
@@ -107,6 +107,18 @@ public final class HdbscanModel extends Model<ClusterID> {
         return outlierScores;
     }
 
+    /**
+     * Returns a deep copy of the cluster exemplars.
+     * @return The cluster exemplars.
+     */
+    public List<HdbscanTrainer.ClusterExemplar> getClusterExemplars() {
+        List<HdbscanTrainer.ClusterExemplar> list = new ArrayList<>(clusterExemplars.size());
+        for (HdbscanTrainer.ClusterExemplar e : clusterExemplars) {
+            list.add(e.copy());
+        }
+        return list;
+    }
+
     @Override
     public Prediction<ClusterID> predict(Example<ClusterID> example) {
         SGDVector vector;

--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
@@ -50,6 +50,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -805,7 +806,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
     /**
      * A cluster exemplar, with attributes for the point's label, outlier score and its features.
      */
-    final static class ClusterExemplar implements Serializable {
+    public final static class ClusterExemplar implements Serializable {
         private static final long serialVersionUID = 1L;
 
         private final Integer label;
@@ -820,25 +821,70 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
             this.maxDistToEdge = maxDistToEdge;
         }
 
-        Integer getLabel() {
+        /**
+         * Get the label in this exemplar.
+         * @return The label.
+         */
+        public Integer getLabel() {
             return label;
         }
 
-        Double getOutlierScore() {
+        /**
+         * Get the outlier score in this exemplar.
+         * @return The outlier score.
+         */
+        public Double getOutlierScore() {
             return outlierScore;
         }
 
-        SGDVector getFeatures() {
+        /**
+         * Get the feature vector in this exemplar.
+         * @return The feature vector.
+         */
+        public SGDVector getFeatures() {
             return features;
         }
 
-        Double getMaxDistToEdge() {
+        /**
+         * Get the maximum distance from this exemplar to the edge of the cluster.
+         * <p>
+         * For models trained in 4.2 this will return {@link Double#NEGATIVE_INFINITY} as that information is 
+         * not produced by 4.2 models.
+         * @return The distance to the edge of the cluster.
+         */
+        public Double getMaxDistToEdge() {
             if (maxDistToEdge != null) {
                 return maxDistToEdge;
             }
             else {
                 return Double.NEGATIVE_INFINITY;
             }
+        }
+
+        /**
+         * Copies this cluster exemplar.
+         * @return A deep copy of this cluster exemplar.
+         */
+        public ClusterExemplar copy() {
+            return new ClusterExemplar(label,outlierScore,features.copy());
+        }
+
+        @Override
+        public String toString() {
+            return "ClusterExemplar(label="+label+",outlierScore="+outlierScore+",vector="+features+")";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ClusterExemplar that = (ClusterExemplar) o;
+            return label.equals(that.label) && outlierScore.equals(that.outlierScore) && features.equals(that.features);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(label, outlierScore, features);
         }
     }
     

--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
@@ -866,12 +866,13 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
          * @return A deep copy of this cluster exemplar.
          */
         public ClusterExemplar copy() {
-            return new ClusterExemplar(label,outlierScore,features.copy());
+            return new ClusterExemplar(label,outlierScore,features.copy(),maxDistToEdge);
         }
 
         @Override
         public String toString() {
-            return "ClusterExemplar(label="+label+",outlierScore="+outlierScore+",vector="+features+")";
+            double dist = maxDistToEdge == null ? Double.NEGATIVE_INFINITY : maxDistToEdge;
+            return "ClusterExemplar(label="+label+",outlierScore="+outlierScore+",vector="+features+",maxDistToEdge="+dist+")";
         }
 
         @Override
@@ -879,12 +880,12 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             ClusterExemplar that = (ClusterExemplar) o;
-            return label.equals(that.label) && outlierScore.equals(that.outlierScore) && features.equals(that.features);
+            return label.equals(that.label) && outlierScore.equals(that.outlierScore) && features.equals(that.features) && Objects.equals(maxDistToEdge, that.maxDistToEdge);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(label, outlierScore, features);
+            return Objects.hash(label, outlierScore, features, maxDistToEdge);
         }
     }
     


### PR DESCRIPTION
### Description
Adds a get method for cluster exemplars in HDBSCAN which returns copies of the exemplars (as the vector is mutable), along with a method that returns the exemplar in terms of feature names.

### Motivation
Fixes #217.
