### PR TITLE
Bumping XGBoost to 1.6.1

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -319,7 +319,7 @@ Copyright 2019, 2020, 2022 The TensorFlow Authors.  All rights reserved.
    See the License for the specific language governing permissions and
    limitations under the License.
 
-XGBoost 1.5.0 - Apache 2.0
+XGBoost 1.6.1 - Apache 2.0
 
                                  Apache License
                            Version 2.0, January 2004

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <libsvm.version>3.25</libsvm.version>
         <onnxruntime.version>1.9.0</onnxruntime.version>
         <tensorflow.version>0.4.1</tensorflow.version>
-        <xgboost.version>1.5.0</xgboost.version>
+        <xgboost.version>1.6.1</xgboost.version>
 
         <!-- 3rd party other dependencies -->
         <junit.version>5.7.1</junit.version>


### PR DESCRIPTION
### Description
Bumps XGBoost to the latest version.

### Motivation
Supported versions are better.
