### PR TITLE
Fix table formatting in PackageOverview.md

### DIFF
--- a/docs/PackageOverview.md
+++ b/docs/PackageOverview.md
@@ -227,7 +227,7 @@ graph.
 Tribuo has a number of other modules:
 
 |  Folder | ArtifactID | Package root | Description |
-|---------| --- | --- | --- | --- |
+|---------| --- | --- | --- |
 | Json  | `tribuo-json` | `org.tribuo.json` | Contains support for reading and writing Json formatted data, along with a program for inspecting and removing provenance information from models. |
 | ModelCard | `tribuo-interop-modelcard` | `org.tribuo.interop.modelcard` | Contains support for reading and writing model cards in Json format, using the provenance information in Tribuo models to guide the card construction. |
 | Reproducibility | `tribuo-reproducibility` | `org.tribuo.reproducibility` | A utility for reproducing Tribuo models and datasets. |


### PR DESCRIPTION
### Description

Fixes the markdown formatting of the Other modules table in docs/PackageOverview.md, which previously prevented the table from rendering correctly. The changes correct the table syntax so it is displayed as intended in GitHub’s markdown renderer

### Motivation

This is a documentation bug fix. The incorrect markdown format breaks table rendering, reducing readability and making the package overview harder to understand. Fixing the formatting ensures the documentation is correctly displayed and improves the overall usability of the project documentation.

No functional code changes are introduced.

### Paper reference
NA