### PR TITLE
Adding JDK 22 and a macOS aarch64 runner to the CI

### DIFF
--- a/.github/workflows/maven-macos-aarch64.yml
+++ b/.github/workflows/maven-macos-aarch64.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Tribuo CI (Ubuntu x86_64, Java SE 17, 21, 22)
+name: Tribuo CI (macOS aarch64, Java SE 17, 21, 22)
 
 on:
   push:
@@ -11,12 +11,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     strategy:
       matrix:
         # test against supported LTS versions and latest
         java: [ 17, 21, 22 ]
-    name: Ubuntu Java SE ${{ matrix.java }}
+    name: macOS Java SE ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Oracle Java SE
@@ -25,4 +25,4 @@ jobs:
           website: oracle.com
           release: ${{ matrix.java }}
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -B package --file pom.xml -Parm

--- a/.github/workflows/maven-macos-aarch64.yml
+++ b/.github/workflows/maven-macos-aarch64.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Oracle Java SE
-        uses: oracle-actions/setup-java@v1
+        uses: oracle-actions/setup-java@master
         with:
           website: oracle.com
           release: ${{ matrix.java }}

--- a/.github/workflows/maven-macos-aarch64.yml
+++ b/.github/workflows/maven-macos-aarch64.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Oracle Java SE
-        uses: oracle-actions/setup-java@master
+        uses: oracle-actions/setup-java@main
         with:
           website: oracle.com
           release: ${{ matrix.java }}

--- a/.github/workflows/maven-macos-x64.yml
+++ b/.github/workflows/maven-macos-x64.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Tribuo CI (macOS x86_64, Java SE 17, 21)
+name: Tribuo CI (macOS x86_64, Java SE 17, 21, 22)
 
 on:
   push:
@@ -11,11 +11,11 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 17, 21 ]
+        java: [ 17, 21, 22 ]
     name: macOS Java SE ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Tribuo CI (Windows x86_64, Java SE 17, 21)
+name: Tribuo CI (Windows x86_64, Java SE 17, 21, 22)
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against supported LTS versions and latest
-        java: [ 17, 21 ]
+        java: [ 17, 21, 22 ]
     name: Windows Java SE ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Description
Adds the newly released JDK 22 to the CI and also ads a macOS aarch64 runner.

### Motivation
We test on LTS JDKs from 17 onwards along with the latest release. Also more development is moving to macOS aarch64 and there are now free Github runners for it.
