### PR TITLE
Adding v4.3.1 release notes to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,13 +191,13 @@ Maven:
 <dependency>
     <groupId>org.tribuo</groupId>
     <artifactId>tribuo-all</artifactId>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
     <type>pom</type>
 </dependency>
 ```
 or from Gradle:
 ```groovy
-implementation ("org.tribuo:tribuo-all:4.3.0@pom") {
+implementation ("org.tribuo:tribuo-all:4.3.1@pom") {
     transitive = true // for build.gradle (i.e., Groovy)
     // isTransitive = true // for build.gradle.kts (i.e., Kotlin)
 }
@@ -265,6 +265,7 @@ Tribuo is licensed under the [Apache 2.0 License](./LICENSE.txt).
 
 ## Release Notes:
 
+- [v4.3.1](https://github.com/oracle/tribuo/blob/main/docs/release-notes/tribuo-v4-3-1-release-notes.md) - Small bug fixes, notably to CART trees and Example.densify, bumps dependencies to more secure versions.
 - [v4.3.0](https://github.com/oracle/tribuo/blob/main/docs/release-notes/tribuo-v4-3-release-notes.md) - Model card support, feature selection for classification, protobuf serialization format, kd-tree for distance computations, speed improvements for sparse linear models. Version bumps for most dependencies, and various other small fixes and improvements.
 - [v4.2.2](https://github.com/oracle/tribuo/blob/main/docs/release-notes/tribuo-v4-2-2-release-notes.md) - Small bug fixes, bump TF-Java to 0.4.2, jackson to 2.13.4, protobuf-java to 3.19.6, OpenCSV to 5.7.1.
 - [v4.2.1](https://github.com/oracle/tribuo/blob/main/docs/release-notes/tribuo-v4-2-1-release-notes.md) - Bug fixes for KMeans' multithreading, nondeterministic iteration orders affecting ONNX export and K-Means initialization, and upgraded TF-Java to 0.4.1.

--- a/docs/release-notes/tribuo-v4-3-1-release-notes.md
+++ b/docs/release-notes/tribuo-v4-3-1-release-notes.md
@@ -1,0 +1,21 @@
+# Tribuo v4.3.1 Release Notes
+
+Small patch release to bump some dependencies and pull in minor fixes. The most
+notable fix allows CART trees to generate pure nodes, which previously they had
+been prevented from doing. This will likely improve the classification tree
+performance both for single trees and when used in an ensemble like
+RandomForests.
+
+- FeatureHasher should have an option to not hash the values, and TokenPipeline should default to not hashing the values ([#309](https://github.com/oracle/tribuo/pull/309)).
+- Improving the documentation for loading multi-label data with CSVLoader ([#306](https://github.com/oracle/tribuo/pull/306)).
+- Allows Example.densify to add arbitrary features ([#304](https://github.com/oracle/tribuo/pull/304)). 
+- Adds accessors to ClassifierChainModel and IndependentMultiLabelModel so the individual models can be accessed ([#302](https://github.com/oracle/tribuo/pull/302)).
+- Allows CART trees to create pure leaves ([#303](https://github.com/oracle/tribuo/pull/303)).
+- Bumping jackson-core to 2.14.1, jackson-databind to 2.14.1, OpenCSV to 5.7.1 (pulling in the fixed commons-text 1.10.0).
+
+## Contributors
+
+- Adam Pocock ([@Craigacp](https://github.com/Craigacp))
+- Jeffrey Alexander ([@jhalexand](https://github.com/jhalexand))
+- Jack Sullivan ([@JackSullivan](https://github.com/JackSullivan))
+- Philip Ogren ([@pogren](https://github.com/pogren))


### PR DESCRIPTION
### Description
Cherry-picks the release notes for v4.3.1 across to `main`.
