### PR TITLE
reduced duplicate code by creating deserializeExamples methods in

### DIFF
--- a/Core/src/main/java/org/tribuo/Dataset.java
+++ b/Core/src/main/java/org/tribuo/Dataset.java
@@ -24,10 +24,8 @@ import org.tribuo.protos.ProtoSerializable;
 import org.tribuo.protos.ProtoUtil;
 import org.tribuo.protos.core.DatasetProto;
 import org.tribuo.protos.core.ExampleProto;
-import org.tribuo.protos.core.SequenceExampleProto;
 import org.tribuo.provenance.DataProvenance;
 import org.tribuo.provenance.DatasetProvenance;
-import org.tribuo.sequence.SequenceExample;
 import org.tribuo.transform.TransformStatistics;
 import org.tribuo.transform.Transformation;
 import org.tribuo.transform.TransformationMap;
@@ -501,7 +499,7 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
         }
     }
 
-    protected static List<Example<?>> deserializeExamples(java.util.List<org.tribuo.protos.core.ExampleProto> examplesList, Class<?> outputClass, FeatureMap fmap) {
+    protected static List<Example<?>> deserializeExamples(List<ExampleProto> examplesList, Class<?> outputClass, FeatureMap fmap) {
         List<Example<?>> examples = new ArrayList<>();
         for (ExampleProto e : examplesList) {
             Example<?> example = Example.deserialize(e);

--- a/Core/src/main/java/org/tribuo/Dataset.java
+++ b/Core/src/main/java/org/tribuo/Dataset.java
@@ -23,8 +23,11 @@ import org.tribuo.impl.DatasetDataCarrier;
 import org.tribuo.protos.ProtoSerializable;
 import org.tribuo.protos.ProtoUtil;
 import org.tribuo.protos.core.DatasetProto;
+import org.tribuo.protos.core.ExampleProto;
+import org.tribuo.protos.core.SequenceExampleProto;
 import org.tribuo.provenance.DataProvenance;
 import org.tribuo.provenance.DatasetProvenance;
+import org.tribuo.sequence.SequenceExample;
 import org.tribuo.transform.TransformStatistics;
 import org.tribuo.transform.Transformation;
 import org.tribuo.transform.TransformationMap;
@@ -498,5 +501,22 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
         }
     }
 
+    protected static List<Example<?>> deserializeExamples(java.util.List<org.tribuo.protos.core.ExampleProto> examplesList, Class<?> outputClass, FeatureMap fmap) {
+        List<Example<?>> examples = new ArrayList<>();
+        for (ExampleProto e : examplesList) {
+            Example<?> example = Example.deserialize(e);
+            if (example.getOutput().getClass().equals(outputClass)) {
+                for (Feature f : example) {
+                   if (fmap.get(f.getName()) == null) {
+                       throw new IllegalStateException("Invalid protobuf, feature domain does not contain feature " + f.getName() + " present in an example");
+                   }
+                }
+                examples.add(example);
+            } else {
+                throw new IllegalStateException("Invalid protobuf, expected all examples to have output class " + outputClass + ", but found " + example.getOutput().getClass());
+            }
+        }
+        return examples;
+    }
 }
 

--- a/Core/src/main/java/org/tribuo/ImmutableDataset.java
+++ b/Core/src/main/java/org/tribuo/ImmutableDataset.java
@@ -190,20 +190,7 @@ public class ImmutableDataset<T extends Output<T>> extends Dataset<T> implements
         DatasetDataCarrier<?> carrier = DatasetDataCarrier.deserialize(proto.getMetadata());
         Class<?> outputClass = carrier.outputFactory().getUnknownOutput().getClass();
         FeatureMap fmap = carrier.featureDomain();
-        List<Example<?>> examples = new ArrayList<>();
-        for (ExampleProto e : proto.getExamplesList()) {
-            Example<?> example = Example.deserialize(e);
-            if (example.getOutput().getClass().equals(outputClass)) {
-                for (Feature f : example) {
-                   if (fmap.get(f.getName()) == null) {
-                       throw new IllegalStateException("Invalid protobuf, feature domain does not contain feature " + f.getName() + " present in an example");
-                   }
-                }
-                examples.add(example);
-            } else {
-                throw new IllegalStateException("Invalid protobuf, expected all examples to have output class " + outputClass + ", but found " + example.getOutput().getClass());
-            }
-        }
+        List<Example<?>> examples = deserializeExamples(proto.getExamplesList(), outputClass, fmap);
         if (!(fmap instanceof ImmutableFeatureMap)) {
             throw new IllegalStateException("Invalid protobuf, feature map was not immutable");
         }

--- a/Core/src/main/java/org/tribuo/MutableDataset.java
+++ b/Core/src/main/java/org/tribuo/MutableDataset.java
@@ -26,6 +26,7 @@ import org.tribuo.protos.core.ExampleProto;
 import org.tribuo.protos.core.MutableDatasetProto;
 import org.tribuo.provenance.DataProvenance;
 import org.tribuo.provenance.DatasetProvenance;
