### PR TITLE
Fixing a bug in IntArrayContainer.merge and adding tests

### DIFF
--- a/Common/Trees/src/main/java/org/tribuo/common/tree/impl/IntArrayContainer.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/impl/IntArrayContainer.java
@@ -88,7 +88,7 @@ public class IntArrayContainer {
      * @param other The array to copy from.
      */
     public void fill(IntArrayContainer other) {
-        if (other.array.length > array.length) {
+        if (other.size > array.length) {
             array = Arrays.copyOf(other.array,other.size);
         } else {
             System.arraycopy(other.array,0,array,0,other.size);

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/impl/IntArrayContainer.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/impl/IntArrayContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,7 +141,6 @@ public class IntArrayContainer {
             }
         }
         output.size = k;
-        assert(k == newSize);
         //logger.info("output = " + Arrays.toString(outputArray));
     }
 
@@ -154,9 +153,9 @@ public class IntArrayContainer {
      * @return A sorted array containing all the elements from the input.
      */
     public static int[] merge(List<int[]> input, IntArrayContainer firstBuffer, IntArrayContainer secondBuffer) {
-        if (input.size() > 0) {
+        if (!input.isEmpty()) {
             firstBuffer.fill(input.get(0));
-            for (int i = 0; i < input.size(); i++) {
+            for (int i = 1; i < input.size(); i++) {
                 merge(firstBuffer,input.get(i),secondBuffer);
                 IntArrayContainer tmp = secondBuffer;
                 secondBuffer = firstBuffer;

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/impl/IntArrayContainer.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/impl/IntArrayContainer.java
@@ -72,6 +72,8 @@ public class IntArrayContainer {
 
     /**
      * Overwrites values from the supplied array into this array.
+     * <p>
+     * Copies in all the other values and sets the length of this array to the length of the other array.
      * @param otherArray The array to copy from.
      */
     public void fill(int[] otherArray) {
@@ -85,6 +87,8 @@ public class IntArrayContainer {
 
     /**
      * Overwrites values in this array with the supplied array.
+     * <p>
+     * Copies in all the other values and sets the length of this array to the length of the other array.
      * @param other The array to copy from.
      */
     public void fill(IntArrayContainer other) {

--- a/Common/Trees/src/test/java/org/tribuo/common/tree/impl/IntArrayContainerTest.java
+++ b/Common/Trees/src/test/java/org/tribuo/common/tree/impl/IntArrayContainerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tribuo.common.tree.impl;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IntArrayContainerTest {
+
+    @Test
+    public void mergeListTest() {
+        IntArrayContainer first = new IntArrayContainer(10);
+        IntArrayContainer second = new IntArrayContainer(10);
+        List<int[]> list = new ArrayList<>();
+        list.add(new int[]{5, 7, 9});
+        list.add(new int[]{1, 2, 4, 6});
+        list.add(new int[]{3, 8, 10});
+
+        int[] output = IntArrayContainer.merge(list, first, second);
+
+        int[] expectedOutput = new int[]{1,2,3,4,5,6,7,8,9,10};
+
+        Assertions.assertArrayEquals(expectedOutput, output);
+    }
+
+    @Test
+    public void mergeTest() {
+        IntArrayContainer first = new IntArrayContainer(10);
+        IntArrayContainer second = new IntArrayContainer(10);
+        first.fill(new int[]{1,2,3,5,7,9});
+        int[] other = new int[]{0,4,6,8,10};
+
+        IntArrayContainer.merge(first, other, second);
+
+        int[] expectedOutput = new int[]{0,1,2,3,4,5,6,7,8,9,10};
+
+        int[] output = second.copy();
+
+        Assertions.assertArrayEquals(expectedOutput, output);
+    }
+
+    @Test
+    public void fillTest() {
+        IntArrayContainer first = new IntArrayContainer(10);
+        IntArrayContainer second = new IntArrayContainer(10);
+        int[] expected = new int[]{1,2,3,5,7,9};
+        first.fill(expected);
+        Assertions.assertArrayEquals(expected, first.copy());
+
+        second.fill(first);
+        Assertions.assertArrayEquals(expected, second.copy());
+    }
+
+    @Test
+    public void growTest() {
+        IntArrayContainer first = new IntArrayContainer(10);
+        int[] expected = new int[]{1,2,3,5,7,9};
+        first.fill(expected);
+        Assertions.assertArrayEquals(expected, first.copy());
+
+        first.grow(20);
+        Assertions.assertEquals(20,first.array.length);
+        Assertions.assertArrayEquals(expected, first.copy());
+    }
+
+    @Test
+    public void removeOtherTest() {
+        IntArrayContainer first = new IntArrayContainer(10);
+        IntArrayContainer second = new IntArrayContainer(10);
+        first.fill(new int[]{1,2,3,5,7,9});
+
+        int[] removed = new int[]{2,6,8,9};
+
+        IntArrayContainer.removeOther(first, removed, second);
+
+        int[] expected = new int[]{1,3,5,7};
+
+        Assertions.assertArrayEquals(expected, second.copy());
+    }
+
+}

--- a/Common/Trees/src/test/java/org/tribuo/common/tree/impl/IntArrayContainerTest.java
+++ b/Common/Trees/src/test/java/org/tribuo/common/tree/impl/IntArrayContainerTest.java
@@ -58,7 +58,7 @@ public class IntArrayContainerTest {
 
     @Test
     public void fillTest() {
-        IntArrayContainer first = new IntArrayContainer(10);
+        IntArrayContainer first = new IntArrayContainer(5);
         IntArrayContainer second = new IntArrayContainer(10);
         int[] expected = new int[]{1,2,3,5,7,9};
         first.fill(expected);
@@ -66,6 +66,10 @@ public class IntArrayContainerTest {
 
         second.fill(first);
         Assertions.assertArrayEquals(expected, second.copy());
+
+        IntArrayContainer third = new IntArrayContainer(3);
+        third.fill(first);
+        Assertions.assertArrayEquals(expected, third.copy());
     }
 
     @Test
@@ -84,13 +88,13 @@ public class IntArrayContainerTest {
     public void removeOtherTest() {
         IntArrayContainer first = new IntArrayContainer(10);
         IntArrayContainer second = new IntArrayContainer(10);
-        first.fill(new int[]{1,2,3,5,7,9});
+        first.fill(new int[]{1,2,3,5,7,9,10});
 
         int[] removed = new int[]{2,6,8,9};
 
         IntArrayContainer.removeOther(first, removed, second);
 
-        int[] expected = new int[]{1,3,5,7};
+        int[] expected = new int[]{1,3,5,7,10};
 
         Assertions.assertArrayEquals(expected, second.copy());
     }

--- a/Regression/RegressionTree/src/test/java/org/tribuo/regression/rtree/TestCARTJointRegressionTrainer.java
+++ b/Regression/RegressionTree/src/test/java/org/tribuo/regression/rtree/TestCARTJointRegressionTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,10 +246,10 @@ public class TestCARTJointRegressionTrainer {
         Pair<Dataset<Regressor>, Dataset<Regressor>> p = RegressionDataGenerator.threeDimDenseTrainTest(1.0, false);
         TreeModel<Regressor> llModel = t.train(p.getA());
         RegressionEvaluation llEval = e.evaluate(llModel, p.getB());
-        double expectedDim1 = -0.6618655170782572;
-        double expectedDim2 = -0.6618655170782572;
-        double expectedDim3 = -2.072009095885796;
-        double expectedAve = -1.1319133766807703;
+        double expectedDim1 = -0.6700413426515754;
+        double expectedDim2 = -0.6700413426515754;
+        double expectedDim3 = -1.1190232216467106;
+        double expectedAve = -0.8197019689832872;
 
         assertEquals(expectedDim1, llEval.r2(new Regressor(RegressionDataGenerator.firstDimensionName, Double.NaN)), 1e-6);
         assertEquals(expectedDim2, llEval.r2(new Regressor(RegressionDataGenerator.secondDimensionName, Double.NaN)), 1e-6);

--- a/Regression/RegressionTree/src/test/java/org/tribuo/regression/rtree/TestCARTRegressionTrainer.java
+++ b/Regression/RegressionTree/src/test/java/org/tribuo/regression/rtree/TestCARTRegressionTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,10 +206,10 @@ public class TestCARTRegressionTrainer {
         Pair<Dataset<Regressor>,Dataset<Regressor>> p = RegressionDataGenerator.threeDimDenseTrainTest(1.0, false);
         TreeModel<Regressor> llModel = t.train(p.getA());
         RegressionEvaluation llEval = e.evaluate(llModel,p.getB());
-        double expectedDim1 = -0.6618655170782572;
-        double expectedDim2 = -0.6618655170782572;
-        double expectedDim3 = -0.7617851143770209;
-        double expectedAve = -0.6951720495111785;
+        double expectedDim1 = -0.6700413426515754;
+        double expectedDim2 = -0.6700413426515754;
+        double expectedDim3 = -0.937479822012605;
+        double expectedAve = -0.7591875024385853;
 
         assertEquals(expectedDim1,llEval.r2(new Regressor(RegressionDataGenerator.firstDimensionName,Double.NaN)),1e-6);
         assertEquals(expectedDim2,llEval.r2(new Regressor(RegressionDataGenerator.secondDimensionName,Double.NaN)),1e-6);

--- a/Regression/RegressionTree/src/test/java/org/tribuo/regression/rtree/TestRegressionEnsembles.java
+++ b/Regression/RegressionTree/src/test/java/org/tribuo/regression/rtree/TestRegressionEnsembles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,10 +158,10 @@ public class TestRegressionEnsembles {
         BaggingTrainer<Regressor> bagT = new BaggingTrainer<>(t,new AveragingCombiner(),10);
         Model<Regressor> llModel = bagT.train(p.getA());
         RegressionEvaluation llEval = evaluator.evaluate(llModel,p.getB());
-        double expectedDim1 = 0.1632337913237244;
-        double expectedDim2 = 0.1632337913237244;
-        double expectedDim3 = -0.5727741047992028;
-        double expectedAve = -0.08210217405058466;
+        double expectedDim1 = 0.1741030329694585;
+        double expectedDim2 = 0.1741030329694585;
+        double expectedDim3 = -0.47778900726641527;
+        double expectedAve = -0.04319431377583275;
 
         assertEquals(expectedDim1,llEval.r2(new Regressor(RegressionDataGenerator.firstDimensionName,Double.NaN)),1e-6);
         assertEquals(expectedDim2,llEval.r2(new Regressor(RegressionDataGenerator.secondDimensionName,Double.NaN)),1e-6);


### PR DESCRIPTION
### Description
The merge method should not duplicate inputs, which can lead to issues in the regression trees which use that method.

### Motivation
Fix for #383 and more tests for `IntArrayContainer`.
