### PR TITLE
Improve the determination of cluster exemplars fix for main

### DIFF
--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanOptions.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanOptions.java
@@ -65,12 +65,20 @@ public final class HdbscanOptions implements Options {
     @Option(longName = "hdbscan-neighbour-query-factory-type", usage = "The nearest neighbour implementation factory to use.")
     public NeighboursQueryFactoryType nqFactoryType = NeighboursQueryFactoryType.KD_TREE;
 
+    /*
+     * The seed to use when sampling cluster exemplars at random from members of a cluster. Defaults to 12345L.
+     */
+    @Option(longName = "hdbscan-exemplar-sample-seed", usage = "The seed to use when sampling cluster exemplars at " +
+        "random from members of a cluster.")
+    public long exemplarSampleSeed = 12345L;
+
     /**
      * Gets the configured HdbscanTrainer using the options in this object.
      * @return A HdbscanTrainer.
      */
     public HdbscanTrainer getTrainer() {
         logger.info("Configuring Hdbscan Trainer");
-        return new HdbscanTrainer(minClusterSize, distType.getDistance(), k, numThreads, nqFactoryType);
+        return new HdbscanTrainer(minClusterSize, distType.getDistance(), k, numThreads, nqFactoryType, exemplarSampleSeed);
     }
+
 }

--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanOptions.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanOptions.java
@@ -18,6 +18,7 @@ package org.tribuo.clustering.hdbscan;
 
 import com.oracle.labs.mlrg.olcut.config.Option;
 import com.oracle.labs.mlrg.olcut.config.Options;
+import org.tribuo.Trainer;
 import org.tribuo.math.distance.DistanceType;
 import org.tribuo.math.neighbour.NeighboursQueryFactoryType;
 
