### PR TITLE
Fixing Example.densify

### DIFF
--- a/Core/src/main/java/org/tribuo/Example.java
+++ b/Core/src/main/java/org/tribuo/Example.java
@@ -309,6 +309,11 @@ public abstract class Example<T extends Output<T>> implements Iterable<Feature>,
      * Converts all implicit zeros into explicit zeros based on the supplied feature map.
      * <p>
      * That is, it inserts a zero valued feature for each feature in the map that is not present in this example.
+     * <p>
+     * Note: this is an optional method, some implementations of {@code Example} may
+     * throw {@link UnsupportedOperationException} or may have additional requirements
+     * on the {@code fMap} argument and consequently throw {@link IllegalArgumentException} if
+     * those requirements are not met.
      * @param fMap The feature map to use for densification.
      */
     public void densify(FeatureMap fMap) {
@@ -320,6 +325,14 @@ public abstract class Example<T extends Output<T>> implements Iterable<Feature>,
 
     /**
      * Adds zero valued features for each feature name in {@code featureNames}.
+     * <p>
+     * {@code featureNames} must be sorted lexicographically using the {@link String}
+     * comparator, and behaviour is undefined otherwise.
+     * <p>
+     * Note: this is an optional method, some implementations of {@code Example} may
+     * throw {@link UnsupportedOperationException} or may have additional requirements
+     * on the {@code featureNames} argument and consequently throw
+     * {@link IllegalArgumentException} if those requirements are not met.
      * @param featureNames A *sorted* list of feature names.
      */
     protected abstract void densify(List<String> featureNames);

--- a/Core/src/main/java/org/tribuo/Example.java
+++ b/Core/src/main/java/org/tribuo/Example.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -307,6 +307,8 @@ public abstract class Example<T extends Output<T>> implements Iterable<Feature>,
 
     /**
      * Converts all implicit zeros into explicit zeros based on the supplied feature map.
+     * <p>
+     * That is, it inserts a zero valued feature for each feature in the map that is not present in this example.
      * @param fMap The feature map to use for densification.
      */
     public void densify(FeatureMap fMap) {
@@ -317,7 +319,7 @@ public abstract class Example<T extends Output<T>> implements Iterable<Feature>,
     }
 
     /**
-     * Converts all implicit zeros into explicit zeros based on the supplied feature names.
+     * Adds zero valued features for each feature name in {@code featureNames}.
      * @param featureNames A *sorted* list of feature names.
      */
     protected abstract void densify(List<String> featureNames);

--- a/Core/src/main/java/org/tribuo/impl/ArrayExample.java
+++ b/Core/src/main/java/org/tribuo/impl/ArrayExample.java
@@ -528,6 +528,13 @@ public class ArrayExample<T extends Output<T>> extends Example<T> {
         }
     }
 
