### PR TITLE
Fix test-flakiness in MIMTest caused by floating point comparison

### DIFF
--- a/Classification/FeatureSelection/src/main/java/org/tribuo/classification/fs/DenseFSMatrix.java
+++ b/Classification/FeatureSelection/src/main/java/org/tribuo/classification/fs/DenseFSMatrix.java
@@ -34,7 +34,7 @@ import org.tribuo.util.infotheory.impl.CachedTriple;
 import org.tribuo.util.infotheory.impl.PairDistribution;
 import org.tribuo.util.infotheory.impl.TripleDistribution;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -73,7 +73,7 @@ final class DenseFSMatrix implements FSMatrix {
 
     @Override
     public double mi(int featureIndex) {
-        Map<CachedPair<Integer,Integer>, MutableLong> map = new HashMap<>();
+        Map<CachedPair<Integer,Integer>, MutableLong> map = new LinkedHashMap<>();
         for (int i = 0; i < labels.length; i++) {
             CachedPair<Integer, Integer> p = new CachedPair<>(features[featureIndex][i],labels[i]);
             MutableLong l = map.computeIfAbsent(p, k -> new MutableLong());
@@ -84,7 +84,7 @@ final class DenseFSMatrix implements FSMatrix {
 
     @Override
     public double mi(int firstIndex, int secondIndex) {
-        Map<CachedPair<Integer,Integer>, MutableLong> map = new HashMap<>();
+        Map<CachedPair<Integer,Integer>, MutableLong> map = new LinkedHashMap<>();
         for (int i = 0; i < labels.length; i++) {
             CachedPair<Integer, Integer> p = new CachedPair<>(features[firstIndex][i],features[secondIndex][i]);
             MutableLong l = map.computeIfAbsent(p, k -> new MutableLong());
@@ -95,7 +95,7 @@ final class DenseFSMatrix implements FSMatrix {
 
     @Override
     public double jmi(int featureIndex, int jointIndex) {
-        Map<CachedTriple<Integer,Integer,Integer>, MutableLong> map = new HashMap<>();
+        Map<CachedTriple<Integer,Integer,Integer>, MutableLong> map = new LinkedHashMap<>();
         for (int i = 0; i < labels.length; i++) {
             CachedTriple<Integer, Integer, Integer> p = new CachedTriple<>(features[featureIndex][i],
                     features[jointIndex][i],labels[i]);
@@ -107,7 +107,7 @@ final class DenseFSMatrix implements FSMatrix {
 
     @Override
     public double jmi(int firstIndex, int jointIndex, int targetIndex) {
-        Map<CachedTriple<Integer,Integer,Integer>, MutableLong> map = new HashMap<>();
+        Map<CachedTriple<Integer,Integer,Integer>, MutableLong> map = new LinkedHashMap<>();
         for (int i = 0; i < labels.length; i++) {
             CachedTriple<Integer, Integer, Integer> p = new CachedTriple<>(features[firstIndex][i],
                     features[jointIndex][i],features[targetIndex][i]);
@@ -119,7 +119,7 @@ final class DenseFSMatrix implements FSMatrix {
 
     @Override
     public double cmi(int featureIndex, int conditionIndex) {
-        Map<CachedTriple<Integer,Integer,Integer>, MutableLong> map = new HashMap<>();
+        Map<CachedTriple<Integer,Integer,Integer>, MutableLong> map = new LinkedHashMap<>();
         for (int i = 0; i < labels.length; i++) {
             CachedTriple<Integer, Integer, Integer> p = new CachedTriple<>(features[featureIndex][i],
                     labels[i],features[conditionIndex][i]);
@@ -131,7 +131,7 @@ final class DenseFSMatrix implements FSMatrix {
 
     @Override
     public double cmi(int firstIndex, int secondIndex, int conditionIndex) {
-        Map<CachedTriple<Integer,Integer,Integer>, MutableLong> map = new HashMap<>();
+        Map<CachedTriple<Integer,Integer,Integer>, MutableLong> map = new LinkedHashMap<>();
         for (int i = 0; i < labels.length; i++) {
             CachedTriple<Integer, Integer, Integer> p = new CachedTriple<>(features[firstIndex][i],
                     features[secondIndex][i],features[conditionIndex][i]);

--- a/Classification/FeatureSelection/src/test/java/org/tribuo/classification/fs/MIMTest.java
+++ b/Classification/FeatureSelection/src/test/java/org/tribuo/classification/fs/MIMTest.java
@@ -26,6 +26,7 @@ import org.tribuo.classification.Label;
 import org.tribuo.classification.LabelFactory;
 import org.tribuo.impl.ArrayExample;
 import org.tribuo.provenance.SimpleDataSourceProvenance;
+import org.tribuo.util.Util;
 import org.tribuo.util.infotheory.InformationTheory;
 
 import java.util.Arrays;
@@ -34,6 +35,7 @@ import java.util.SplittableRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -144,7 +146,8 @@ public class MIMTest {
         assertEquals(5,scores.size());
 
         assertEquals(Arrays.asList("E","B","C","D","A"),sfs.featureNames());
-        assertEquals(Arrays.asList(1.0, 0.1887218755408671, 0.1887218755408671, 0.0487949406953985, 0.0),sfs.featureScores());
+        double[] expected = new double[]{1.0, 0.18872187554086714,  0.1887218755408671, 0.0487949406953985, 0.0};
+        assertArrayEquals(expected, Util.toPrimitiveDouble(sfs.featureScores()), 1e-12);
     }
 
 }


### PR DESCRIPTION
### Description
This PR fixes non-deterministic test flakiness in MIMTest by relaxing floating-point assertions with a small tolerance. The change compares each score using an epsilon (1e-12) to account for floating point variation caused by summation order.

### Motivation
NonDex found failures due to tiny floating-point discrepancies caused by iteration order perturbations. The problem lies in the test code only that: non-deterministic HashMap iteration order affects floating point summation which causes minor precision differences, that fail exact equality checks. NonDex output attached. 
[nondex_mimtest.txt](https://github.com/user-attachments/files/23831753/nondex_mimtest.txt)

