### PR TITLE
Bumping to oci-java-sdk 2.38.0

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1484,9 +1484,9 @@ of the input file used when generating it.  This code is not
 standalone and requires a support library to be linked with it.  This
 support library is itself covered by the above license.
 
-oci-java-sdk 2.12.0 - Dual licensed UPL/Apache 2.0
+oci-java-sdk 2.38.0 - Dual licensed UPL/Apache 2.0
 
-Copyright (c) 2016, 2020, Oracle and/or its affiliates.  All rights reserved.
+Copyright (c) 2016, 2022, Oracle and/or its affiliates.  All rights reserved.
 
 This software is dual-licensed to you under the Universal Permissive License (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl
 or Apache License 2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose either license.

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <olcut.version>5.2.1</olcut.version>
 
         <!-- Oracle dependencies -->
-        <oci.sdk.version>2.12.0</oci.sdk.version>
+        <oci.sdk.version>2.38.0</oci.sdk.version>
 
         <!-- 3rd party backend dependencies -->
         <liblinear.version>2.44</liblinear.version>


### PR DESCRIPTION
### Description
Bumps to the latest version of the OCI Java SDK.

### Motivation
Newer versions are better.