@@ -70,7 +71,7 @@ public final class HdbscanOptions implements Options {
      */
     @Option(longName = "hdbscan-exemplar-sample-seed", usage = "The seed to use when sampling cluster exemplars at " +
         "random from members of a cluster.")
-    public long exemplarSampleSeed = 12345L;
+    public long exemplarSampleSeed = Trainer.DEFAULT_SEED;
 
     /**
      * Gets the configured HdbscanTrainer using the options in this object.

--- a/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
+++ b/Clustering/Hdbscan/src/main/java/org/tribuo/clustering/hdbscan/HdbscanTrainer.java
@@ -155,7 +155,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
         "from the members of a cluster.")
     private long exemplarSampleSeed = Trainer.DEFAULT_SEED;
 
-    private SplittableRandom rng = new SplittableRandom(exemplarSampleSeed);
+    private SplittableRandom rng;
 
     private int trainInvocationCounter;
 
@@ -207,6 +207,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
         this.k = k;
         this.numThreads = numThreads;
         this.neighboursQueryFactory = NeighboursQueryFactoryType.getNeighboursQueryFactory(nqFactoryType, dist, numThreads);
+        postConfig();
     }
 
     /**
@@ -227,7 +228,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
         this.numThreads = numThreads;
         this.neighboursQueryFactory = NeighboursQueryFactoryType.getNeighboursQueryFactory(nqFactoryType, dist, numThreads);
         this.exemplarSampleSeed = exemplarSampleSeed;
-        this.rng = new SplittableRandom(exemplarSampleSeed);
+        postConfig();
     }
 
     /**
@@ -242,6 +243,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
         this.dist = neighboursQueryFactory.getDistance();
         this.k = k;
         this.neighboursQueryFactory = neighboursQueryFactory;
+        postConfig();
     }
 
     /**
@@ -268,6 +270,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
             }
         }
 
+        this.rng = new SplittableRandom(exemplarSampleSeed);
     }
 
     @Override
@@ -790,7 +793,7 @@ public final class HdbscanTrainer implements Trainer<ClusterID> {
      * @param rng The RNG to use.
      * @return A list of {@link ClusterExemplar}s which are used for predictions.
      */
-    private List<ClusterExemplar> computeExemplars(SGDVector[] data, Map<Integer, List<Pair<Double, Integer>>> clusterAssignments,
+    private static List<ClusterExemplar> computeExemplars(SGDVector[] data, Map<Integer, List<Pair<Double, Integer>>> clusterAssignments,
                                                           org.tribuo.math.distance.Distance dist, SplittableRandom rng) {
         List<ClusterExemplar> clusterExemplars = new ArrayList<>();
         // The formula to calculate the exemplar number. This calculates the number of exemplars to be used for this

--- a/Clustering/Hdbscan/src/test/java/org/tribuo/clustering/hdbscan/TestHdbscan.java
+++ b/Clustering/Hdbscan/src/test/java/org/tribuo/clustering/hdbscan/TestHdbscan.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.tribuo.DataSource;
 import org.tribuo.Dataset;
+import org.tribuo.Example;
 import org.tribuo.Feature;
 import org.tribuo.Model;
 import org.tribuo.MutableDataset;
@@ -37,6 +38,7 @@ import org.tribuo.data.columnar.RowProcessor;
 import org.tribuo.data.columnar.processors.field.DoubleFieldProcessor;
 import org.tribuo.data.columnar.processors.response.EmptyResponseProcessor;
 import org.tribuo.data.csv.CSVDataSource;
+import org.tribuo.datasource.ListDataSource;
 import org.tribuo.evaluation.TrainTestSplitter;
 import org.tribuo.impl.ArrayExample;
 import org.tribuo.math.distance.DistanceType;
@@ -45,6 +47,8 @@ import org.tribuo.math.la.SGDVector;
 import org.tribuo.math.neighbour.NeighboursQueryFactory;
 import org.tribuo.math.neighbour.NeighboursQueryFactoryType;
 import org.tribuo.math.neighbour.kdtree.KDTreeFactory;
+import org.tribuo.provenance.DataSourceProvenance;
+import org.tribuo.provenance.SimpleDataSourceProvenance;
 import org.tribuo.protos.core.ModelProto;
 import org.tribuo.test.Helpers;
 
@@ -57,6 +61,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -404,6 +409,49 @@ public class TestHdbscan {
     @Test
     public void testSparseData() {
         runSparseData(t);
+    }
+
+    @Test
+    public void testContrivedDataset() {
+        final HdbscanTrainer trainer = new HdbscanTrainer(100, DistanceType.L2.getDistance(),
+                10,1, NeighboursQueryFactoryType.BRUTE_FORCE);
+
+        ClusteringFactory outputFactory = new ClusteringFactory();
+        DataSourceProvenance dataProvenance = new SimpleDataSourceProvenance("test", outputFactory);
+
+        List<Example<ClusterID>> dataList = new ArrayList<>();
+        for (int n = 0; n < 10; n++) {
+            for (double i = 1.0; i <= 2.0; i += 0.1) {
+                dataList.add(createClusterExample("A", i));
+            }
+            for (double i = 10.0; i <= 19.0; i += 0.1) {
+                dataList.add(createClusterExample("B", i));
+            }
+        }
+
+        DataSource<ClusterID> dataSource = new ListDataSource<>(dataList, outputFactory, dataProvenance);
+        Dataset<ClusterID> trainData = new MutableDataset<>(dataSource);
+
+        HdbscanModel model = trainer.train(trainData);
+        assertEquals(new HashSet<>(model.getClusterLabels()).size(), 2);
+
+        // Predict on the same training data. A good confirmation to make, but don't do this to evaluate a model.
+        List<Prediction<ClusterID>> predictions = model.predict(trainData);
+
+        int i = 0;
+        for (Prediction<ClusterID> prediction : predictions) {
+            if (i % 100 < 10) {
+                assertEquals(2, prediction.getOutput().getID());
+            }
+            else {
+                assertEquals(3, prediction.getOutput().getID());
+            }
+            i++;
+        }
+    }
+
+    private Example<ClusterID> createClusterExample(String name, double value) {
+        return new ArrayExample<>(ClusteringFactory.UNASSIGNED_CLUSTER_ID, new String[]{name}, new double[]{value});
     }
 
     @Test


### PR DESCRIPTION

### Description
We need to improve the determination of cluster exemplars, which are used after the model is trained to make predictions. Some cases, such as those which use contrived datasets, can result in very "clean" clusters, with no outliers. One such case has exposed an issue in the current logic to determine cluster exemplars. The seed, which is used when sampling cluster exemplars at random from members of a cluster, is exposed as a config parameter.

### Motivation
This change fixes #355 on the main branch.
