### PR TITLE
Fixes for test failures when running in a path with spaces in

### DIFF
--- a/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
+++ b/Classification/LibLinear/src/test/java/org/tribuo/classification/liblinear/TestLibLinearModel.java
@@ -52,6 +52,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -74,12 +76,19 @@ public class TestLibLinearModel {
 
     private static final LibLinearClassificationTrainer t = new LibLinearClassificationTrainer();
 
-    //on Windows, this resolves to some nonsense like this: /C:/workspace/Classification/LibLinear/target/test-classes/test_input.tribuo
-    //and the leading slash is a problem and causes this test to fail on windows.
-    //it's generally poor practice to convert a resource to a path because the file won't normally exist as a file at runtime
-    //it only works at test time because ./target/test-classes/ is a folder that exists and it is on the classpath.
-    private final String TEST_INPUT_PATH = this.getClass().getResource("/test_input_binary.tribuo").getPath().replaceFirst("^/(.:/)", "$1");
-    private final String TEST_INPUT_PATH_MULTICLASS = this.getClass().getResource("/test_input_multiclass.tribuo").getPath().replaceFirst("^/(.:/)", "$1");
+    private static final Path TEST_INPUT_PATH;
+    private static final Path TEST_INPUT_PATH_MULTICLASS;
+    static {
+        URL input = null;
+        try {
+            input = TestLibLinearModel.class.getResource("/test_input_binary.tribuo");
+            TEST_INPUT_PATH = Paths.get(input.toURI());
+            input = TestLibLinearModel.class.getResource("/test_input_multiclass.tribuo");
+            TEST_INPUT_PATH_MULTICLASS = Paths.get(input.toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Invalid URL to test resource " + input);
+        }
+    }
 
     @Test
     public void testPredictDataset() throws IOException, ClassNotFoundException {
@@ -141,20 +150,20 @@ public class TestLibLinearModel {
     }
 
     private LibLinearClassificationModel loadModel(String path) throws IOException, ClassNotFoundException {
-        File modelFile = new File(this.getClass().getResource(path).getPath());
-        assertTrue(modelFile.exists(),String.format("model for %s does not exist", path));
-        try (ObjectInputStream oin = new ObjectInputStream(new FileInputStream(modelFile))) {
+        URL modelFile = this.getClass().getResource(path);
+        assertNotNull(modelFile, String.format("model for %s does not exist", path));
+        try (ObjectInputStream oin = new ObjectInputStream(modelFile.openStream())) {
             Object data = oin.readObject();
             return (LibLinearClassificationModel) data;
         }
     }
 
     private Dataset<Label> loadTestDataset(LibLinearClassificationModel model) throws IOException {
-        return loadDataset(model, Paths.get(TEST_INPUT_PATH));
+        return loadDataset(model, TEST_INPUT_PATH);
     }
 
     private Dataset<Label> loadMulticlassTestDataset(LibLinearClassificationModel model) throws IOException {
-        return loadDataset(model, Paths.get(TEST_INPUT_PATH_MULTICLASS));
+        return loadDataset(model, TEST_INPUT_PATH_MULTICLASS);
     }
 
     private Dataset<Label> loadDataset(LibLinearClassificationModel model, Path path) throws IOException {

--- a/Classification/XGBoost/src/test/java/org/tribuo/classification/xgboost/TestXGBoost.java
+++ b/Classification/XGBoost/src/test/java/org/tribuo/classification/xgboost/TestXGBoost.java
@@ -44,10 +44,10 @@ import org.junit.jupiter.api.Test;
 import org.tribuo.test.Helpers;
 import org.tribuo.util.tokens.impl.BreakIteratorTokenizer;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -77,12 +77,19 @@ public class TestXGBoost {
 
     private static final int[] NUM_TREES = new int[]{1,5,10,50};
 
-    //on Windows, this resolves to some nonsense like this: /C:/workspace/Classification/XGBoost/target/test-classes/test_input.tribuo
-    //and the leading slash is a problem and causes this test to fail on windows.
-    //it's generally poor practice to convert a resource to a path because the file won't normally exist as a file at runtime
-    //it only works at test time because ./target/test-classes/ is a folder that exists and it is on the classpath.
-    private final String TEST_INPUT_PATH = this.getClass().getResource("/test_input_binary.tribuo").getPath().replaceFirst("^/(.:/)", "$1");
-    private final String TEST_INPUT_PATH_MULTICLASS = this.getClass().getResource("/test_input_multiclass.tribuo").getPath().replaceFirst("^/(.:/)", "$1");
+    private static final Path TEST_INPUT_PATH;
+    private static final Path TEST_INPUT_PATH_MULTICLASS;
+    static {
+        URL input = null;
+        try {
+            input = TestXGBoost.class.getResource("/test_input_binary.tribuo");
+            TEST_INPUT_PATH = Paths.get(input.toURI());
+            input = TestXGBoost.class.getResource("/test_input_multiclass.tribuo");
+            TEST_INPUT_PATH_MULTICLASS = Paths.get(input.toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Invalid URL to test resource " + input);
+        }
+    }
 
     @Test
     public void testSingleClassTraining() {
@@ -144,8 +151,8 @@ public class TestXGBoost {
     }
 
     private XGBoostModel<Label> loadModel(String path) throws IOException, ClassNotFoundException {
-        File modelFile = new File(this.getClass().getResource(path).getPath());
-        try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(modelFile))) {
+        URL modelFile = this.getClass().getResource(path);
+        try (ObjectInputStream ois = new ObjectInputStream(modelFile.openStream())) {
             @SuppressWarnings("unchecked") // checked by validate call.
             XGBoostModel<Label> data = (XGBoostModel<Label>) ois.readObject();
             if (!data.validate(Label.class)) {
@@ -159,11 +166,11 @@ public class TestXGBoost {
     }
 
     private Dataset<Label> loadTestDataset(XGBoostModel<Label> model) throws IOException {
-        return loadDataset(model, Paths.get(TEST_INPUT_PATH));
+        return loadDataset(model, TEST_INPUT_PATH);
     }
 
     private Dataset<Label> loadMulticlassTestDataset(XGBoostModel<Label> model) throws IOException {
-        return loadDataset(model, Paths.get(TEST_INPUT_PATH_MULTICLASS));
+        return loadDataset(model, TEST_INPUT_PATH_MULTICLASS);
     }
 
     private Dataset<Label> loadDataset(XGBoostModel<Label> model, Path path) throws IOException {

--- a/Common/NearestNeighbour/src/test/java/org/tribuo/common/nearest/TestKNN.java
+++ b/Common/NearestNeighbour/src/test/java/org/tribuo/common/nearest/TestKNN.java
@@ -39,9 +39,9 @@ import org.tribuo.regression.evaluation.RegressionEvaluator;
 import org.tribuo.regression.example.RegressionDataGenerator;
 import org.tribuo.test.Helpers;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -203,10 +203,10 @@ public class TestKNN {
     @SuppressWarnings("unchecked")
     public void deserializeKNNRegressionV42ModelTest() {
         String serializedModelFilename = "KNNTrainerRegressor_k3_L2_nt2_voting_streams_v4.2.model";
-        String serializedModelPath = this.getClass().getClassLoader().getResource(serializedModelFilename).getPath();
+        URL serializedModelPath = this.getClass().getClassLoader().getResource(serializedModelFilename);
 
         KNNModel<Regressor> model = null;
-        try (ObjectInputStream oin = new ObjectInputStream(new FileInputStream(serializedModelPath))) {
+        try (ObjectInputStream oin = new ObjectInputStream(serializedModelPath.openStream())) {
             Object data = oin.readObject();
             model = (KNNModel<Regressor>) data;
             if (!model.validate(Regressor.class)) {

--- a/Math/src/test/java/org/tribuo/math/neighbour/NeighbourQueryTestHelper.java
+++ b/Math/src/test/java/org/tribuo/math/neighbour/NeighbourQueryTestHelper.java
@@ -21,6 +21,7 @@ import org.tribuo.math.la.DenseVector;
 import org.tribuo.math.la.SGDVector;
 import org.tribuo.math.util.SGDVectorsFromCSV;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -474,13 +475,13 @@ public class NeighbourQueryTestHelper {
 
     private static SGDVector[] get3DTestDataVectorArray() {
         String filename = "basic-gaussians-3d.csv";
-        String filepath = NeighbourQueryTestHelper.class.getClassLoader().getResource(filename).getPath();
+        URL filepath = NeighbourQueryTestHelper.class.getClassLoader().getResource(filename);
         return SGDVectorsFromCSV.getSGDVectorsFromCSV(filepath, true);
     }
 
     private static SGDVector[] get4DIntegerTestDataVectorArray() {
         String filename = "integers-1K-4features.csv";
-        String filepath = NeighbourQueryTestHelper.class.getClassLoader().getResource(filename).getPath();
+        URL filepath = NeighbourQueryTestHelper.class.getClassLoader().getResource(filename);
         return SGDVectorsFromCSV.getSGDVectorsFromCSV(filepath, true);
     }
 

--- a/Math/src/test/java/org/tribuo/math/util/SGDVectorsFromCSV.java
+++ b/Math/src/test/java/org/tribuo/math/util/SGDVectorsFromCSV.java
@@ -20,9 +20,10 @@ import org.tribuo.math.la.DenseVector;
 import org.tribuo.math.la.SGDVector;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,9 +32,9 @@ import java.util.List;
  */
 public class SGDVectorsFromCSV {
 
-    public static SGDVector[] getSGDVectorsFromCSV(String filePath, boolean fileContainsHeader) {
+    public static SGDVector[] getSGDVectorsFromCSV(URL filePath, boolean fileContainsHeader) {
         List<SGDVector> vectorList = new ArrayList<>();
-        try (BufferedReader br = new BufferedReader(new FileReader(filePath))) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(filePath.openStream()))) {
             String line;
 
             if (fileContainsHeader) {


### PR DESCRIPTION
### Description
Due to iffy URL handling to get around some Windows issues when accessing test resources a bunch of failures happen if Tribuo is checked out into a path with spaces. These are all fixed by not using Strings as an intermediate step for paths.
