### PR TITLE
Fixes for protobuf creation in a few classes

### DIFF
--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.tribuo.clustering.hdbscan;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
@@ -893,8 +894,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
         public Double getMaxDistToEdge() {
             if (maxDistToEdge != null) {
                 return maxDistToEdge;
-            }
-            else {
+            } else {
                 return Double.NEGATIVE_INFINITY;
             }
         }
@@ -932,7 +932,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
             builder.setLabel(label);
             builder.setOutlierScore(outlierScore);
             builder.setFeatures(features.serialize());
-            builder.setMaxDistToEdge(maxDistToEdge);
+            builder.setMaxDistToEdge(getMaxDistToEdge());
 
             return builder.build();
         }

--- a/Data/src/main/java/org/tribuo/data/text/DirectoryFileSource.java
+++ b/Data/src/main/java/org/tribuo/data/text/DirectoryFileSource.java
@@ -287,6 +287,7 @@ public class DirectoryFileSource<T extends Output<T>> implements ConfigurableDat
         protected static ExtractedInfo extractProvenanceInfo(Map<String,Provenance> map) {
             Map<String,Provenance> configuredParameters = new HashMap<>(map);
             String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters,CLASS_NAME, StringProvenance.class, DirectoryFileSourceProvenance.class.getSimpleName()).getValue();
