### PR TITLE
Fix for exemplars from small clusters

### DIFF
--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
@@ -774,7 +774,10 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
                 TreeMap<Double, Integer> outlierScoreIndexTree = new TreeMap<>();
                 outlierScoreIndexList.forEach(p -> outlierScoreIndexTree.put(p.getA(), p.getB()));
                 int numExemplarsThisCluster = e.getValue().size() * numExemplars / data.length;
-                if (numExemplarsThisCluster > outlierScoreIndexTree.size()) {
+                if (numExemplarsThisCluster == 0) {
+                    numExemplarsThisCluster = 1;
+                }
+                else if (numExemplarsThisCluster > outlierScoreIndexTree.size()) {
                     numExemplarsThisCluster = outlierScoreIndexTree.size();
                 }
 


### PR DESCRIPTION
### Description
This change fixes an issue where clusters with small numbers of members don't have any exemplars sampled. The issue was identified by @Craigacp during some recent dev testing.

### Motivation
Every cluster should have at least one exemplar which can be used for predictions.