+    /**
+     * Adds zero valued features for each feature name in {@code featureList}.
+     * <p>
+     * {@code featureList} must be sorted lexicographically using the {@link String}
+     * comparator, and behaviour is undefined otherwise.
+     * @param featureList A *sorted* list of feature names.
+     */
     @Override
     public void densify(List<String> featureList) {
         int featureListSize = featureList.size();

--- a/Core/src/main/java/org/tribuo/impl/ArrayExample.java
+++ b/Core/src/main/java/org/tribuo/impl/ArrayExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -530,32 +530,42 @@ public class ArrayExample<T extends Output<T>> extends Example<T> {
 
     @Override
     public void densify(List<String> featureList) {
-        // Ensure we have enough space.
-        if (featureList.size() > featureNames.length) {
-            growArray(featureList.size());
-        }
-        int insertedCount = 0;
-        int curPos = 0;
-        for (String curName : featureList) {
-            // If we've reached the end of our old feature set, just insert.
-            if (curPos == size) {
-                featureNames[size + insertedCount] = curName;
-                insertedCount++;
+        int featureListSize = featureList.size();
+        List<String> insertionList = new ArrayList<>();
+
+        int thisIdx = 0;
+        int otherIdx = 0;
+        // Walk down both lists, checking the feature comparators
+        while (thisIdx < size && otherIdx < featureListSize) {
+            String curName = featureList.get(otherIdx);
+            int comp = curName.compareTo(featureNames[thisIdx]);
+            // String not present in featureNames, step featureList
+            if (comp < 0) {
+                insertionList.add(curName);
+                otherIdx++;
+            } else if (comp == 0) {
+                // Found feature, step both
+                thisIdx++;
+                otherIdx++;
             } else {
-                // Check to see if our insertion candidate is the same as the current feature name.
-                int comparison = curName.compareTo(featureNames[curPos]);
-                if (comparison < 0) {
-                    // If it's earlier, insert it.
-                    featureNames[size + insertedCount] = curName;
-                    insertedCount++;
-                } else if (comparison == 0) {
-                    // Otherwise just bump our pointer, we've already got this feature.
-                    curPos++;
-                }
+                // featureList is past this, step this
+                thisIdx++;
             }
         }
-        // Bump the size up by the number of inserted features.
-        size += insertedCount;
+        // Insert any remaining features from the list
+        for (; otherIdx < featureListSize; otherIdx++) {
+            insertionList.add(featureList.get(otherIdx));
+        }
+        // Check capacity and grow array
+        int capacityCheck = insertionList.size() + size;
+        if (capacityCheck > featureNames.length) {
+            growArray(capacityCheck);
+        }
+        // Insert new features
+        for (String s : insertionList) {
+            featureNames[size] = s;
+            size++;
+        }
         // Sort the features
         sort();
     }

--- a/Core/src/main/java/org/tribuo/impl/IndexedArrayExample.java
+++ b/Core/src/main/java/org/tribuo/impl/IndexedArrayExample.java
@@ -364,6 +364,11 @@ public class IndexedArrayExample<T extends Output<T>> extends ArrayExample<T> {
         return new IndexedArrayExample<>(this);
     }
 
+    /**
+     * Unlike {@link ArrayExample#densify(List)} this method will throw {@link IllegalArgumentException}
+     * if one of the feature names is not present in this example's {@link ImmutableFeatureMap}.
+     * @param featureList A *sorted* list of feature names.
+     */
     @Override
     public void densify(List<String> featureList) {
         if (featureList.size() != featureMap.size()) {
@@ -376,10 +381,14 @@ public class IndexedArrayExample<T extends Output<T>> extends ArrayExample<T> {
         int insertedCount = 0;
         int curPos = 0;
         for (String curName : featureList) {
+            int newId = featureMap.getID(curName);
+            if (newId == -1) {
+                throw new IllegalArgumentException("Unexpected feature name '" + curName + "'");
+            }
             // If we've reached the end of our old feature set, just insert.
             if (curPos == size) {
                 featureNames[size + insertedCount] = curName;
-                featureIDs[size + insertedCount] = featureMap.getID(curName);
+                featureIDs[size + insertedCount] = newId;
                 insertedCount++;
             } else {
                 // Check to see if our insertion candidate is the same as the current feature name.
@@ -387,7 +396,7 @@ public class IndexedArrayExample<T extends Output<T>> extends ArrayExample<T> {
                 if (comparison < 0) {
                     // If it's earlier, insert it.
                     featureNames[size + insertedCount] = curName;
-                    featureIDs[size + insertedCount] = featureMap.getID(curName);
+                    featureIDs[size + insertedCount] = newId;
                     insertedCount++;
                 } else if (comparison == 0) {
                     // Otherwise just bump our pointer, we've already got this feature.

--- a/Core/src/main/java/org/tribuo/impl/IndexedArrayExample.java
+++ b/Core/src/main/java/org/tribuo/impl/IndexedArrayExample.java
@@ -367,13 +367,13 @@ public class IndexedArrayExample<T extends Output<T>> extends ArrayExample<T> {
     /**
      * Unlike {@link ArrayExample#densify(List)} this method will throw {@link IllegalArgumentException}
      * if one of the feature names is not present in this example's {@link ImmutableFeatureMap}.
+     * <p>
+     * {@code featureList} must be sorted lexicographically using the {@link String}
+     * comparator, and behaviour is undefined otherwise.
      * @param featureList A *sorted* list of feature names.
      */
     @Override
     public void densify(List<String> featureList) {
-        if (featureList.size() != featureMap.size()) {
-            throw new IllegalArgumentException("Densifying an example with a different feature map");
-        }
         // Ensure we have enough space.
         if (featureList.size() > featureNames.length) {
             growArray(featureList.size());

--- a/Core/src/main/java/org/tribuo/impl/ListExample.java
+++ b/Core/src/main/java/org/tribuo/impl/ListExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -331,23 +331,14 @@ public class ListExample<T extends Output<T>> extends Example<T> implements Seri
 
     @Override
     protected void densify(List<String> featureList) {
-        int oldSize = features.size();
-        int curPos = 0;
-        for (String curName : featureList) {
-            // If we've reached the end of our old feature set, just insert.
-            if (curPos == oldSize) {
-                features.add(new Feature(curName,0.0));
-            } else {
-                // Check to see if our insertion candidate is the same as the current feature name.
-                int comparison = curName.compareTo(features.get(curPos).getName());
-                if (comparison < 0) {
-                    // If it's earlier, insert it.
-                    features.add(new Feature(curName,0.0));
-                } else if (comparison == 0) {
-                    // Otherwise just bump our pointer, we've already got this feature.
-                    curPos++;
-                }
-            }
+        Set<String> featureSet = new HashSet<>(featureList);
+        // Compute intersection
+        for (Feature f : features) {
+            featureSet.remove(f.getName());
+        }
+        // Add missing features
+        for (String s : featureSet) {
+            features.add(new Feature(s,0.0));
         }
         // Sort the features
         sort();

--- a/Core/src/main/java/org/tribuo/impl/ListExample.java
+++ b/Core/src/main/java/org/tribuo/impl/ListExample.java
@@ -329,9 +329,16 @@ public class ListExample<T extends Output<T>> extends Example<T> implements Seri
         }
     }
 
+    /**
+     * Adds zero valued features for each feature name in {@code featureNames}.
+     * <p>
+     * {@code featureNames} must be sorted lexicographically using the {@link String}
+     * comparator, and behaviour is undefined otherwise.
+     * @param featureNames A *sorted* list of feature names.
+     */
     @Override
-    protected void densify(List<String> featureList) {
-        Set<String> featureSet = new HashSet<>(featureList);
+    protected void densify(List<String> featureNames) {
+        Set<String> featureSet = new HashSet<>(featureNames);
         // Compute intersection
         for (Feature f : features) {
             featureSet.remove(f.getName());

--- a/Core/src/test/java/org/tribuo/ExampleTest.java
+++ b/Core/src/test/java/org/tribuo/ExampleTest.java
@@ -80,6 +80,32 @@ public class ExampleTest {
     }
 
     @Test
+    public void testExtendedArrayExampleDensify() {
+        MockOutput output = new MockOutput("UNK");
+        ArrayExample<MockOutput> example, expected;
+
+        // Single feature, contiguous densification
+        example = new ArrayExample<>(output, new String[]{"F0"}, new double[]{1.0});
+        example.densify(Arrays.asList("F0", "F1", "F2"));
+        expected = new ArrayExample<>(new MockOutput("UNK"), new String[]{"F0","F1","F2"}, new double[]{1.0,0.0,0.0});
+        checkDenseExample(expected,example);
+        example = new ArrayExample<>(output, new String[]{"F0"}, new double[]{1.0});
+        example.densify(Arrays.asList("F", "F1", "F2"));
+        expected = new ArrayExample<>(new MockOutput("UNK"), new String[]{"F","F0","F1","F2"}, new double[]{0.0,1.0,0.0,0.0});
+        checkDenseExample(expected,example);
+
+        // Multiple features, edges
+        example = new ArrayExample<>(output, new String[]{"F0","F7"}, new double[]{1.0,1.0});
+        example.densify(Arrays.asList("F0", "F5", "F10"));
+        expected = new ArrayExample<>(new MockOutput("UNK"), new String[]{"F0","F5","F7","F10"}, new double[]{1.0,0.0,1.0,0.0});
+        checkDenseExample(expected,example);
+        example = new ArrayExample<>(output, new String[]{"F0","F1","F2"}, new double[]{1.0,1.0,1.0});
+        example.densify(Arrays.asList("F1.5", "F2.5"));
+        expected = new ArrayExample<>(new MockOutput("UNK"), new String[]{"F0","F1","F1.5","F2","F2.5"}, new double[]{1.0,1.0,0.0,1.0,0.0});
+        checkDenseExample(expected,example);
+    }
+
+    @Test
     public void testListExampleDensify() {
         MockOutput output = new MockOutput("UNK");
         Example<MockOutput> example, expected;
@@ -111,6 +137,32 @@ public class ExampleTest {
         expected = new ListExample<>(new MockOutput("UNK"), featureNames, new double[]{1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.0});
         checkDenseExample(expected,example);
         testProtoSerialization(example);
+    }
+
+    @Test
+    public void testExtendedListExampleDensify() {
+        MockOutput output = new MockOutput("UNK");
+        Example<MockOutput> example, expected;
+
+        // Single feature, contiguous densification
+        example = new ListExample<>(output, new String[]{"F0"}, new double[]{1.0});
+        example.densify(Arrays.asList("F0", "F1", "F2"));
+        expected = new ListExample<>(new MockOutput("UNK"), new String[]{"F0","F1","F2"}, new double[]{1.0,0.0,0.0});
+        checkDenseExample(expected,example);
+        example = new ListExample<>(output, new String[]{"F0"}, new double[]{1.0});
+        example.densify(Arrays.asList("F", "F1", "F2"));
+        expected = new ListExample<>(new MockOutput("UNK"), new String[]{"F","F0","F1","F2"}, new double[]{0.0,1.0,0.0,0.0});
+        checkDenseExample(expected,example);
+
+        // Multiple features, edges
+        example = new ListExample<>(output, new String[]{"F0","F7"}, new double[]{1.0,1.0});
+        example.densify(Arrays.asList("F0", "F5", "F10"));
+        expected = new ListExample<>(new MockOutput("UNK"), new String[]{"F0","F5","F7","F10"}, new double[]{1.0,0.0,1.0,0.0});
+        checkDenseExample(expected,example);
+        example = new ListExample<>(output, new String[]{"F0","F1","F2"}, new double[]{1.0,1.0,1.0});
+        example.densify(Arrays.asList("F1.5", "F2.5"));
+        expected = new ListExample<>(new MockOutput("UNK"), new String[]{"F0","F1","F1.5","F2","F2.5"}, new double[]{1.0,1.0,0.0,1.0,0.0});
+        checkDenseExample(expected,example);
     }
 
     @Test


### PR DESCRIPTION
### Description
`Example.densify(List<String>)` behaved incorrectly if the list did not contain the feature names already present in the example. This PR fixes it so densify always adds zero valued features for any feature names not present in the example.

### Motivation
Fixes #299.
