### PR TITLE
Validate the hash salt during object creation

### DIFF
--- a/Core/src/main/java/org/tribuo/hash/HashCodeHasher.java
+++ b/Core/src/main/java/org/tribuo/hash/HashCodeHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.tribuo.hash;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import com.oracle.labs.mlrg.olcut.provenance.ConfiguredObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.Provenance;
 import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
@@ -48,6 +49,7 @@ public final class HashCodeHasher extends Hasher {
      */
     public HashCodeHasher(String salt) {
         this.salt = salt;
+        postConfig();
     }
 
     @Override
@@ -57,6 +59,19 @@ public final class HashCodeHasher extends Hasher {
         }
         String salted = salt + name;
         return ""+salted.hashCode();
+    }
+
+    /**
+     * Used by the OLCUT configuration system, and should not be called by external code.
+     */
+    @Override
+    public synchronized void postConfig() throws PropertyException{
+        if (salt == null) {
+            throw new PropertyException("","salt","Salt not set in HashCodeHasher.");
+        }
+        else if (!Hasher.validateSalt(salt)) {
+            throw new PropertyException("","salt","Salt does not meet the requirements for a salt.");
+        }
     }
 
     @Override

--- a/Core/src/main/java/org/tribuo/hash/HashCodeHasher.java
+++ b/Core/src/main/java/org/tribuo/hash/HashCodeHasher.java
@@ -65,11 +65,10 @@ public final class HashCodeHasher extends Hasher {
      * Used by the OLCUT configuration system, and should not be called by external code.
      */
     @Override
-    public synchronized void postConfig() throws PropertyException{
+    public void postConfig() throws PropertyException{
         if (salt == null) {
             throw new PropertyException("","salt","Salt not set in HashCodeHasher.");
-        }
-        else if (!Hasher.validateSalt(salt)) {
+        } else if (!Hasher.validateSalt(salt)) {
             throw new PropertyException("","salt","Salt does not meet the requirements for a salt.");
         }
     }

--- a/Core/src/main/java/org/tribuo/hash/Hasher.java
+++ b/Core/src/main/java/org/tribuo/hash/Hasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Core/src/main/java/org/tribuo/hash/MessageDigestHasher.java
+++ b/Core/src/main/java/org/tribuo/hash/MessageDigestHasher.java
@@ -88,7 +88,7 @@ public final class MessageDigestHasher extends Hasher {
      * Used by the OLCUT configuration system, and should not be called by external code.
      */
     @Override
-    public synchronized void postConfig() throws PropertyException {
+    public void postConfig() throws PropertyException {
         if (saltStr != null) {
             if (!Hasher.validateSalt(saltStr)) {
                 throw new PropertyException("","saltStr","Salt does not meet the requirements for a salt.");

--- a/Core/src/main/java/org/tribuo/hash/MessageDigestHasher.java
+++ b/Core/src/main/java/org/tribuo/hash/MessageDigestHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,9 @@ public final class MessageDigestHasher extends Hasher {
      */
     public MessageDigestHasher(String hashType, String salt) {
         this.hashType = hashType;
+        if (!Hasher.validateSalt(salt)) {
+            throw new IllegalArgumentException("Salt: '" + salt + ", does not meet the requirements for a salt.");
+        }
         this.salt = salt.getBytes(utf8Charset);
         this.md = ThreadLocal.withInitial(getDigestSupplier(hashType));
         MessageDigest d = this.md.get(); // To trigger the unsupported digest exception.
@@ -85,8 +88,11 @@ public final class MessageDigestHasher extends Hasher {
      * Used by the OLCUT configuration system, and should not be called by external code.
      */
     @Override
-    public void postConfig() throws PropertyException {
+    public synchronized void postConfig() throws PropertyException {
         if (saltStr != null) {
+            if (!Hasher.validateSalt(saltStr)) {
+                throw new PropertyException("","saltStr","Salt does not meet the requirements for a salt.");
+            }
             salt = saltStr.getBytes(utf8Charset);
         } else {
             throw new PropertyException("","saltStr","Salt not set in MessageDigestHasher.");

--- a/Core/src/main/java/org/tribuo/hash/ModHashCodeHasher.java
+++ b/Core/src/main/java/org/tribuo/hash/ModHashCodeHasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.tribuo.hash;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import com.oracle.labs.mlrg.olcut.provenance.ConfiguredObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.Provenance;
@@ -73,7 +74,13 @@ public final class ModHashCodeHasher extends Hasher {
      * Used by the OLCUT configuration system, and should not be called by external code.
      */
     @Override
-    public void postConfig() {
+    public synchronized void postConfig() throws PropertyException {
+        if (salt == null) {
+            throw new PropertyException("","salt","Salt not set in ModHashCodeHasher.");
+        }
+        else if (!Hasher.validateSalt(salt)) {
+            throw new PropertyException("","salt","Salt does not meet the requirements for a salt.");
+        }
         this.provenance = new ModHashCodeHasherProvenance(dimension);
     }
 

--- a/Core/src/main/java/org/tribuo/hash/ModHashCodeHasher.java
+++ b/Core/src/main/java/org/tribuo/hash/ModHashCodeHasher.java
@@ -74,11 +74,10 @@ public final class ModHashCodeHasher extends Hasher {
      * Used by the OLCUT configuration system, and should not be called by external code.
      */
     @Override
-    public synchronized void postConfig() throws PropertyException {
+    public void postConfig() throws PropertyException {
         if (salt == null) {
             throw new PropertyException("","salt","Salt not set in ModHashCodeHasher.");
-        }
-        else if (!Hasher.validateSalt(salt)) {
+        } else if (!Hasher.validateSalt(salt)) {
             throw new PropertyException("","salt","Salt does not meet the requirements for a salt.");
         }
         this.provenance = new ModHashCodeHasherProvenance(dimension);

--- a/Core/src/test/java/org/tribuo/hash/HasherTests.java
+++ b/Core/src/test/java/org/tribuo/hash/HasherTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.hash;
+
+import com.oracle.labs.mlrg.olcut.config.PropertyException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HasherTests {
+
+    private static final String VALID_SALT = "aSaltString";
+    private static final String ANOTHER_VALID_SALT = "anotherSaltString";
+    private static final String INVALID_SALT = "tooShort";
+    private static final String ANOTHER_INVALID_SALT = "wayShort";
+
+    private static void hasherSimpleTest(Hasher hasher, String firstHashedStr, String secondHashedStr) {
+        assertEquals(firstHashedStr, hasher.hash("AStringToHash"));
+        hasher.setSalt(ANOTHER_VALID_SALT);
+        assertEquals(secondHashedStr, hasher.hash("AStringToHash"));
+    }
+
+    @Test
+    public void hashCodeHasherSimpleTest() {
+        Hasher hasher = new HashCodeHasher(VALID_SALT);
+        hasherSimpleTest(hasher, "365284915", "509047121");
+    }
+
+    @Test
+    public void hashCodeHasherConstructThrows() {
+        assertThrows(PropertyException.class, () -> new HashCodeHasher(INVALID_SALT));
+    }
+
+    @Test
+    public void hashCodeHasherSetSaltThrows() {
+        Hasher hasher = new HashCodeHasher(VALID_SALT);
+        assertThrows(IllegalArgumentException.class, () -> hasher.setSalt(ANOTHER_INVALID_SALT));
+    }
+
+    @Test void messageDigestHasherSimpleTest() {
+        Hasher hasher = new MessageDigestHasher("SHA-256", VALID_SALT);
+        hasherSimpleTest(hasher, "akemHZ4RWFogeccq7nVBoIYDeqES2oEb2yKamVIOz+k=",
+            "pFa7A2fVQHsumKMVkgoLnagSxzrHwVgBCAOvq52c9XI=");
+    }
+
+    @Test
+    public void messageDigestHasherConstructThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new MessageDigestHasher("SHA-256", INVALID_SALT));
+    }
+
+    @Test
+    public void messageDigestHasherSetSaltThrows() {
+        Hasher hasher = new MessageDigestHasher("SHA1", VALID_SALT);
+        assertThrows(IllegalArgumentException.class, () -> hasher.setSalt(ANOTHER_INVALID_SALT));
+    }
+
+    @Test
+    public void modHashCodeHasherSimpleTest() {
+        Hasher hasher = new ModHashCodeHasher(VALID_SALT);
+        hasherSimpleTest(hasher, "15", "21");
+    }
+
+    @Test
+    public void modHashCodeHasherConstructThrows() {
+        assertThrows(PropertyException.class, () -> new ModHashCodeHasher(INVALID_SALT));
+    }
+
+    @Test
+    public void modHashCodeHasherSetSaltThrows() {
+        Hasher hasher = new ModHashCodeHasher(VALID_SALT);
+        assertThrows(IllegalArgumentException.class, () -> hasher.setSalt(ANOTHER_INVALID_SALT));
+    }
+}


### PR DESCRIPTION
### Description
These changes add validations of the hash salt during object creation, either programmatically or via the Configuration System.

### Motivation
These changes fix #233 
