### PR TITLE
Bumping OpenCSV to 5.10.

### DIFF
--- a/Common/XGBoost/pom.xml
+++ b/Common/XGBoost/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/Data/pom.xml
+++ b/Data/pom.xml
@@ -55,16 +55,33 @@
             <version>${opencsv.version}</version>
             <exclusions>
                 <exclusion>
+                     <groupId>org.apache.commons</groupId>
+                     <artifactId>commons-text</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-lang3</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
-        <!-- pin commons lang3 after excluding it from OpenCSV due to convergence issues. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.13.1</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.17.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/Interop/OCI/pom.xml
+++ b/Interop/OCI/pom.xml
@@ -115,6 +115,10 @@
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
                 <exclusion>
+                     <groupId>commons-logging</groupId>
+                     <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>jakarta.activation</groupId>
                     <artifactId>jakarta.activation-api</artifactId>
                 </exclusion>
@@ -146,6 +150,11 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.15</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>jakarta.activation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
         <!-- 3rd party other dependencies -->
         <junit.version>5.11.3</junit.version>
-        <opencsv.version>5.9</opencsv.version>
+        <opencsv.version>5.10</opencsv.version>
         <protobuf.version>3.25.6</protobuf.version>
         <jackson.version>2.18.0</jackson.version>
 


### PR DESCRIPTION
### Description
Bump OpenCSV to 5.10. 5.11 has a bug in the RFC1480 parser which causes it to erroneously return null - https://sourceforge.net/p/opencsv/bugs/259/.

### Motivation
Bumping dependencies of OpenCSV.