+import org.tribuo.sequence.SequenceExample;
 import org.tribuo.transform.TransformerMap;
 
 import java.util.ArrayList;
@@ -132,20 +133,7 @@ public class MutableDataset<T extends Output<T>> extends Dataset<T> {
         DatasetDataCarrier<?> carrier = DatasetDataCarrier.deserialize(proto.getMetadata());
         Class<?> outputClass = carrier.outputFactory().getUnknownOutput().getClass();
         FeatureMap fmap = carrier.featureDomain();
-        List<Example<?>> examples = new ArrayList<>();
-        for (ExampleProto e : proto.getExamplesList()) {
-            Example<?> example = Example.deserialize(e);
-            if (example.getOutput().getClass().equals(outputClass)) {
-                for (Feature f : example) {
-                   if (fmap.get(f.getName()) == null) {
-                       throw new IllegalStateException("Invalid protobuf, feature domain does not contain feature " + f.getName() + " present in an example");
-                   }
-                }
-                examples.add(example);
-            } else {
-                throw new IllegalStateException("Invalid protobuf, expected all examples to have output class " + outputClass + ", but found " + example.getOutput().getClass());
-            }
-        }
+        List<Example<?>> examples = deserializeExamples(proto.getExamplesList(), outputClass, fmap);
         if (!(fmap instanceof MutableFeatureMap)) {
             throw new IllegalStateException("Invalid protobuf, feature map was not mutable");
         }

--- a/Core/src/main/java/org/tribuo/MutableDataset.java
+++ b/Core/src/main/java/org/tribuo/MutableDataset.java
@@ -22,11 +22,9 @@ import com.oracle.labs.mlrg.olcut.provenance.ListProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
 import org.tribuo.impl.DatasetDataCarrier;
 import org.tribuo.protos.core.DatasetProto;
-import org.tribuo.protos.core.ExampleProto;
 import org.tribuo.protos.core.MutableDatasetProto;
 import org.tribuo.provenance.DataProvenance;
 import org.tribuo.provenance.DatasetProvenance;
-import org.tribuo.sequence.SequenceExample;
 import org.tribuo.transform.TransformerMap;
 
 import java.util.ArrayList;

--- a/Core/src/main/java/org/tribuo/dataset/MinimumCardinalityDataset.java
+++ b/Core/src/main/java/org/tribuo/dataset/MinimumCardinalityDataset.java
@@ -164,20 +164,7 @@ public class MinimumCardinalityDataset<T extends Output<T>> extends ImmutableDat
         DatasetDataCarrier<?> carrier = DatasetDataCarrier.deserialize(proto.getMetadata());
         Class<?> outputClass = carrier.outputFactory().getUnknownOutput().getClass();
         FeatureMap fmap = carrier.featureDomain();
-        List<Example<?>> examples = new ArrayList<>();
-        for (ExampleProto e : proto.getExamplesList()) {
-            Example<?> example = Example.deserialize(e);
-            if (example.getOutput().getClass().equals(outputClass)) {
-                for (Feature f : example) {
-                    if (fmap.get(f.getName()) == null) {
-                        throw new IllegalStateException("Invalid protobuf, feature domain does not contain feature " + f.getName() + " present in an example");
-                    }
-                }
-                examples.add(example);
-            } else {
-                throw new IllegalStateException("Invalid protobuf, expected all examples to have output class " + outputClass + ", but found " + example.getOutput().getClass());
-            }
-        }
+        List<Example<?>> examples = deserializeExamples(proto.getExamplesList(), outputClass, fmap);
         if (!(fmap instanceof ImmutableFeatureMap)) {
             throw new IllegalStateException("Invalid protobuf, feature map was not immutable");
         }

--- a/Core/src/main/java/org/tribuo/sequence/ImmutableSequenceDataset.java
+++ b/Core/src/main/java/org/tribuo/sequence/ImmutableSequenceDataset.java
@@ -168,22 +168,7 @@ public class ImmutableSequenceDataset<T extends Output<T>> extends SequenceDatas
         DatasetDataCarrier<?> carrier = DatasetDataCarrier.deserialize(proto.getMetadata());
         Class<?> outputClass = carrier.outputFactory().getUnknownOutput().getClass();
         FeatureMap fmap = carrier.featureDomain();
-        List<SequenceExample<?>> examples = new ArrayList<>();
-        for (SequenceExampleProto e : proto.getExamplesList()) {
-            SequenceExample<?> seq = SequenceExample.deserialize(e);
-            for (Example<?> example : seq) {
-                if (example.getOutput().getClass().equals(outputClass)) {
-                    for (Feature f : example) {
-                        if (fmap.get(f.getName()) == null) {
-                            throw new IllegalStateException("Invalid protobuf, feature domain does not contain feature " + f.getName() + " present in an example");
-                        }
-                    }
-                } else {
-                    throw new IllegalStateException("Invalid protobuf, expected all examples to have output class " + outputClass + ", but found " + example.getOutput().getClass());
-                }
-            }
-            examples.add(seq);
-        }
+        List<SequenceExample<?>> examples = deserializeExamples(proto.getExamplesList(), outputClass, fmap);
         if (!(fmap instanceof ImmutableFeatureMap)) {
             throw new IllegalStateException("Invalid protobuf, feature map was not immutable");
         }

--- a/Core/src/main/java/org/tribuo/sequence/MinimumCardinalitySequenceDataset.java
+++ b/Core/src/main/java/org/tribuo/sequence/MinimumCardinalitySequenceDataset.java
@@ -182,22 +182,7 @@ public class MinimumCardinalitySequenceDataset<T extends Output<T>> extends Immu
         DatasetDataCarrier<?> carrier = DatasetDataCarrier.deserialize(proto.getMetadata());
         Class<?> outputClass = carrier.outputFactory().getUnknownOutput().getClass();
         FeatureMap fmap = carrier.featureDomain();
-        List<SequenceExample<?>> examples = new ArrayList<>();
-        for (SequenceExampleProto e : proto.getExamplesList()) {
-            SequenceExample<?> seq = SequenceExample.deserialize(e);
-            for (Example<?> example : seq) {
-                if (example.getOutput().getClass().equals(outputClass)) {
-                    for (Feature f : example) {
-                        if (fmap.get(f.getName()) == null) {
-                            throw new IllegalStateException("Invalid protobuf, feature domain does not contain feature " + f.getName() + " present in an example");
-                        }
-                    }
-                } else {
-                    throw new IllegalStateException("Invalid protobuf, expected all examples to have output class " + outputClass + ", but found " + example.getOutput().getClass());
-                }
-            }
-            examples.add(seq);
-        }
+        List<SequenceExample<?>> examples = deserializeExamples(proto.getExamplesList(), outputClass, fmap);
         if (!(fmap instanceof ImmutableFeatureMap)) {
             throw new IllegalStateException("Invalid protobuf, feature map was not immutable");
         }

--- a/Core/src/main/java/org/tribuo/sequence/MutableSequenceDataset.java
+++ b/Core/src/main/java/org/tribuo/sequence/MutableSequenceDataset.java
@@ -143,22 +143,7 @@ public class MutableSequenceDataset<T extends Output<T>> extends SequenceDataset
         DatasetDataCarrier<?> carrier = DatasetDataCarrier.deserialize(proto.getMetadata());
         Class<?> outputClass = carrier.outputFactory().getUnknownOutput().getClass();
         FeatureMap fmap = carrier.featureDomain();
-        List<SequenceExample<?>> examples = new ArrayList<>();
-        for (SequenceExampleProto e : proto.getExamplesList()) {
-            SequenceExample<?> seq = SequenceExample.deserialize(e);
-            for (Example<?> example : seq) {
-                if (example.getOutput().getClass().equals(outputClass)) {
-                    for (Feature f : example) {
-                        if (fmap.get(f.getName()) == null) {
-                            throw new IllegalStateException("Invalid protobuf, feature domain does not contain feature " + f.getName() + " present in an example");
-                        }
-                    }
-                } else {
-                    throw new IllegalStateException("Invalid protobuf, expected all examples to have output class " + outputClass + ", but found " + example.getOutput().getClass());
-                }
-            }
-            examples.add(seq);
-        }
+        List<SequenceExample<?>> examples = deserializeExamples(proto.getExamplesList(), outputClass, fmap);
         if (!(fmap instanceof MutableFeatureMap)) {
             throw new IllegalStateException("Invalid protobuf, feature map was not mutable");
         }

--- a/Core/src/main/java/org/tribuo/sequence/SequenceDataset.java
+++ b/Core/src/main/java/org/tribuo/sequence/SequenceDataset.java
@@ -213,7 +213,7 @@ public abstract class SequenceDataset<T extends Output<T>> implements Iterable<S
         }
     }
 
-    protected static List<SequenceExample<?>> deserializeExamples(java.util.List<org.tribuo.protos.core.SequenceExampleProto> examplesList, Class<?> outputClass, FeatureMap fmap) {
+    protected static List<SequenceExample<?>> deserializeExamples(List<SequenceExampleProto> examplesList, Class<?> outputClass, FeatureMap fmap) {
         List<SequenceExample<?>> examples = new ArrayList<>();
         for (SequenceExampleProto e : examplesList) {
             SequenceExample<?> seq = SequenceExample.deserialize(e);


### PR DESCRIPTION
### Description
Reduce redundant code by creating a `deserializeExamples` method in both `Dataset` and `SequenceDataset` classes as a protected static method that the respective impls can use instead of repeating code.  
### Motivation
This is a cosmetic change to simplify code maintenance by consolidating redundant code. 

This small change came out of the review for PR #264.
