### PR TITLE
Adding accessors to ClassifierChainModel and IndependentMultiLabelModel

### DIFF
--- a/Classification/Core/src/main/java/org/tribuo/classification/sequence/viterbi/ViterbiModel.java
+++ b/Classification/Core/src/main/java/org/tribuo/classification/sequence/viterbi/ViterbiModel.java
@@ -157,7 +157,14 @@ public class ViterbiModel extends SequenceModel<Label> {
         } else {
             return viterbi(examples);
         }
+    }
 
+    /**
+     * Returns the inner model used for sequence element predictions.
+     * @return The inner model.
+     */
+    public Model<Label> getInnerModel() {
+        return model;
     }
 
     private List<Feature> extractFeatures(List<Label> labels) {

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/baseline/ClassifierChainModel.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/baseline/ClassifierChainModel.java
@@ -152,6 +152,14 @@ public final class ClassifierChainModel extends Model<MultiLabel> {
         return new ClassifierChainModel(carrier.name(),carrier.provenance(),carrier.featureDomain(),outputDomain,labelOrder,models);
     }
 
+    /**
+     * Returns an unmodifiable view on the chain members.
+     * @return The chain members.
+     */
+    public List<Model<Label>> getModels() {
+        return models;
+    }
+
     @Override
     public Prediction<MultiLabel> predict(Example<MultiLabel> example) {
         Set<Label> predictedLabels = new HashSet<>();

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/baseline/IndependentMultiLabelModel.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/baseline/IndependentMultiLabelModel.java
@@ -137,6 +137,22 @@ public class IndependentMultiLabelModel extends Model<MultiLabel> {
         return new IndependentMultiLabelModel(carrier.name(),carrier.provenance(),carrier.featureDomain(),outputDomain,labels,models);
     }
 
+    /**
+     * Returns an unmodifiable view on the binary model members.
+     * @return The binary model members.
+     */
+    public List<Model<Label>> getModels() {
+        return Collections.unmodifiableList(models);
+    }
+
+    /**
+     * Returns the training label order.
+     * @return The training label order.
+     */
+    public List<Label> getLabelOrder() {
+        return Collections.unmodifiableList(labels);
+    }
+
     @Override
     public Prediction<MultiLabel> predict(Example<MultiLabel> example) {
         Set<Label> predictedLabels = new HashSet<>();

--- a/MultiLabel/Core/src/main/java/org/tribuo/multilabel/baseline/IndependentMultiLabelTrainer.java
+++ b/MultiLabel/Core/src/main/java/org/tribuo/multilabel/baseline/IndependentMultiLabelTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.tribuo.multilabel.baseline;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
 import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import java.util.Collections;
 import org.tribuo.Dataset;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
@@ -120,7 +121,9 @@ public class IndependentMultiLabelTrainer implements Trainer<MultiLabel> {
             modelsList.add(innerTrainer.train(trainingData));
         }
 
-        return new IndependentMultiLabelModel(labelList,modelsList,provenance,featureMap,labelInfo);
+        return new IndependentMultiLabelModel(Collections.unmodifiableList(labelList),
+                                              Collections.unmodifiableList(modelsList),
+                                              provenance,featureMap,labelInfo);
     }
 
     @Override


### PR DESCRIPTION
### Description
Adds accessors for the models which comprise a classifier chain or a binary relevance multilabel model.

### Motivation
Model access is useful for inspecting the inner models. Fixes #300.
