### PR TITLE
Fix tree construction to consistently use the same ids

### DIFF
--- a/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/CARTClassificationTrainer.java
+++ b/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/CARTClassificationTrainer.java
@@ -18,6 +18,8 @@ package org.tribuo.classification.dtree;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
 import org.tribuo.Dataset;
+import org.tribuo.ImmutableFeatureMap;
+import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Trainer;
 import org.tribuo.classification.Label;
 import org.tribuo.classification.dtree.impl.ClassifierTrainingNode;
@@ -144,8 +146,10 @@ public class CARTClassificationTrainer extends AbstractCARTTrainer<Label> {
 
     @Override
     protected AbstractTrainingNode<Label> mkTrainingNode(Dataset<Label> examples,
+                                                         ImmutableFeatureMap featureIDMap,
+                                                         ImmutableOutputInfo<Label> outputIDInfo,
                                                          AbstractTrainingNode.LeafDeterminer leafDeterminer) {
-        return new ClassifierTrainingNode(impurity, examples, leafDeterminer);
+        return new ClassifierTrainingNode(impurity, examples, featureIDMap, outputIDInfo, leafDeterminer);
     }
 
     @Override

--- a/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/impl/ClassifierTrainingNode.java
+++ b/Classification/DecisionTree/src/main/java/org/tribuo/classification/dtree/impl/ClassifierTrainingNode.java
@@ -32,8 +32,6 @@ import org.tribuo.math.la.SparseVector;
 import org.tribuo.math.la.VectorTuple;
 import org.tribuo.util.Util;
 
-import java.io.IOException;
-import java.io.NotSerializableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,11 +70,12 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
      * Constructor which creates the inverted file.
      * @param impurity The impurity function to use.
      * @param examples The training data.
+     * @param featureIDMap The feature id mapping.
+     * @param outputIDInfo The output id mapping.
      * @param leafDeterminer Contains parameters needed to determine whether a child node will be a leaf.
      */
-    public ClassifierTrainingNode(LabelImpurity impurity, Dataset<Label> examples, LeafDeterminer leafDeterminer) {
-        this(impurity,invertData(examples), examples.size(), 0, examples.getFeatureIDMap(),
-                examples.getOutputIDInfo(),leafDeterminer);
+    public ClassifierTrainingNode(LabelImpurity impurity, Dataset<Label> examples, ImmutableFeatureMap featureIDMap, ImmutableOutputInfo<Label> outputIDInfo, LeafDeterminer leafDeterminer) {
+        this(impurity,invertData(examples, featureIDMap, outputIDInfo), examples.size(), 0, featureIDMap, outputIDInfo,leafDeterminer);
     }
 
     private ClassifierTrainingNode(LabelImpurity impurity, ArrayList<TreeFeature> data, int numExamples, int depth,
@@ -361,11 +360,11 @@ public class ClassifierTrainingNode extends AbstractTrainingNode<Label> {
      * Inverts a training dataset from row major to column major. This partially de-sparsifies the dataset
      * so it's very expensive in terms of memory.
      * @param examples An input dataset.
+     * @param featureInfos The feature id mapping.
+     * @param labelInfo The label id mapping.
      * @return A list of TreeFeatures which contain {@link InvertedFeature}s.
      */
-    private static ArrayList<TreeFeature> invertData(Dataset<Label> examples) {
-        ImmutableFeatureMap featureInfos = examples.getFeatureIDMap();
-        ImmutableOutputInfo<Label> labelInfo = examples.getOutputIDInfo();
+    private static ArrayList<TreeFeature> invertData(Dataset<Label> examples, ImmutableFeatureMap featureInfos, ImmutableOutputInfo<Label> labelInfo) {
         int numLabels = labelInfo.size();
         int numFeatures = featureInfos.size();
         int numExamples = examples.size();

--- a/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractCARTTrainer.java
+++ b/Common/Trees/src/main/java/org/tribuo/common/tree/AbstractCARTTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -219,7 +219,7 @@ public abstract class AbstractCARTTrainer<T extends Output<T>> implements Decisi
         AbstractTrainingNode.LeafDeterminer leafDeterminer = new AbstractTrainingNode.LeafDeterminer(maxDepth,
                 minChildWeight, scaledMinImpurityDecrease);
 
-        AbstractTrainingNode<T> root = mkTrainingNode(examples, leafDeterminer);
+        AbstractTrainingNode<T> root = mkTrainingNode(examples, featureIDMap, outputIDInfo, leafDeterminer);
         Deque<AbstractTrainingNode<T>> queue = new ArrayDeque<>();
         queue.add(root);
 
@@ -247,10 +247,14 @@ public abstract class AbstractCARTTrainer<T extends Output<T>> implements Decisi
     /**
      * Makes the initial training node.
      * @param examples The dataset to use.
+     * @param featureIDMap The feature id map.
+     * @param outputIDInfo The output id info.
      * @param leafDeterminer The leaf determination function.
      * @return The initial training node.
      */
     protected abstract AbstractTrainingNode<T> mkTrainingNode(Dataset<T> examples,
+                                                              ImmutableFeatureMap featureIDMap,
+                                                              ImmutableOutputInfo<T> outputIDInfo,
                                                               AbstractTrainingNode.LeafDeterminer leafDeterminer);
 
     /**

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/CARTJointRegressionTrainer.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/CARTJointRegressionTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.tribuo.regression.rtree;
 
 import com.oracle.labs.mlrg.olcut.config.Config;
 import org.tribuo.Dataset;
+import org.tribuo.ImmutableFeatureMap;
+import org.tribuo.ImmutableOutputInfo;
 import org.tribuo.Trainer;
 import org.tribuo.common.tree.AbstractCARTTrainer;
 import org.tribuo.common.tree.AbstractTrainingNode;
@@ -138,8 +140,10 @@ public class CARTJointRegressionTrainer extends AbstractCARTTrainer<Regressor> {
 
     @Override
     protected AbstractTrainingNode<Regressor> mkTrainingNode(Dataset<Regressor> examples,
+                                                             ImmutableFeatureMap featureIDMap,
+                                                             ImmutableOutputInfo<Regressor> outputIDInfo,
                                                              AbstractTrainingNode.LeafDeterminer leafDeterminer) {
-        return new JointRegressorTrainingNode(impurity, examples, normalize, leafDeterminer);
+        return new JointRegressorTrainingNode(impurity, examples, featureIDMap, outputIDInfo, normalize, leafDeterminer);
     }
 
     @Override

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/CARTRegressionTrainer.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/CARTRegressionTrainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,6 +137,8 @@ public final class CARTRegressionTrainer extends AbstractCARTTrainer<Regressor> 
 
     @Override
     protected AbstractTrainingNode<Regressor> mkTrainingNode(Dataset<Regressor> examples,
+                                                             ImmutableFeatureMap featureIDMap,
+                                                             ImmutableOutputInfo<Regressor> outputIDInfo,
                                                              AbstractTrainingNode.LeafDeterminer leafDeterminer) {
         throw new IllegalStateException("Shouldn't reach here.");
     }
@@ -187,7 +189,7 @@ public final class CARTRegressionTrainer extends AbstractCARTTrainer<Regressor> 
         AbstractTrainingNode.LeafDeterminer leafDeterminer = new AbstractTrainingNode.LeafDeterminer(maxDepth,
                 minChildWeight, scaledMinImpurityDecrease);
 
-        InvertedData data = RegressorTrainingNode.invertData(examples);
+        InvertedData data = RegressorTrainingNode.invertData(examples, featureIDMap, outputIDInfo);
 
         Map<String, Node<Regressor>> nodeMap = new HashMap<>();
         for (Regressor r : domain) {

--- a/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/RegressorTrainingNode.java
+++ b/Regression/RegressionTree/src/main/java/org/tribuo/regression/rtree/impl/RegressorTrainingNode.java
@@ -35,8 +35,6 @@ import org.tribuo.regression.rtree.impurity.RegressorImpurity;
 import org.tribuo.regression.rtree.impurity.RegressorImpurity.ImpurityTuple;
 import org.tribuo.util.Util;
 
-import java.io.IOException;
-import java.io.NotSerializableException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -400,12 +398,12 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
      * Inverts a training dataset from row major to column major. This partially de-sparsifies the dataset
      * so it's very expensive in terms of memory.
      * @param examples An input dataset.
+     * @param featureInfos The feature id mapping.
+     * @param outputInfo The output regression id mapping.
      * @return A list of TreeFeatures which contain {@link InvertedFeature}s.
      */
-    public static InvertedData invertData(Dataset<Regressor> examples) {
-        ImmutableFeatureMap featureInfos = examples.getFeatureIDMap();
-        ImmutableOutputInfo<Regressor> labelInfo = examples.getOutputIDInfo();
-        int numLabels = labelInfo.size();
+    public static InvertedData invertData(Dataset<Regressor> examples, ImmutableFeatureMap featureInfos, ImmutableOutputInfo<Regressor> outputInfo) {
+        int numLabels = outputInfo.size();
         int numFeatures = featureInfos.size();
         int[] indices = new int[examples.size()];
         float[][] targets = new float[numLabels][examples.size()];
@@ -418,7 +416,7 @@ public class RegressorTrainingNode extends AbstractTrainingNode<Regressor> {
             data.add(new TreeFeature(i));
         }
 
-        int[] ids = ((ImmutableRegressionInfo) labelInfo).getNaturalOrderToIDMapping();
+        int[] ids = ((ImmutableRegressionInfo) outputInfo).getNaturalOrderToIDMapping();
         for (int i = 0; i < examples.size(); i++) {
             Example<Regressor> e = examples.getExample(i);
             indices[i] = i;


### PR DESCRIPTION
### Description
Modify `mkTrainingNode` in `AbtractCARTTrainer` so that it takes the feature and output maps, allowing them to be constructed once.

### Motivation
Fixes #419. The iteration order is unlikely to change, but as constructing the immutable maps is expensive and the order could theoretically change we should only do it once.
