### PR TITLE
Add build_spec.yaml as a preparation for Oracle's GitHub repository guideline checks

### DIFF
--- a/build_spec.yaml
+++ b/build_spec.yaml
@@ -1,0 +1,14 @@
+version: 0.1
+component: build
+timeoutInSeconds: 1000
+shell: bash
+
+steps:
+  - type: Command
+    name: "compress the repo"
+    command: |
+      tar -cvzf repo.tgz ./
+outputArtifacts:
+  - name: artifact
+    type: BINARY
+    location: ${OCI_PRIMARY_SOURCE_DIR}/repo.tgz


### PR DESCRIPTION
### Description
Add build_spec.yaml

### Motivation
This prepares the repository for Oracle's GitHub repository guideline checks

