### PR TITLE
Moving to TF-Java 1.0.0

### DIFF
--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowCheckpointModel.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowCheckpointModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.tensorflow.exceptions.TensorFlowException;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Output;

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowFrozenExternalModel.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowFrozenExternalModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.oracle.labs.mlrg.olcut.util.Pair;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tribuo.Example;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowModel.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.tensorflow.Session;
 import org.tensorflow.SessionFunction;
 import org.tensorflow.Signature;
 import org.tensorflow.Tensor;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tribuo.Example;
 import org.tribuo.Excuse;
 import org.tribuo.ImmutableFeatureMap;

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowNativeModel.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowNativeModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.tensorflow.Graph;
 import org.tensorflow.Session;
 import org.tensorflow.Tensor;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Output;

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowSavedModelExternalModel.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowSavedModelExternalModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowTrainer.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/TensorFlowTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ import org.tensorflow.ndarray.Shape;
 import org.tensorflow.op.Op;
 import org.tensorflow.op.Ops;
 import org.tensorflow.op.core.Placeholder;
-import org.tensorflow.proto.framework.ConfigProto;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.ConfigProto;
+import org.tensorflow.proto.GraphDef;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.family.TNumber;
 import org.tribuo.Dataset;

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/example/CNNExamples.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/example/CNNExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.tensorflow.op.math.Add;
 import org.tensorflow.op.nn.Conv2d;
 import org.tensorflow.op.nn.MaxPool;
 import org.tensorflow.op.nn.Relu;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tensorflow.types.TFloat32;
 import org.tensorflow.types.TInt64;
 import org.tribuo.Trainer;

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/example/GraphDefTuple.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/example/GraphDefTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.tribuo.interop.tensorflow.example;
 
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 
 /**
  * A tuple containing a graph def protobuf along with the relevant operation names.

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/example/MLPExamples.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/example/MLPExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.tensorflow.op.core.Placeholder;
 import org.tensorflow.op.core.Variable;
 import org.tensorflow.op.math.Add;
 import org.tensorflow.op.nn.Relu;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tensorflow.types.TFloat32;
 import org.tribuo.Trainer;
 

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/sequence/TensorFlowSequenceModel.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/sequence/TensorFlowSequenceModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.oracle.labs.mlrg.olcut.util.Pair;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Output;

--- a/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/sequence/TensorFlowSequenceTrainer.java
+++ b/Interop/Tensorflow/src/main/java/org/tribuo/interop/tensorflow/sequence/TensorFlowSequenceTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import com.oracle.labs.mlrg.olcut.provenance.primitives.DateTimeProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.primitives.HashProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;
 import org.tensorflow.exceptions.TensorFlowException;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tensorflow.types.TFloat32;
 import org.tribuo.ImmutableFeatureMap;
 import org.tribuo.ImmutableOutputInfo;

--- a/Interop/Tensorflow/src/test/java/org/tribuo/interop/tensorflow/ClassificationTest.java
+++ b/Interop/Tensorflow/src/test/java/org/tribuo/interop/tensorflow/ClassificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.tensorflow.ndarray.FloatNdArray;
 import org.tensorflow.ndarray.IntNdArray;
-import org.tensorflow.proto.framework.GraphDef;
+import org.tensorflow.proto.GraphDef;
 import org.tribuo.Dataset;
 import org.tribuo.Example;
 import org.tribuo.Feature;

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -113,9 +113,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-TensorFlow-Java 0.5.0 - Apache 2.0
+TensorFlow-Java 1.0.0 - Apache 2.0
 
-Copyright 2019, 2020, 2022 The TensorFlow Authors.  All rights reserved.
+Copyright 2019, 2024 The TensorFlow Authors.  All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <liblinear.version>2.44</liblinear.version>
         <libsvm.version>3.25</libsvm.version>
         <onnxruntime.version>1.16.0</onnxruntime.version>
-        <tensorflow.version>1.0.0-rc.2</tensorflow.version>
+        <tensorflow.version>1.0.0</tensorflow.version>
         <xgboost.version>1.6.2</xgboost.version>
 
         <!-- 3rd party other dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <liblinear.version>2.44</liblinear.version>
         <libsvm.version>3.25</libsvm.version>
         <onnxruntime.version>1.16.0</onnxruntime.version>
-        <tensorflow.version>1.0.0-rc.1</tensorflow.version>
+        <tensorflow.version>1.0.0-rc.2</tensorflow.version>
         <xgboost.version>1.6.2</xgboost.version>
 
         <!-- 3rd party other dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <liblinear.version>2.44</liblinear.version>
         <libsvm.version>3.25</libsvm.version>
         <onnxruntime.version>1.16.0</onnxruntime.version>
-        <tensorflow.version>0.5.0</tensorflow.version>
+        <tensorflow.version>1.0.0-rc.1</tensorflow.version>
         <xgboost.version>1.6.2</xgboost.version>
 
         <!-- 3rd party other dependencies -->
@@ -405,7 +405,6 @@
             <id>arm</id>
             <properties>
                 <skipXGBoostTests>true</skipXGBoostTests>
-                <skipTFTests>true</skipTFTests>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
### Description
Bumps Tribuo's TF interop to TF-Java 1.0.0-rc1 for testing. This release adds macOS ARM64 binaries and has a fix for the training gradient issue.

### Motivation
Run the CI against the new release candidate.
