### PR TITLE
Bumping OpenCSV to 5.6

### DIFF
--- a/Data/pom.xml
+++ b/Data/pom.xml
@@ -53,6 +53,18 @@
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>${opencsv.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- pin commons lang3 after excluding it from OpenCSV due to convergence issues. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -524,7 +524,7 @@ XGBoost 1.5.0 - Apache 2.0
    limitations under the License.
 
 
-OpenCSV 5.4 - Apache 2.0
+OpenCSV 5.6 - Apache 2.0
 
                                  Apache License
                            Version 2.0, January 2004

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
         <!-- 3rd party other dependencies -->
         <junit.version>5.7.1</junit.version>
-        <opencsv.version>5.4</opencsv.version>
+        <opencsv.version>5.6</opencsv.version>
         <protobuf.version>3.19.4</protobuf.version>
 
         <!-- Other properties -->


### PR DESCRIPTION
### Description
Bumps to the latest version of OpenCSV.

### Motivation
Newer versions are better.