+            // This is relaxed as before v4.3.2 this field is left out of marshalled provenances due to a bug in getinstanceValues.
             String hostTypeStringName;
             Optional<StringProvenance> optHostName = ObjectProvenance.maybeExtractProvenance(configuredParameters,HOST_SHORT_NAME,StringProvenance.class, DirectoryFileSourceProvenance.class.getSimpleName());
             if (optHostName.isPresent()) {

--- a/Data/src/main/java/org/tribuo/data/text/DirectoryFileSource.java
+++ b/Data/src/main/java/org/tribuo/data/text/DirectoryFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.logging.Logger;
 
@@ -286,7 +287,13 @@ public class DirectoryFileSource<T extends Output<T>> implements ConfigurableDat
         protected static ExtractedInfo extractProvenanceInfo(Map<String,Provenance> map) {
             Map<String,Provenance> configuredParameters = new HashMap<>(map);
             String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters,CLASS_NAME, StringProvenance.class, DirectoryFileSourceProvenance.class.getSimpleName()).getValue();
-            String hostTypeStringName = ObjectProvenance.checkAndExtractProvenance(configuredParameters,HOST_SHORT_NAME, StringProvenance.class, DirectoryFileSourceProvenance.class.getSimpleName()).getValue();
+            String hostTypeStringName;
+            Optional<StringProvenance> optHostName = ObjectProvenance.maybeExtractProvenance(configuredParameters,HOST_SHORT_NAME,StringProvenance.class, DirectoryFileSourceProvenance.class.getSimpleName());
+            if (optHostName.isPresent()) {
+                hostTypeStringName = optHostName.get().getValue();
+            } else {
+                hostTypeStringName = "DataSource";
+            }
 
             Map<String,PrimitiveProvenance<?>> instanceParameters = new HashMap<>();
             instanceParameters.put(DATASOURCE_CREATION_TIME,ObjectProvenance.checkAndExtractProvenance(configuredParameters,DATASOURCE_CREATION_TIME,DateTimeProvenance.class, DirectoryFileSourceProvenance.class.getSimpleName()));
@@ -296,7 +303,7 @@ public class DirectoryFileSource<T extends Output<T>> implements ConfigurableDat
 
         @Override
         public Map<String, PrimitiveProvenance<?>> getInstanceValues() {
-            Map<String,PrimitiveProvenance<?>> map = new HashMap<>();
+            Map<String,PrimitiveProvenance<?>> map = super.getInstanceValues();
 
             map.put(FILE_MODIFIED_TIME,fileModifiedTime);
             map.put(DATASOURCE_CREATION_TIME,dataSourceCreationTime);

--- a/Data/src/main/java/org/tribuo/data/text/impl/SimpleStringDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/text/impl/SimpleStringDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,7 +147,13 @@ public class SimpleStringDataSource<T extends Output<T>> extends SimpleTextDataS
         protected static ExtractedInfo extractProvenanceInfo(Map<String,Provenance> map) {
             Map<String,Provenance> configuredParameters = new HashMap<>(map);
             String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters,CLASS_NAME, StringProvenance.class, SimpleStringDataSourceProvenance.class.getSimpleName()).getValue();
-            String hostTypeStringName = ObjectProvenance.checkAndExtractProvenance(configuredParameters,HOST_SHORT_NAME, StringProvenance.class, SimpleStringDataSourceProvenance.class.getSimpleName()).getValue();
+            String hostTypeStringName;
+            Optional<StringProvenance> optHostName = ObjectProvenance.maybeExtractProvenance(configuredParameters,HOST_SHORT_NAME,StringProvenance.class, SimpleStringDataSourceProvenance.class.getSimpleName());
+            if (optHostName.isPresent()) {
+                hostTypeStringName = optHostName.get().getValue();
+            } else {
+                hostTypeStringName = "DataSource";
+            }
 
             Map<String, PrimitiveProvenance<?>> instanceParameters = new HashMap<>();
             instanceParameters.put(DATASOURCE_CREATION_TIME,ObjectProvenance.checkAndExtractProvenance(configuredParameters,DATASOURCE_CREATION_TIME,DateTimeProvenance.class, SimpleStringDataSourceProvenance.class.getSimpleName()));
@@ -173,7 +179,7 @@ public class SimpleStringDataSource<T extends Output<T>> extends SimpleTextDataS
 
         @Override
         public Map<String, PrimitiveProvenance<?>> getInstanceValues() {
-            Map<String,PrimitiveProvenance<?>> map = new HashMap<>();
+            Map<String,PrimitiveProvenance<?>> map = super.getInstanceValues();
 
             map.put(DATASOURCE_CREATION_TIME,dataSourceCreationTime);
             map.put(RESOURCE_HASH,sha256Hash);

--- a/Data/src/main/java/org/tribuo/data/text/impl/SimpleStringDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/text/impl/SimpleStringDataSource.java
@@ -147,6 +147,7 @@ public class SimpleStringDataSource<T extends Output<T>> extends SimpleTextDataS
         protected static ExtractedInfo extractProvenanceInfo(Map<String,Provenance> map) {
             Map<String,Provenance> configuredParameters = new HashMap<>(map);
             String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters,CLASS_NAME, StringProvenance.class, SimpleStringDataSourceProvenance.class.getSimpleName()).getValue();
+            // This is relaxed as before v4.3.2 this field is left out of marshalled provenances due to a bug in getinstanceValues.
             String hostTypeStringName;
             Optional<StringProvenance> optHostName = ObjectProvenance.maybeExtractProvenance(configuredParameters,HOST_SHORT_NAME,StringProvenance.class, SimpleStringDataSourceProvenance.class.getSimpleName());
             if (optHostName.isPresent()) {

--- a/Data/src/main/java/org/tribuo/data/text/impl/SimpleTextDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/text/impl/SimpleTextDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -220,7 +220,13 @@ public class SimpleTextDataSource<T extends Output<T>> extends TextDataSource<T>
         protected static ExtractedInfo extractProvenanceInfo(Map<String,Provenance> map) {
             Map<String,Provenance> configuredParameters = new HashMap<>(map);
             String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters,CLASS_NAME, StringProvenance.class, SimpleTextDataSourceProvenance.class.getSimpleName()).getValue();
-            String hostTypeStringName = ObjectProvenance.checkAndExtractProvenance(configuredParameters,HOST_SHORT_NAME, StringProvenance.class, SimpleTextDataSourceProvenance.class.getSimpleName()).getValue();
+            String hostTypeStringName;
+            Optional<StringProvenance> optHostName = ObjectProvenance.maybeExtractProvenance(configuredParameters,HOST_SHORT_NAME,StringProvenance.class, SimpleTextDataSourceProvenance.class.getSimpleName());
+            if (optHostName.isPresent()) {
+                hostTypeStringName = optHostName.get().getValue();
+            } else {
+                hostTypeStringName = "DataSource";
+            }
 
             Map<String,PrimitiveProvenance<?>> instanceParameters = new HashMap<>();
             instanceParameters.put(FILE_MODIFIED_TIME,ObjectProvenance.checkAndExtractProvenance(configuredParameters,FILE_MODIFIED_TIME,DateTimeProvenance.class, SimpleTextDataSourceProvenance.class.getSimpleName()));
@@ -248,7 +254,7 @@ public class SimpleTextDataSource<T extends Output<T>> extends TextDataSource<T>
 
         @Override
         public Map<String, PrimitiveProvenance<?>> getInstanceValues() {
-            Map<String,PrimitiveProvenance<?>> map = new HashMap<>();
+            Map<String,PrimitiveProvenance<?>> map = super.getInstanceValues();
 
             map.put(FILE_MODIFIED_TIME,fileModifiedTime);
             map.put(DATASOURCE_CREATION_TIME,dataSourceCreationTime);

--- a/Data/src/main/java/org/tribuo/data/text/impl/SimpleTextDataSource.java
+++ b/Data/src/main/java/org/tribuo/data/text/impl/SimpleTextDataSource.java
@@ -220,6 +220,7 @@ public class SimpleTextDataSource<T extends Output<T>> extends TextDataSource<T>
         protected static ExtractedInfo extractProvenanceInfo(Map<String,Provenance> map) {
             Map<String,Provenance> configuredParameters = new HashMap<>(map);
             String className = ObjectProvenance.checkAndExtractProvenance(configuredParameters,CLASS_NAME, StringProvenance.class, SimpleTextDataSourceProvenance.class.getSimpleName()).getValue();
+            // This is relaxed as before v4.3.2 this field is left out of marshalled provenances due to a bug in getinstanceValues.
             String hostTypeStringName;
             Optional<StringProvenance> optHostName = ObjectProvenance.maybeExtractProvenance(configuredParameters,HOST_SHORT_NAME,StringProvenance.class, SimpleTextDataSourceProvenance.class.getSimpleName());
             if (optHostName.isPresent()) {

--- a/Data/src/test/java/org/tribuo/data/text/impl/SimpleStringDataSourceTest.java
+++ b/Data/src/test/java/org/tribuo/data/text/impl/SimpleStringDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,12 @@
 
 package org.tribuo.data.text.impl;
 
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
+import com.oracle.labs.mlrg.olcut.provenance.ProvenanceUtil;
+import com.oracle.labs.mlrg.olcut.provenance.io.MarshalledProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import org.tribuo.data.text.TextFeatureExtractor;
+import org.tribuo.provenance.DataProvenance;
 import org.tribuo.test.MockOutput;
 import org.tribuo.test.MockOutputFactory;
 import org.junit.jupiter.api.Test;
@@ -26,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
@@ -36,6 +42,18 @@ public class SimpleStringDataSourceTest {
         List<String> rawLines = new ArrayList<>();
         SimpleStringDataSource<MockOutput> src = new SimpleStringDataSource<>(rawLines, new MockOutputFactory(), getFeatureExtractor());
         assertThrows(IllegalStateException.class, src::iterator);
+    }
+
+    @Test
+    public void provenanceSerializationTest() {
+        List<String> rawLines = new ArrayList<>();
+        rawLines.add("things ## stuff");
+        rawLines.add("other ## objects");
+        SimpleStringDataSource<MockOutput> src = new SimpleStringDataSource<>(rawLines, new MockOutputFactory(), getFeatureExtractor());
+        DataProvenance p = src.getProvenance();
+        List<ObjectMarshalledProvenance> marshalledProvenance = ProvenanceUtil.marshalProvenance(p);
+        Provenance unMarshalledProv = ProvenanceUtil.unmarshalProvenance(marshalledProvenance);
+        assertEquals(p, unMarshalledProv);
     }
 
     public static TextFeatureExtractor<MockOutput> getFeatureExtractor() {


### PR DESCRIPTION
### Description
`DirectoryFileSource`, `SimpleStringDataSource` and `SimpleTextDataSource` all failed to call `super.getInstanceValues()` and so missed some values when converted into marshalled provenances. This PR relaxes the check for existing protobufs (as the missing value is a constant) and fixes `getInstanceValues` for these classes so it is correctly marshalled in the future. It also properly serializes `ClusterExemplar`s from v4.2 which may contain null values.

### Motivation
Protobuf serialization will be the only supported form in v5.
