### PR TITLE
Dataset.createTransformers fix for DatasetView/TransformTrainer

### DIFF
--- a/Core/src/main/java/org/tribuo/Dataset.java
+++ b/Core/src/main/java/org/tribuo/Dataset.java
@@ -395,7 +395,7 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
             }
             // Add the queue to the map for that feature
             featureStats.put(entry.getKey(),l);
-            sparseCount.put(entry.getKey(), new MutableLong(data.size()));
+            sparseCount.put(entry.getKey(), new MutableLong(size()));
         }
         if (!transformations.getGlobalTransformations().isEmpty()) {
             // Append all the global transformations
@@ -411,7 +411,7 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
                 // Add the queue to the map for that feature
                 featureStats.put(v, l);
                 // Generate the sparse count initialised to the number of features.
-                sparseCount.putIfAbsent(v, new MutableLong(data.size()));
+                sparseCount.putIfAbsent(v, new MutableLong(size()));
                 ndone++;
                 if(logger.isLoggable(Level.FINE) && ndone % 10000 == 0) {
                     logger.fine(String.format("Completed %,d of %,d global transformations", ndone, ntransform));
@@ -424,7 +424,7 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
         boolean initialisedSparseCounts = false;
         // Iterate through the dataset max(transformations.length) times.
         while (!featureStats.isEmpty()) {
-            for (Example<T> example : data) {
+            for (Example<T> example : this) {
                 for (Feature f : example) {
                     if (featureStats.containsKey(f.getName())) {
                         if (!initialisedSparseCounts) {

--- a/Core/src/main/java/org/tribuo/Dataset.java
+++ b/Core/src/main/java/org/tribuo/Dataset.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Core/src/main/java/org/tribuo/Dataset.java
+++ b/Core/src/main/java/org/tribuo/Dataset.java
@@ -1,5 +1,4 @@
 /*
-
  * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/Core/src/main/java/org/tribuo/Dataset.java
+++ b/Core/src/main/java/org/tribuo/Dataset.java
@@ -73,7 +73,7 @@ public abstract class Dataset<T extends Output<T>> implements Iterable<Example<T
     /**
      * Users of this RNG should synchronize on the Dataset to prevent replicability issues.
      */
-    private static final SplittableRandom rng = new SplittableRandom(Trainer.DEFAULT_SEED);
+    protected static final SplittableRandom rng = new SplittableRandom(Trainer.DEFAULT_SEED);
 
     /**
      * The data in this data set.

--- a/Core/src/main/java/org/tribuo/dataset/DatasetView.java
+++ b/Core/src/main/java/org/tribuo/dataset/DatasetView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Core/src/main/java/org/tribuo/dataset/DatasetView.java
+++ b/Core/src/main/java/org/tribuo/dataset/DatasetView.java
@@ -374,8 +374,21 @@ public final class DatasetView<T extends Output<T>> extends ImmutableDataset<T> 
     }
 
     @Override
+    public synchronized void shuffle(boolean shuffle) {
+        if (shuffle) {
+            indices = Util.randperm(size(), rng);
+        } else {
+            indices = null;
+        }
+    }
+
+    @Override
     public Iterator<Example<T>> iterator() {
-        return new ViewIterator<>(this);
+        if (indices != null) {
+            return new ShuffledViewIterator<>(this);
+        } else{
+            return new ViewIterator<>(this);
+        }
     }
 
     @Override
@@ -459,6 +472,29 @@ public final class DatasetView<T extends Output<T>> extends ImmutableDataset<T> 
         return valid;
     }
 
+    private static final class ShuffledViewIterator<T extends Output<T>> implements Iterator<Example<T>> {
+
+        private int counter = 0;
+        private final DatasetView<T> dataset;
+
+        ShuffledViewIterator(DatasetView<T> dataset) {
+            this.dataset = dataset;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return counter < dataset.size();
+        }
+
+        @Override
+        public Example<T> next() {
+            Example<T> example = dataset.getExample(dataset.indices[counter]);
+            counter++;
+            return example;
+        }
+
+    }
+
     private static final class ViewIterator<T extends Output<T>> implements Iterator<Example<T>> {
 
         private int counter = 0;
@@ -509,7 +545,7 @@ public final class DatasetView<T extends Output<T>> extends ImmutableDataset<T> 
             this.weighted = new BooleanProvenance(WEIGHTED,dataset.weighted);
             this.sampled = new BooleanProvenance(SAMPLED,dataset.sampled);
             this.tag = new StringProvenance(TAG,dataset.tag);
-            this.indices = storeIndices ? dataset.indices : new int[0];
+            this.indices = storeIndices ? dataset.exampleIndices : new int[0];
         }
 
         /**
@@ -525,7 +561,7 @@ public final class DatasetView<T extends Output<T>> extends ImmutableDataset<T> 
             this.sampled = ObjectProvenance.checkAndExtractProvenance(map,SAMPLED,BooleanProvenance.class, DatasetViewProvenance.class.getSimpleName());
             @SuppressWarnings("unchecked") // List provenance cast
             ListProvenance<IntProvenance> listIndices = ObjectProvenance.checkAndExtractProvenance(map,INDICES,ListProvenance.class, DatasetViewProvenance.class.getSimpleName());
-            if (listIndices.getList().size() > 0) {
+            if (!listIndices.getList().isEmpty()) {
                 try {
                     IntProvenance i = listIndices.getList().get(0);
                 } catch (ClassCastException e) {


### PR DESCRIPTION
### Description
`Dataset.createTransformers` incorrectly iterated `Dataset.data` rather than using the dataset iterator. As the dataset iterator is overridden in `DatasetView` but the data array is empty this caused the transformation to be fit incorrectly and the feature values to be corrupted. 

The fix causes `Dataset.createTransformers` to use `Dataset.size()` and `Dataset.iterator()` both of which can be overridden. The PR also includes two additional fixes for `DatasetView` behaviour as shuffling was incorrect because it could return data points that weren't in the view, and the provenance recorded the wrong indices (it was tracking the shuffle indices not the indices selected for the view). I think this covers all direct uses of `Dataset.data` so they now are routed through the proper methods.

### Motivation
This interaction causes poor performance when using `TransformTrainer` and `CrossValidation`, leading to random performance on the MNIST test I did, after we found it in a different internal usecase.
