### PR TITLE
ci: add automatic release and provenance generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Apache Maven Central
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with: # Running setup-java again overwrites the settings.xml
-        distribution: temurin
+        distribution: oracle
         java-version: '17'
         server-id: maven-central # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: MAVEN_USERNAME # env variable for username in deploy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
       with:
         fetch-depth: 0
 
+    # Use actions/setup-java to handle credentials and create the settings.xml file.
     - name: Set up Apache Maven Central
       uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
       with: # Running setup-java again overwrites the settings.xml
@@ -34,9 +35,19 @@ jobs:
         server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
         gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+        settings-path: ${{ github.workspace }} # location to store the settings.xml file
 
+    # Use Oracle Java SE for compiling the artifact.
+    - name: Setup Oracle Java SE
+      uses: oracle-actions/setup-java@83e2004a40aaa491fbc6b4697353b9a75b095efb # v1.3.4
+      with:
+        website: oracle.com
+        release: '17'
+
+    # Use Maven to publish to Apache Maven Central.
+    # Note that the settings.xml file is prepared by actions/setup-java.
     - name: Publish to Apache Maven Central
-      run: mvn javadoc:jar source:jar deploy
+      run: mvn javadoc:jar source:jar deploy -s "$GITHUB_WORKSPACE"/settings.xml
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: Release
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+
+    - name: Check out repository
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        fetch-depth: 0
+
+    - name: Set up Apache Maven Central
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+      with: # Running setup-java again overwrites the settings.xml
+        distribution: temurin
+        java-version: '17'
+        server-id: maven-central # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: MAVEN_USERNAME # env variable for username in deploy
+        server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+
+    - name: Publish to Apache Maven Central
+      run: mvn javadoc:jar source:jar deploy
+      env:
+        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+        MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+    # Build provenance
+    - name: Attest Build Provenance
+      uses: actions/attest-build-provenance@bdd51370e0416ac948727f861e03c2f05d32d78e # v1.3.2
+      with:
+        subject-path: ./*/target/*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,14 @@
     <artifactId>tribuo</artifactId>
     <version>5.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
+  <distributionManagement>
+    <repository>
+      <id>maven-central</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/releases/</url>
+    </repository>
+  </distributionManagement>
+
     <modules>
         <module>Core</module>
         <module>Data</module>


### PR DESCRIPTION
### Description
This PR adds a new GitHub Actions workflow to automate the release of the artifacts and generate [SLSA](https://slsa.dev/) provenances. 

To use this Action to release, the following secrets [need to be created](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository):

- `MAVEN_USERNAME`: the username to used to deploy the artifacts to Maven Central.
- `MAVEN_CENTRAL_TOKEN`: the token that you can obtain from the Maven Central portal
- `MAVEN_GPG_PRIVATE_KEY`: the GPG private key
- `MAVEN_GPG_PASSPHRASE`: the GPG private key passphrase

When the project is ready for the next release, the version should be bumped as usual and committed to the repo. Then a draft release and tag can be created using [GitHub's release feature.](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release). Once the release is created, the `release.yaml` GitHub Action will automatically run and deploy the artifact to Maven Central.

For more information, see the documentation here: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven 

### Motivation
Having automatic releases and generating provenances helps mitigating [supply-chain attacks](https://slsa.dev/spec/v1.0/threats). For example, if the deployment is done manually and the maintainer's machine is compromised, the released artifact may contain malicious code and abused by malicious actors to distribute malware.
