### PR TITLE
Add more accessors to TransformedModel

### DIFF
--- a/Core/src/main/java/org/tribuo/transform/TransformedModel.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformedModel.java
@@ -77,6 +77,26 @@ public class TransformedModel<T extends Output<T>> extends Model<T> {
         return transformerMap;
     }
 
+    /**
+     * Gets the inner model to allow access to any class specific methods
+     * that model contains (e.g., to examine cluster centroids).
+     * <p>
+     * Note that this model expects all examples to have been transformed using
+     * the transformer map, which can be extracted with {@link #getTransformerMap}.
+     * @return The inner model.
+     */
+    public Model<T> getInnerModel() {
+        return innerModel;
+    }
+
+    /**
+     * Returns true if the model densifies the feature space before applying the transformations.
+     * @return True if the transforms operate on the dense feature space.
+     */
+    public boolean getDensify() {
+        return densify;
+    }
+
     @Override
     public Prediction<T> predict(Example<T> example) {
         Example<T> transformedExample;

--- a/Core/src/main/java/org/tribuo/transform/TransformedModel.java
+++ b/Core/src/main/java/org/tribuo/transform/TransformedModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description
Adds accessors to `TransformedModel` which allow access to the wrapped model, so users can call model specific methods.

### Motivation
Allows users to see the cluster centroids of the transformed model. Fixes #242.
