### PR TITLE
Bumping to OLCUT 5.2.1

### DIFF
--- a/Interop/OCI/src/test/java/org/tribuo/interop/oci/OCIUtilTest.java
+++ b/Interop/OCI/src/test/java/org/tribuo/interop/oci/OCIUtilTest.java
@@ -37,7 +37,6 @@ public class OCIUtilTest {
                 "test_conda",
                 "oci://service-conda-packs@id19sfcrra6z/service_pack/cpu/Onnx for CPU Python 3.7/1.0/test_conda");
         Path zip = OCIUtil.createModelArtifact(new File(OCIUtilTest.class.getResource("iris-lr-model.onnx").toURI()).toPath(),config);
-        System.out.println(zip);
         zip.toFile().delete();
     }
 

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,4 +1,4 @@
-OLCUT 5.2.0 - BSD License
+OLCUT 5.2.1 - BSD License
 
 Copyright © 2020, 2021 Oracle and/or its affiliates.
 
@@ -113,9 +113,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-TensorFlow 0.4.0 - Apache 2.0
+TensorFlow 0.4.1 - Apache 2.0
 
-Copyright 2019, 2020, 2021 The TensorFlow Authors.  All rights reserved.
+Copyright 2019, 2020, 2022 The TensorFlow Authors.  All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -1908,7 +1908,7 @@ ONNX v1.9.0 - Apache 2.0
    See the License for the specific language governing permissions and
    limitations under the License.
 
-protobuf-java 3.17.3 - 3-clause BSD
+protobuf-java 3.19.4 - 3-clause BSD
 
 Copyright 2008 Google Inc.  All rights reserved.
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- MLRG dependencies -->
-        <olcut.version>5.2.0</olcut.version>
+        <olcut.version>5.2.1</olcut.version>
 
         <!-- Oracle dependencies -->
         <oci.sdk.version>2.12.0</oci.sdk.version>
@@ -58,7 +58,7 @@
         <junit.version>5.7.1</junit.version>
         <opencsv.version>5.4</opencsv.version>
         <commonsmath.version>3.6.1</commonsmath.version>
-        <protobuf.version>3.17.3</protobuf.version>
+        <protobuf.version>3.19.4</protobuf.version>
 
         <!-- Other properties -->
         <!-- Turn off tests which rely on native code -->


### PR DESCRIPTION
### Description
Bumps OLCUT to 5.2.1 from 5.2.0.

### Motivation
Pick up fixes in OLCUT's dependencies.
